### PR TITLE
optimistic concurrency controls supported with SqlAgent#update (Object).

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -682,8 +682,8 @@ public class SqlAgentImpl extends AbstractAgent {
 			handler.setUpdateParams(context, entity);
 			int count = handler.doUpdate(this, context, entity);
 
-			if (MappingUtils.getVersionMappingColumn(type).isPresent() && count == 0) {
-				throw new OptimisticLockException();
+			if (count == 0 && MappingUtils.getVersionMappingColumn(type).isPresent()) {
+				throw new OptimisticLockException(context);
 			}
 			return count;
 		} catch (SQLException e) {

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -22,9 +22,11 @@ import jp.co.future.uroborosql.context.SqlContextImpl;
 import jp.co.future.uroborosql.converter.MapResultSetConverter;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.exception.EntitySqlRuntimeException;
+import jp.co.future.uroborosql.exception.OptimisticLockException;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.mapping.EntityHandler;
+import jp.co.future.uroborosql.mapping.MappingUtils;
 import jp.co.future.uroborosql.mapping.TableMetadata;
 import jp.co.future.uroborosql.parameter.Parameter;
 import jp.co.future.uroborosql.store.SqlManager;
@@ -678,7 +680,12 @@ public class SqlAgentImpl extends AbstractAgent {
 			TableMetadata metadata = handler.getMetadata(this.transactionManager, type);
 			SqlContext context = handler.createUpdateContext(this, metadata, type);
 			handler.setUpdateParams(context, entity);
-			return handler.doUpdate(this, context, entity);
+			int count = handler.doUpdate(this, context, entity);
+
+			if (MappingUtils.getVersionMappingColumn(type).isPresent() && count == 0) {
+				throw new OptimisticLockException();
+			}
+			return count;
 		} catch (SQLException e) {
 			throw new EntitySqlRuntimeException(EntitySqlRuntimeException.EntityProcKind.UPDATE, e);
 		}

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
@@ -213,4 +213,10 @@ public interface SqlContext extends TransformContext, SqlFluent<SqlContext> {
 	 */
 	Map<String, Object> contextAttrs();
 
+	/**
+	 * バインドパラメータの文字列表現を返す
+	 *
+	 * @return バインドパラメータの文字列表現
+	 */
+	String formatParams();
 }

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -892,4 +892,12 @@ public class SqlContextImpl implements SqlContext {
 		return contextAttributes;
 	}
 
+	@Override
+	public String formatParams() {
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i < bindNames.size(); i++) {
+			sb.append(String.format("[%s=%s]", bindNames.get(i), bindValiables.get(i)));
+		}
+		return sb.toString();
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/exception/OptimisticLockException.java
+++ b/src/main/java/jp/co/future/uroborosql/exception/OptimisticLockException.java
@@ -1,5 +1,7 @@
 package jp.co.future.uroborosql.exception;
 
+import jp.co.future.uroborosql.context.*;
+
 /**
  * 楽観的排他制御の実行時例外
  *
@@ -7,8 +9,8 @@ package jp.co.future.uroborosql.exception;
  */
 public class OptimisticLockException extends UroborosqlRuntimeException {
 
-	public OptimisticLockException() {
-		super();
+	public OptimisticLockException(SqlContext context) {
+		super(String.format("An error occurred due to optimistic locking.\nExecuted SQL [\n%s]\nparams:%s", context.getExecutableSql(), context.formatParams()));
 	}
 
 	public OptimisticLockException(final String message) {

--- a/src/main/java/jp/co/future/uroborosql/exception/OptimisticLockException.java
+++ b/src/main/java/jp/co/future/uroborosql/exception/OptimisticLockException.java
@@ -1,0 +1,26 @@
+package jp.co.future.uroborosql.exception;
+
+/**
+ * 楽観的排他制御の実行時例外
+ *
+ * @author hoshi
+ */
+public class OptimisticLockException extends UroborosqlRuntimeException {
+
+	public OptimisticLockException() {
+		super();
+	}
+
+	public OptimisticLockException(final String message) {
+		super(message);
+	}
+
+	public OptimisticLockException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public OptimisticLockException(final Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/MappingColumn.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MappingColumn.java
@@ -44,4 +44,10 @@ public interface MappingColumn {
 	 */
 	JavaType getJavaType();
 
+	/**
+	 * バージョン情報カラムかどうか
+	 *
+	 * @return バージョンカラムの場合は<code>true</code>
+	 */
+	boolean isVersion();
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/annotations/Version.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/annotations/Version.java
@@ -1,0 +1,13 @@
+package jp.co.future.uroborosql.mapping.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * エンティティ バージョン情報アノテーション
+ *
+ * @author hoshi
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Version {
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntity3.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntity3.java
@@ -1,26 +1,24 @@
 package jp.co.future.uroborosql.mapping;
 
-import java.time.LocalDate;
-
-import jp.co.future.uroborosql.mapping.annotations.*;
-
 import jp.co.future.uroborosql.mapping.annotations.Table;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import jp.co.future.uroborosql.mapping.annotations.*;
+import org.apache.commons.lang3.builder.*;
+
+import java.time.*;
 
 @Table(name = "TEST")
-public class TestEntity2 {
+public class TestEntity3 {
 	private long id;
 	private String name;
 	private int age;
 	private LocalDate birthday;
+	@Version
 	private int lockVersion = 0;
 
-	public TestEntity2() {
+	public TestEntity3() {
 	}
 
-	public TestEntity2(final long id, final String name, final int age, final LocalDate birthday) {
+	public TestEntity3(final long id, final String name, final int age, final LocalDate birthday) {
 		this.id = id;
 		this.name = name;
 		this.age = age;


### PR DESCRIPTION
When using the DAO interface, we support optimistic locking like JPA's @ Version.

such as

```java
@Table(name = "TEST")
public class TestEntity3 {
	private long id;
	private String name;
	private int age;
	private LocalDate birthday;
	@Version
	private int lockVersion = 0;

       ...
}
```

```java
	@Test(expected = OptimisticLockException.class)
	public void testUpdateLockVersionError() throws Exception {

		try (SqlAgent agent = config.createAgent()) {
			agent.required(() -> {
				TestEntity3 test = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
				test.setLockVersion(1);
				agent.insert(test);

				test.setName("updatename");
				test.setLockVersion(0);
				agent.update(test); // throw OptimisticLockException!!
			});
		}
	}
```
In addition, I fixed the typo. (geTable -> getTable)