### PR TITLE
improve syntax highlight of html coverage report

### DIFF
--- a/src/main/resources/jp/co/future/uroborosql/coverage/reports/html/sqlcov.js
+++ b/src/main/resources/jp/co/future/uroborosql/coverage/reports/html/sqlcov.js
@@ -1,11 +1,15 @@
 hljs.initHighlightingOnLoad();
 
-$(function() {
-    $(".hljs-comment").each(function() {
-       if (!$(this).text().match(/\/\*(IF.*)|(ELSE)|(END)|(BEGIN)\*\//) &&
-           $(this).text().match(/\/\*[\w_]+\*\//)) {
-           $(this).wrapInner('<span class="hljs-param"></span>');
-       }
+$(function () {
+    $(".hljs-comment").each(function () {
+        if (!$(this).text().match(/\/\*(IF.*)|(ELIF.*)|(ELSE)|(END)|(BEGIN)\*\//) &&
+            $(this).text().match(/\/\*[\w_]+\*\//)) {
+            $(this).wrapInner('<span class="hljs-param"></span>');
+        }
+        var html = $(this).html();
+        $(this).html(
+            html.replace(/(\/\*)(IF\s|ELIF\s|ELSE|END|BEGIN)/,
+                '$1<span class="hljs-comment-statement">$2</span>'));
     });
 });
 

--- a/src/main/resources/jp/co/future/uroborosql/coverage/reports/html/style.css
+++ b/src/main/resources/jp/co/future/uroborosql/coverage/reports/html/style.css
@@ -12,6 +12,15 @@ pre, code, span.cline {
     line-height: 1.2em;
 }
 
+a, a:visited {
+    color: #1e88e5;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
 h1 {
     font-size: 1.8em;
     word-break: break-all;
@@ -70,6 +79,7 @@ table.coverage-summary th {
     padding: 10px;
     cursor: pointer;
 }
+
 th.sorting-asc::after {
     content: "";
     width: 0;
@@ -303,5 +313,10 @@ Intellij Idea-like styling (c) Vasily Polovnyov <vast@whiteants.net>
 
 .hljs-param {
     color: mediumblue;
+    font-weight: bold;
+}
+
+.hljs-comment-statement {
+    color: green;
     font-weight: bold;
 }

--- a/src/test/java/jp/co/future/uroborosql/coverage/reports/html/HtmlReportCoverageHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/coverage/reports/html/HtmlReportCoverageHandlerTest.java
@@ -80,7 +80,7 @@ public class HtmlReportCoverageHandlerTest {
 		assertThat(Files.readAllLines(path.resolve("covertest/test01.html")).size(), is(97));
 		assertThat(Files.readAllLines(path.resolve("covertest/test01_hash_1.html")).size(), is(99));
 		assertThat(Files.readAllLines(path.resolve("covertest/test02.html")).size(), is(97));
-		assertThat(Files.readAllLines(path.resolve("covertest/test03.html")).size(), is(115));
+		assertThat(Files.readAllLines(path.resolve("covertest/test03.html")).size(), is(121));
 		assertThat(Files.readAllLines(path.resolve("example/select_test.html")).size(), is(76));
 
 		ref.set(before);

--- a/src/test/resources/sql/covertest/test03.sql
+++ b/src/test/resources/sql/covertest/test03.sql
@@ -10,6 +10,8 @@ WHERE
 /*IF SF.isNotEmpty(id) */
     /*IF id < 100 */
 AND T.ID    =   /*id*/0
+    /*ELIF id >= 100 */
+AND 1       =   1
     /*ELSE*/
 AND T.ID    =   100
     /*END*/


### PR DESCRIPTION
Syntax highlighting of html coverage report was improved.

The syntax (IF / ELSE / ELIF / BEGIN / END) in the 2 way-SQL comment can be highlighted as shown in the code below.

![uroborosql_code_coverage_report_for_covertest_test01](https://cloud.githubusercontent.com/assets/7599623/24586832/40c83848-17e4-11e7-8465-ccbd50d4cc30.jpg)
