### PR TITLE
LocalTransactionManager conforms to Optional

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/config/DefaultSqlConfig.java
+++ b/src/main/java/jp/co/future/uroborosql/config/DefaultSqlConfig.java
@@ -37,7 +37,7 @@ public class DefaultSqlConfig implements SqlConfig {
 	private final SqlContextFactory sqlContextFactory;
 	private final SqlAgentFactory sqlAgentFactory;
 	private final Dialect dialect;
-	private final EntityHandler<?> entityHandler;
+	private EntityHandler<?> entityHandler;
 
 	/**
 	 * コンストラクタ
@@ -330,6 +330,16 @@ public class DefaultSqlConfig implements SqlConfig {
 	@Override
 	public EntityHandler<?> getEntityHandler() {
 		return entityHandler;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfig#setEntityHandler(EntityHandler)
+	 */
+	@Override
+	public void setEntityHandler(final EntityHandler<?> entityHandler) {
+		this.entityHandler = entityHandler;
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
+++ b/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
@@ -99,4 +99,10 @@ public interface SqlConfig {
 	 */
 	EntityHandler<?> getEntityHandler();
 
+	/**
+	 * entityHandler を設定します
+	 *
+	 * @param entityHandler
+	 */
+	void setEntityHandler(EntityHandler<?> entityHandler);
 }


### PR DESCRIPTION
In LocalTransactionManager, there was one that would become NPE if TransactionContext could not be acquired, so we reexamined it entirely and rewritten it with Optional.