### PR TITLE
DefaultEntityHandler check transient annotation

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -206,12 +206,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		StringBuilder sql = new StringBuilder("INSERT ").append("/* ").append(sqlIdKeyName).append(" */")
 				.append(" INTO ").append(metadata.getTableIdentifier()).append("(").append(System.lineSeparator());
 
-		Map<String, MappingColumn> mappingColumns = Arrays.stream(
-				MappingUtils.getMappingColumns(type, SqlStatement.INSERT)).collect(
-				Collectors.toMap(c -> c.getName().toLowerCase(), c -> c));
+		List<String> mappingColumnNames = Arrays.stream(MappingUtils.getMappingColumns(type, SqlStatement.INSERT))
+				.map(c -> c.getName().toLowerCase()).collect(Collectors.toList());
 		boolean firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
-			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+			if (!mappingColumnNames.isEmpty() && !mappingColumnNames.contains(col.getColumnName().toLowerCase())) {
 				// Transient annotation のついているカラムをスキップ
 				continue;
 			}
@@ -243,7 +242,7 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 
 		firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
-			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+			if (!mappingColumnNames.isEmpty() && !mappingColumnNames.contains(col.getColumnName().toLowerCase())) {
 				// Transient annotation のついているカラムをスキップ
 				continue;
 			}
@@ -284,16 +283,15 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		StringBuilder sql = new StringBuilder("UPDATE ").append("/* ").append(sqlIdKeyName).append(" */")
 				.append(" ").append(metadata.getTableIdentifier()).append(" SET ").append(System.lineSeparator());
 
-		Map<String, MappingColumn> mappingColumns = Arrays.stream(
-				MappingUtils.getMappingColumns(type, SqlStatement.UPDATE)).collect(
-				Collectors.toMap(c -> c.getName().toLowerCase(), c -> c));
+		List<String> mappingColumnNames = Arrays.stream(MappingUtils.getMappingColumns(type, SqlStatement.UPDATE))
+				.map(c -> c.getName().toLowerCase()).collect(Collectors.toList());
 
 		Optional<MappingColumn> versionMappingColumn = type == null ? Optional.empty() : MappingUtils
 				.getVersionMappingColumn(type);
 
 		boolean firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
-			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+			if (!mappingColumnNames.isEmpty() && !mappingColumnNames.contains(col.getColumnName().toLowerCase())) {
 				// Transient annotation のついているカラムをスキップ
 				continue;
 			}
