### PR TITLE
[fix] SqlManager getSql,existSql 動作違いを修正

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/store/SqlManagerImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/store/SqlManagerImpl.java
@@ -92,7 +92,11 @@ public class SqlManagerImpl implements SqlManager {
 	 */
 	@Override
 	public boolean existSql(final String sqlPath) {
-		return sqlLoader.existSql(sqlPath);
+		if (!cache) {
+			return sqlLoader.existSql(sqlPath);
+		} else {
+			return sqlMap.get(sqlPath.replace(".", "/")) != null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
SqlManagerImpl キャッシュモード時 getSqlとexistSqlの動作の違いを修正