### PR TITLE
Add SqlQuery#first(Class) method and refine

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -94,6 +94,13 @@ public interface SqlAgentFactory {
 	EntityHandler<?> getEntityHandler();
 
 	/**
+	 * ORM処理クラスを設定します。
+	 *
+	 * @param entityHandler ORM処理クラス
+	 */
+	void setEntityHandler(EntityHandler<?> entityHandler);
+
+	/**
 	 * 例外発生時のログ出力を行うかどうかを取得します。
 	 *
 	 * @return 例外発生時のログ出力を行うかどうか。ログ出力する場合は<code>true</code>

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -156,6 +156,7 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	 *
 	 * @param entityHandler SQLフィルタ管理クラス
 	 */
+	@Override
 	public void setEntityHandler(final EntityHandler<?> entityHandler) {
 		this.entityHandler = entityHandler;
 	}

--- a/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
@@ -107,6 +107,17 @@ final class SqlQueryImpl extends AbstractSqlFluent<SqlQuery> implements SqlQuery
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlQuery#first(Class)
+	 */
+	@Override
+	public <T>T first(Class<T> type) {
+		Optional<T> first = stream(new EntityResultSetConverter<T>(type, new PropertyMapperManager())).findFirst();
+		return first.orElseThrow(() -> new DataNotFoundException("query result is empty."));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlQuery#collect(jp.co.future.uroborosql.utils.CaseFormat)
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
@@ -64,6 +64,16 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	Map<String, Object> first();
 
 	/**
+	 * 検索結果の先頭行をEntityとして取得（終端処理）
+	 *
+	 * @param <T>  Entityの型
+	 * @param type 受け取りたいEntityの型
+	 * @return 検索結果の先頭行のEntity
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 */
+	<T>T first(Class<T> type);
+
+	/**
 	 * 検索結果をStreamとして取得（終端処理）
 	 *
 	 * @param <T>       Streamの型

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -253,6 +253,27 @@ public class SqlAgentTest {
 	}
 
 	/**
+	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
+	 */
+	@Test
+	public void testQueryFluentFirstByClass() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		try (SqlAgent agent = config.createAgent()) {
+			Product product = agent.query("example/select_product")
+				.paramList("product_id", 0, 1, 2, 3)
+				.first(Product.class);
+
+			assertEquals(0, product.getProductId());
+			assertEquals("商品名0", product.getProductName());
+			assertEquals("ショウヒンメイゼロ", product.getProductKanaName());
+			assertEquals("1234567890123", product.getJanCode());
+			assertEquals("0番目の商品", product.getProductDescription());
+		}
+	}
+
+	/**
 	 * クエリ実行処理のテストケース。
 	 */
 	@Test


### PR DESCRIPTION
### 1. Add SqlQuery#first(Class) method

see below.

```java
try (SqlAgent agent = config.createAgent()) {
    Product product = agent.query("example/select_product")
        .paramList("product_id", 0, 1, 2, 3)
        .first(Product.class);

    assertEquals(0, product.getProductId());
    assertEquals("商品名0", product.getProductName());
    assertEquals("ショウヒンメイゼロ", product.getProductKanaName());
    assertEquals("1234567890123", product.getJanCode());
    assertEquals("0番目の商品", product.getProductDescription());
}
```

### 2. Add SqlAgendFactory#setEntityHandler method

It was public method in the implementation class so far, but it was made public in Interface this time.

By making EntityHandler replaceable, I would like to make it possible to insert common processing from the outside.

For example, set common columns such as creation datetime etc.