@@ -332,11 +330,6 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.asList(metadata.getColumns().get(0));
 		firstFlag = true;
 		for (TableMetadata.Column col : cols) {
-			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
-				// Transient annotation のついているカラムをスキップ
-				continue;
-			}
-
 			StringBuilder parts = new StringBuilder().append("\t");
 			if (firstFlag) {
 				if (col.isNullable()) {

--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.SqlAgent;
@@ -205,8 +206,16 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		StringBuilder sql = new StringBuilder("INSERT ").append("/* ").append(sqlIdKeyName).append(" */")
 				.append(" INTO ").append(metadata.getTableIdentifier()).append("(").append(System.lineSeparator());
 
+		Map<String, MappingColumn> mappingColumns = Arrays.stream(
+				MappingUtils.getMappingColumns(type, SqlStatement.INSERT)).collect(
+				Collectors.toMap(c -> c.getName().toLowerCase(), c -> c));
 		boolean firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
+			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+				// Transient annotation のついているカラムをスキップ
+				continue;
+			}
+
 			StringBuilder parts = new StringBuilder().append("\t");
 			if (firstFlag) {
 				if (col.isNullable()) {
@@ -234,6 +243,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 
 		firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
+			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+				// Transient annotation のついているカラムをスキップ
+				continue;
+			}
+
 			StringBuilder parts = new StringBuilder().append("\t");
 			if (firstFlag) {
 				if (col.isNullable()) {
@@ -270,11 +284,20 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		StringBuilder sql = new StringBuilder("UPDATE ").append("/* ").append(sqlIdKeyName).append(" */")
 				.append(" ").append(metadata.getTableIdentifier()).append(" SET ").append(System.lineSeparator());
 
+		Map<String, MappingColumn> mappingColumns = Arrays.stream(
+				MappingUtils.getMappingColumns(type, SqlStatement.UPDATE)).collect(
+				Collectors.toMap(c -> c.getName().toLowerCase(), c -> c));
+
 		Optional<MappingColumn> versionMappingColumn = type == null ? Optional.empty() : MappingUtils
 				.getVersionMappingColumn(type);
 
 		boolean firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {
+			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+				// Transient annotation のついているカラムをスキップ
+				continue;
+			}
+
 			String camelColName = col.getCamelColumnName();
 			StringBuilder parts = new StringBuilder().append("\t");
 			if (firstFlag) {
@@ -309,6 +332,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.asList(metadata.getColumns().get(0));
 		firstFlag = true;
 		for (TableMetadata.Column col : cols) {
+			if (mappingColumns.size() > 0 && !mappingColumns.containsKey(col.getColumnName().toLowerCase())) {
+				// Transient annotation のついているカラムをスキップ
+				continue;
+			}
+
 			StringBuilder parts = new StringBuilder().append("\t");
 			if (firstFlag) {
 				if (col.isNullable()) {

--- a/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
@@ -153,6 +153,10 @@ public final class MappingUtils {
 	 * @return カラムマッピング情報
 	 */
 	public static MappingColumn[] getMappingColumns(final Class<?> entityType, final SqlStatement stmt) {
+		if (entityType == null) {
+			return new MappingColumn[0];
+		}
+
 		Map<SqlStatement, MappingColumn[]> cols;
 		synchronized (CACHE) {
 			cols = CACHE.get(entityType);

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
@@ -339,7 +339,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 		Consumer<SqlContext> binder1 = (ctx) -> ctx.param("ins_datetime", LocalDateTime.now());
 		factory.addUpdateAutoParameterBinder(binder1);
 
-		int count = 100;
+		int count = 1000;
 		try (SqlAgent agent = config.agent()) {
 			agent.updateWith("truncate table PRODUCT").count();
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/annotations/ColumnTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/annotations/ColumnTest.java
@@ -67,15 +67,20 @@ public class ColumnTest {
 		private int ageAaaaAaaa;
 		@Column(name = "BIRTHDAY")
 		private LocalDate birthdayAaaaAaaa;
+		@Column(name = "MEMO")
+		@Transient
+		private String memoAaaaAaaa;
 
 		public ColumnAnnoTestEntity() {
 		}
 
-		public ColumnAnnoTestEntity(final long id, final String name, final int age, final LocalDate birthday) {
+		public ColumnAnnoTestEntity(final long id, final String name, final int age, final LocalDate birthday,
+				final String memo) {
 			this.idAaaaAaaa = id;
 			this.nameAaaaAaaa = name;
 			this.ageAaaaAaaa = age;
 			this.birthdayAaaaAaaa = birthday;
+			this.memoAaaaAaaa = memo;
 		}
 
 		@Override
@@ -100,14 +105,20 @@ public class ColumnTest {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
 				ColumnAnnoTestEntity test1 = new ColumnAnnoTestEntity(1, "name1", 20, LocalDate
-						.of(1990, Month.APRIL, 1));
+						.of(1990, Month.APRIL, 1), "memo1");
 				agent.insert(test1);
+				test1.memoAaaaAaaa = null;
+
 				ColumnAnnoTestEntity test2 = new ColumnAnnoTestEntity(2, "name2", 21, LocalDate
-						.of(1990, Month.APRIL, 2));
+						.of(1990, Month.APRIL, 2), null);
 				agent.insert(test2);
+				test2.memoAaaaAaaa = null;
+
 				ColumnAnnoTestEntity test3 = new ColumnAnnoTestEntity(3, "name3", 22, LocalDate
-						.of(1990, Month.APRIL, 3));
+						.of(1990, Month.APRIL, 3), "memo3");
 				agent.insert(test3);
+				test3.memoAaaaAaaa = null;
+
 				ColumnAnnoTestEntity data = agent.find(ColumnAnnoTestEntity.class, 1).orElse(null);
 				assertThat(data, is(test1));
 				data = agent.find(ColumnAnnoTestEntity.class, 2).orElse(null);

--- a/src/test/java/jp/co/future/uroborosql/mapping/annotations/ColumnTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/annotations/ColumnTest.java
@@ -104,6 +104,7 @@ public class ColumnTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
+				// insert
 				ColumnAnnoTestEntity test1 = new ColumnAnnoTestEntity(1, "name1", 20, LocalDate
 						.of(1990, Month.APRIL, 1), "memo1");
 				agent.insert(test1);
@@ -125,6 +126,17 @@ public class ColumnTest {
 				assertThat(data, is(test2));
 				data = agent.find(ColumnAnnoTestEntity.class, 3).orElse(null);
 				assertThat(data, is(test3));
+
+				// update
+
+				test1.nameAaaaAaaa = "name11";
+				test1.memoAaaaAaaa = "memo11";
+				agent.update(test1);
+
+				test1.memoAaaaAaaa = null;
+
+				data = agent.find(ColumnAnnoTestEntity.class, 1).orElse(null);
+				assertThat(data, is(test1));
 
 			});
 		}


### PR DESCRIPTION
When constructing insert and update SQL with DefaultEntityHandler, check Transient annotation attached to the field of Entity class and fix not to output column.