### PR TITLE
Add SqlQuery#stream(Class) method

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
@@ -8,11 +8,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.converter.*;
+import jp.co.future.uroborosql.converter.EntityResultSetConverter;
+import jp.co.future.uroborosql.converter.MapResultSetConverter;
+import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.exception.DataNotFoundException;
 import jp.co.future.uroborosql.exception.UroborosqlSQLException;
 import jp.co.future.uroborosql.fluent.SqlQuery;
-import jp.co.future.uroborosql.mapping.mapper.*;
+import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
 /**

--- a/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
@@ -8,11 +8,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.converter.MapResultSetConverter;
-import jp.co.future.uroborosql.converter.ResultSetConverter;
+import jp.co.future.uroborosql.converter.*;
 import jp.co.future.uroborosql.exception.DataNotFoundException;
 import jp.co.future.uroborosql.exception.UroborosqlSQLException;
 import jp.co.future.uroborosql.fluent.SqlQuery;
+import jp.co.future.uroborosql.mapping.mapper.*;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
 /**
@@ -53,6 +53,15 @@ final class SqlQueryImpl extends AbstractSqlFluent<SqlQuery> implements SqlQuery
 	public <T> Stream<T> stream(final ResultSetConverter<T> converter) {
 		try {
 			return agent.query(context(), converter);
+		} catch (SQLException e) {
+			throw new UroborosqlSQLException(e);
+		}
+	}
+
+	@Override
+	public <T> Stream<T> stream(final Class<T> type) {
+		try {
+			return agent.query(context(), new EntityResultSetConverter<T>(type, new PropertyMapperManager()));
 		} catch (SQLException e) {
 			throw new UroborosqlSQLException(e);
 		}

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
@@ -3,17 +3,16 @@
  */
 package jp.co.future.uroborosql.fluent;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.exception.DataNotFoundException;
 import jp.co.future.uroborosql.utils.CaseFormat;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * SQL Query 実行インタフェース
@@ -26,7 +25,6 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	 * ResultSetの取得（終端処理）
 	 *
 	 * @return ResultSet
-	 *
 	 * @see SqlAgent#query(SqlContext)
 	 */
 	ResultSet resultSet();
@@ -35,7 +33,6 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	 * 検索結果の取得（終端処理）
 	 *
 	 * @return 検索結果のリスト. MapのキーはSnakeCaseに変換される.
-	 *
 	 * @see SqlAgent#query(String)
 	 */
 	List<Map<String, Object>> collect();
@@ -45,7 +42,6 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	 *
 	 * @param caseFormat Mapのキーの変換書式
 	 * @return 検索結果のリスト
-	 *
 	 * @see SqlAgent#query(String)
 	 */
 	List<Map<String, Object>> collect(CaseFormat caseFormat);
@@ -70,7 +66,7 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	/**
 	 * 検索結果をStreamとして取得（終端処理）
 	 *
-	 * @param <T> Streamの型
+	 * @param <T>       Streamの型
 	 * @param converter ResultSetの各行を変換するための変換器
 	 * @return 検索結果を順次取得するStream
 	 */
@@ -82,4 +78,11 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	 * @return 検索結果を順次取得するStream. MapのキーはCamel式に変換される.
 	 */
 	Stream<Map<String, Object>> stream();
+
+	/**
+	 * 検索結果をEntityのStreamとして取得（終端処理）
+	 *
+	 * @return 検索結果を順次取得するStream.
+	 */
+	<T> Stream<T> stream(Class<T> type);
 }

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
@@ -3,16 +3,16 @@
  */
 package jp.co.future.uroborosql.fluent;
 
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.exception.DataNotFoundException;
 import jp.co.future.uroborosql.utils.CaseFormat;
-
-import java.sql.ResultSet;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * SQL Query 実行インタフェース

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -1,16 +1,6 @@
 package jp.co.future.uroborosql;
 
