### PR TITLE
Fixed an exception occurs when calling SqlUpdate#batch without calling SqlUpdate#addBatch never

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlUpdateImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlUpdateImpl.java
@@ -13,7 +13,7 @@ import jp.co.future.uroborosql.fluent.SqlUpdate;
 final class SqlUpdateImpl extends AbstractSqlFluent<SqlUpdate> implements SqlUpdate {
 	private final SqlAgent agent;
 	/** バッチ処理を行うかどうか */
-	boolean batch = false;
+	private boolean batch = false;
 
 	/**
 	 * コンストラクタ
@@ -58,6 +58,9 @@ final class SqlUpdateImpl extends AbstractSqlFluent<SqlUpdate> implements SqlUpd
 	 */
 	@Override
 	public int[] batch() throws SQLException {
+		if (context.batchCount() == 0) {
+			return new int[0];
+		}
 		if (!batch) {
 			addBatch();
 		}

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
@@ -133,6 +133,12 @@ public interface SqlContext extends TransformContext, SqlFluent<SqlContext> {
 	SqlContext clearBatch();
 
 	/**
+	 * addBatchされた回数を取得する
+	 * @return バッチ回数
+	 */
+	int batchCount();
+
+	/**
 	 * 列型の定義追加<br>
 	 *
 	 * @param column カラム番号

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -741,6 +741,16 @@ public class SqlContextImpl implements SqlContext {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.context.SqlContext#batchCount()
+	 */
+	@Override
+	public int batchCount() {
+		return batchParameters.size();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.context.SqlContext#addDefineColumnType(int, int)
 	 */
 	@Override

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -543,6 +543,18 @@ public class SqlAgentTest {
 		}
 	}
 
+	@Test
+	public void testExecuteBatchNoAddBatch() throws Exception {
+		// 事前条件
+		truncateTable("PRODUCT");
+
+		// 処理実行
+		try (SqlAgent agent = config.createAgent()) {
+			int[] count = agent.update("example/insert_product").batch();
+			assertEquals("データの登録件数が不正です。", 0, count.length);
+		}
+	}
+
 	/**
 	 * SQLファイルが存在しない場合のテストケース。
 	 */


### PR DESCRIPTION
A ParameterNotFoundRuntimeException occurs when you call batch without calling addBatch, but we think that it is appropriate to judge by batch's return value without raising an exception.