-import jp.co.future.uroborosql.config.DefaultSqlConfig;
-import jp.co.future.uroborosql.config.SqlConfig;
-import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.converter.ResultSetConverter;
-import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
-import jp.co.future.uroborosql.filter.SqlFilterManager;
-import jp.co.future.uroborosql.filter.WrapContextSqlFilter;
-import jp.co.future.uroborosql.utils.CaseFormat;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -34,7 +24,18 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import jp.co.future.uroborosql.config.DefaultSqlConfig;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.converter.ResultSetConverter;
+import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.filter.SqlFilterManager;
+import jp.co.future.uroborosql.filter.WrapContextSqlFilter;
+import jp.co.future.uroborosql.utils.CaseFormat;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SqlAgentTest {
 	private SqlConfig config;
@@ -45,7 +46,7 @@ public class SqlAgentTest {
 		try (SqlAgent agent = config.createAgent()) {
 
 			String[] sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/ddl/create_tables.sql")),
-				StandardCharsets.UTF_8).split(";");
+					StandardCharsets.UTF_8).split(";");
 			for (String sql : sqls) {
 				if (StringUtils.isNotBlank(sql)) {
 					agent.updateWith(sql.trim()).count();
@@ -94,7 +95,7 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			dataList.stream().map(map -> map.get("table")).collect(Collectors.toSet())
-				.forEach(tbl -> truncateTable(tbl));
+					.forEach(tbl -> truncateTable(tbl));
 
 			dataList.stream().forEach(map -> {
 				try {
@@ -112,6 +113,7 @@ public class SqlAgentTest {
 
 	/**
 	 * クエリ実行処理のテストケース。
+	 *
 	 */
 	@Test
 	public void testQuery() throws Exception {
@@ -123,7 +125,7 @@ public class SqlAgentTest {
 			productIdList.add(new BigDecimal("0"));
 			productIdList.add(new BigDecimal("2"));
 			SqlContext ctx = agent.contextFrom("example/select_product").param("product_id", productIdList)
-				.setSqlId("test_sql_id");
+					.setSqlId("test_sql_id");
 
 			ResultSet rs = agent.query(ctx);
 			assertNotNull("ResultSetが取得できませんでした。", rs);
@@ -147,15 +149,15 @@ public class SqlAgentTest {
 
 		SqlFilterManager manager = config.getSqlFilterManager();
 		WrapContextSqlFilter filter = new WrapContextSqlFilter("",
-			"LIMIT /*$maxRowCount*/10 OFFSET /*$startRowIndex*/0", ".*(FOR\\sUPDATE|\\.NEXTVAL).*");
+				"LIMIT /*$maxRowCount*/10 OFFSET /*$startRowIndex*/0", ".*(FOR\\sUPDATE|\\.NEXTVAL).*");
 		filter.initialize();
 		manager.addSqlFilter(filter);
 
 		try (SqlAgent agent = config.createAgent()) {
 
 			SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramList("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
-				.param("maxRowCount", 1);
+					.paramList("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
+					.param("maxRowCount", 1);
 
 			ResultSet rs = agent.query(ctx);
 			assertNotNull("ResultSetが取得できませんでした。", rs);
@@ -221,7 +223,7 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
-				.collect();
+					.collect();
 			assertEquals("結果の件数が一致しません。", 2, ans.size());
 			Map<String, Object> map = ans.get(0);
 			assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
@@ -298,7 +300,7 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			Stream<Map<String, Object>> stream = agent.query("example/select_product").paramList("product_id", 0, 1)
-				.stream();
+					.stream();
 
 			stream.forEach((m) -> {
 				assertTrue(m.containsKey("PRODUCT_ID"));
@@ -392,13 +394,13 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			agent.query("example/select_product").paramList("product_id", 0, 1).stream(new CustomResultSetConverter())
-				.forEach((m) -> {
-					try {
-						agent.update("example/insert_product_regist_work").paramMap(m).count();
-					} catch (Exception e) {
-						fail(e.getMessage());
-					}
-				});
+					.forEach((m) -> {
+						try {
+							agent.update("example/insert_product_regist_work").paramMap(m).count();
+						} catch (Exception e) {
+							fail(e.getMessage());
+						}
+					});
 
 			List<Map<String, Object>> collect = agent.queryWith("select * from product_regist_work").collect();
 			assertEquals(2, collect.size());
@@ -415,17 +417,17 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			SqlContext ctx = agent.contextFrom("example/selectinsert_product")
-				.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
-				.param("jan_code", "1234567890123", Types.CHAR);
+					.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
+					.param("jan_code", "1234567890123", Types.CHAR);
 
 			int updateCount = agent.update(ctx);
 			assertEquals("データの登録に失敗しました。", 1, updateCount);
 
 			// 検証処理
 			List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
-				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
+					"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 			List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 0, 1).stream(new CustomResultSetConverter()).collect(Collectors.toList());
+					.paramList("product_id", 0, 1).stream(new CustomResultSetConverter()).collect(Collectors.toList());
 
 			assertEquals(expectedDataList.toString(), actualDataList.toString());
 		}
@@ -441,15 +443,15 @@ public class SqlAgentTest {
 
 		try (SqlAgent agent = config.createAgent()) {
 			int updateCount = agent.update("example/selectinsert_product")
-				.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
-				.param("jan_code", "1234567890123", Types.CHAR).count();
+					.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
+					.param("jan_code", "1234567890123", Types.CHAR).count();
 			assertEquals("データの登録に失敗しました。", 1, updateCount);
 
 			// 検証処理
 			List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
-				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
+					"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 			List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 0, 1).stream(new CustomResultSetConverter()).collect(Collectors.toList());
+					.paramList("product_id", 0, 1).stream(new CustomResultSetConverter()).collect(Collectors.toList());
 
 			assertEquals(expectedDataList.toString(), actualDataList.toString());
 		}
@@ -468,14 +470,14 @@ public class SqlAgentTest {
 			Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
 
 			SqlContext ctx = agent.contextFrom("example/insert_product").param("product_id", new BigDecimal(1))
-				.param("product_name", "商品名1").param("product_kana_name", "ショウヒンメイイチ")
-				.param("jan_code", "1234567890123").param("product_description", "1番目の商品")
-				.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
-				.param("version_no", new BigDecimal(0)).addBatch().param("product_id", new BigDecimal(2))
-				.param("product_name", "商品名2").param("product_kana_name", "ショウヒンメイニ")
-				.param("jan_code", "1234567890124").param("product_description", "2番目の商品")
-				.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
-				.param("version_no", new BigDecimal(0)).addBatch();
+					.param("product_name", "商品名1").param("product_kana_name", "ショウヒンメイイチ")
+					.param("jan_code", "1234567890123").param("product_description", "1番目の商品")
+					.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
+					.param("version_no", new BigDecimal(0)).addBatch().param("product_id", new BigDecimal(2))
+					.param("product_name", "商品名2").param("product_kana_name", "ショウヒンメイニ")
+					.param("jan_code", "1234567890124").param("product_description", "2番目の商品")
+					.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
+					.param("version_no", new BigDecimal(0)).addBatch();
 
 			int[] count = agent.batch(ctx);
 			assertEquals("データの登録件数が不正です。", 2, count.length);
@@ -484,9 +486,9 @@ public class SqlAgentTest {
 
 			// 検証処理
 			List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
-				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
+					"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 			List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
+					.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
 
 			assertEquals(expectedDataList.toString(), actualDataList.toString());
 		}
@@ -505,19 +507,19 @@ public class SqlAgentTest {
 			Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
 
 			SqlContext ctx = agent.contextFrom("example/insert_product").param("product_id", new BigDecimal(1))
-				.param("product_name", "商品名1").param("product_kana_name", "ショウヒンメイイチ")
-				.param("jan_code", "1234567890123").param("product_description", "1番目の商品")
-				.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
-				.param("version_no", new BigDecimal(0)).addBatch();
+					.param("product_name", "商品名1").param("product_kana_name", "ショウヒンメイイチ")
+					.param("jan_code", "1234567890123").param("product_description", "1番目の商品")
+					.param("ins_datetime", currentDatetime).param("upd_datetime", currentDatetime)
+					.param("version_no", new BigDecimal(0)).addBatch();
 
 			int[] count = agent.batch(ctx);
 			assertEquals("データの登録件数が不正です。", 1, count.length);
 			assertEquals("1行目のデータの登録に失敗しました。", 1, count[0]);
 
 			ctx.param("product_id", new BigDecimal(2)).param("product_name", "商品名2")
-				.param("product_kana_name", "ショウヒンメイニ").param("jan_code", "1234567890124")
-				.param("product_description", "2番目の商品").param("ins_datetime", currentDatetime)
-				.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch();
+					.param("product_kana_name", "ショウヒンメイニ").param("jan_code", "1234567890124")
+					.param("product_description", "2番目の商品").param("ins_datetime", currentDatetime)
+					.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch();
 
 			count = agent.batch(ctx);
 			assertEquals("データの登録件数が不正です。", 1, count.length);
@@ -525,9 +527,9 @@ public class SqlAgentTest {
 
 			// 検証処理
 			List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
-				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
+					"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 			List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
+					.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
 
 			assertEquals(expectedDataList.toString(), actualDataList.toString());
 		}
@@ -545,13 +547,13 @@ public class SqlAgentTest {
 		try (SqlAgent agent = config.createAgent()) {
 			Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
 			SqlContext ctx = agent.contextFrom("example/insert_product").param("product_id", new BigDecimal(1))
-				.param("product_name", null).param("product_kana_name", null).param("jan_code", "1234567890123")
-				.param("product_description", "1番目の商品").param("ins_datetime", currentDatetime)
-				.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch()
-				.param("product_id", new BigDecimal(2)).param("product_name", "商品名2")
-				.param("product_kana_name", "ショウヒンメイニ").param("jan_code", "1234567890124")
-				.param("product_description", "2番目の商品").param("ins_datetime", currentDatetime)
-				.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch();
+					.param("product_name", null).param("product_kana_name", null).param("jan_code", "1234567890123")
+					.param("product_description", "1番目の商品").param("ins_datetime", currentDatetime)
+					.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch()
+					.param("product_id", new BigDecimal(2)).param("product_name", "商品名2")
+					.param("product_kana_name", "ショウヒンメイニ").param("jan_code", "1234567890124")
+					.param("product_description", "2番目の商品").param("ins_datetime", currentDatetime)
+					.param("upd_datetime", currentDatetime).param("version_no", new BigDecimal(0)).addBatch();
 
 			int[] count = agent.batch(ctx);
 			assertEquals("データの登録件数が不正です。", 2, count.length);
@@ -559,9 +561,9 @@ public class SqlAgentTest {
 			assertEquals("2行目のデータの登録に失敗しました。", 1, count[1]);
 
 			List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
-				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchNull.ltsv"));
+					"src/test/resources/data/expected/SqlAgent", "testExecuteBatchNull.ltsv"));
 			List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
+					.paramList("product_id", 1, 2).stream(new CustomResultSetConverter()).collect(Collectors.toList());
 
 			assertEquals(expectedDataList.toString(), actualDataList.toString());
 		}


### PR DESCRIPTION
I added the `SqlQuery#stream` overload method. 

This method can map multiple results with `SqlAgent#query` to an arbitrary type using` EntityResultSetConveter`.

See below.

```java
try (SqlAgent agent = config.createAgent()) {
  agent.query("example/select_product")
    .paramList("product_id", 0, 1)
    .stream(Product.class)
    .forEach(p -> {
      assertNotNull(p.getProductId());
      assertNotNull(p.getProductName());
      assertNotNull(p.getProductKanaName());
      assertNotNull(p.getJanCode());
      assertNotNull(p.getProductDescription());
      assertNotNull(p.getInsDatetime());
      assertNotNull(p.getUpdDatetime());
      assertNotNull(p.getVersionNo());
    });
}
```