### PR TITLE
I would like ResultSetConverter to convert CLOB, BLOB, and Array to a manageable type instead of getting it as an object

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/converter/MapResultSetConverter.java
+++ b/src/main/java/jp/co/future/uroborosql/converter/MapResultSetConverter.java
@@ -1,5 +1,10 @@
 package jp.co.future.uroborosql.converter;
 
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.JDBCType;
+import java.sql.NClob;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -15,9 +20,13 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  *
  */
 public class MapResultSetConverter implements ResultSetConverter<Map<String, Object>> {
-	private CaseFormat caseFormat = CaseFormat.UPPER_SNAKE_CASE;
+	private CaseFormat caseFormat;
 
+	/**
+	 * コンストラクタ
+	 */
 	public MapResultSetConverter() {
+		this(CaseFormat.UPPER_SNAKE_CASE);
 	}
 
 	/**
@@ -40,9 +49,31 @@ public class MapResultSetConverter implements ResultSetConverter<Map<String, Obj
 		int columnCount = rsmd.getColumnCount();
 		Map<String, Object> record = new LinkedHashMap<>(columnCount);
 		for (int i = 1; i <= columnCount; i++) {
-			record.put(caseFormat.convert(rsmd.getColumnLabel(i)), rs.getObject(i));
+			record.put(caseFormat.convert(rsmd.getColumnLabel(i)), getValue(rs, rsmd, i));
 		}
 		return record;
+	}
+
+	private Object getValue(final ResultSet rs, final ResultSetMetaData rsmd, final int columnIndex)
+			throws SQLException {
+		JDBCType type = JDBCType.valueOf(rsmd.getColumnType(columnIndex));
+		switch (type) {
+		case CLOB:
+			Clob clob = rs.getClob(columnIndex);
+			return clob.getSubString(1, (int) clob.length());
+		case NCLOB:
+			NClob nclob = rs.getNClob(columnIndex);
+			return nclob.getSubString(1, (int) nclob.length());
+		case BLOB:
+			Blob blob = rs.getBlob(columnIndex);
+			return blob.getBytes(1, (int) blob.length());
+		case ARRAY:
+			Array arr = rs.getArray(columnIndex);
+			return arr.getArray();
+		default:
+			return rs.getObject(columnIndex);
+		}
+
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/converter/EntityResultSetConverterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/converter/EntityResultSetConverterTest.java
@@ -1,0 +1,152 @@
+package jp.co.future.uroborosql.converter;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.sql.DriverManager;
+import java.util.Optional;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EntityResultSetConverterTest {
+
+	private SqlConfig config;
+
+	private SqlAgent agent;
+
+	public static class ColumnTypeTest2 {
+		private String colClob;
+		private String colNclob;
+		private byte[] colBlob;
+		private Object[] colArray;
+
+		/**
+		 * colClob を取得します。
+		 *
+		 * @return colClob
+		 */
+		public String getColClob() {
+			return colClob;
+		}
+
+		/**
+		 * colClob を設定します。
+		 *
+		 * @param colClob colClob
+		 */
+		public void setColClob(final String colClob) {
+			this.colClob = colClob;
+		}
+
+		/**
+		 * colNclob を取得します。
+		 *
+		 * @return colNclob
+		 */
+		public String getColNclob() {
+			return colNclob;
+		}
+
+		/**
+		 * colNclob を設定します。
+		 *
+		 * @param colNclob colNclob
+		 */
+		public void setColNclob(final String colNclob) {
+			this.colNclob = colNclob;
+		}
+
+		/**
+		 * colBlob を取得します。
+		 *
+		 * @return colBlob
+		 */
+		public byte[] getColBlob() {
+			return colBlob;
+		}
+
+		/**
+		 * colBlob を設定します。
+		 *
+		 * @param colBlob colBlob
+		 */
+		public void setColBlob(final byte[] colBlob) {
+			this.colBlob = colBlob;
+		}
+
+		/**
+		 * colArray を取得します。
+		 *
+		 * @return colArray
+		 */
+		public Object[] getColArray() {
+			return colArray;
+		}
+
+		/**
+		 * colArray を設定します。
+		 *
+		 * @param colArray colArray
+		 */
+		public void setColArray(final Object[] colArray) {
+			this.colArray = colArray;
+		}
+
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		config = UroboroSQL.builder(DriverManager.getConnection("jdbc:h2:mem:EntityResultSetConverterTest")).build();
+		agent = config.agent();
+
+		String sql = "create table if not exists COLUMN_TYPE_TEST2 (" +
+				"	COL_CLOB			CLOB," +
+				"	COL_NCLOB			NCLOB," +
+				"	COL_BLOB			BLOB," +
+				"	COL_ARRAY			ARRAY" +
+				");";
+		agent.updateWith(sql).count();
+
+		agent.commit();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		agent.close();
+	}
+
+	@Test
+	public void testCreateRecord() {
+		String clob = StringUtils.repeat('1', 10000);
+		String nclob = StringUtils.repeat('あ', 10000);
+		byte[] blob = StringUtils.repeat('x', 20000).getBytes();
+		Object[] arr = { 1, 2 };
+
+		ColumnTypeTest2 entity = new ColumnTypeTest2();
+		entity.setColClob(clob);
+		entity.setColNclob(nclob);
+		entity.setColBlob(blob);
+		entity.setColArray(arr);
+
+		agent.insert(entity);
+
+		Optional<ColumnTypeTest2> optional = agent.queryWith("select * from COLUMN_TYPE_TEST2").findFirst(
+				ColumnTypeTest2.class);
+		assertThat(optional.isPresent(), is(true));
+		ColumnTypeTest2 row = optional.get();
+
+		assertThat(row.getColClob(), is(clob));
+		assertThat(row.getColNclob(), is(nclob));
+		assertThat(row.getColBlob(), is(blob));
+		assertThat(row.getColArray(), is(arr));
+
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
@@ -1,0 +1,83 @@
+package jp.co.future.uroborosql.converter;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.DriverManager;
+import java.util.Map;
+import java.util.Optional;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MapResultSetConverterTest {
+
+	private SqlConfig config;
+
+	private SqlAgent agent;
+
+	@Before
+	public void setUp() throws Exception {
+		config = UroboroSQL.builder(DriverManager.getConnection("jdbc:h2:mem:MapResultSetConverterTest")).build();
+		agent = config.agent();
+
+		String sql = "create table if not exists COLUMN_TYPE_TEST2 (" +
+				"	COL_CLOB			CLOB," +
+				"	COL_NCLOB			NCLOB," +
+				"	COL_BLOB			BLOB," +
+				"	COL_ARRAY			ARRAY" +
+				");";
+		agent.updateWith(sql).count();
+
+		agent.commit();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		agent.close();
+	}
+
+	@Test
+	public void testCreateRecord() {
+		String sql = "insert into COLUMN_TYPE_TEST2 (" +
+				"	COL_CLOB," +
+				"	COL_NCLOB," +
+				"	COL_BLOB," +
+				"	COL_ARRAY" +
+				") VALUES (" +
+				"	/*clob*/, " +
+				"	/*nclob*/, " +
+				"	/*blob*/, " +
+				"	/*arr*/" +
+				")";
+
+		String clob = StringUtils.repeat('1', 10000);
+		String nclob = StringUtils.repeat('あ', 10000);
+		byte[] blob = StringUtils.repeat('x', 20000).getBytes();
+		int[] arr = { 1, 2 };
+		agent.updateWith(sql).clobParam("clob", new StringReader(clob))
+				.clobParam("nclob", new StringReader(nclob))
+				.blobParam("blob", new ByteArrayInputStream(blob))
+				.param("arr", arr)
+				.count();
+
+		Optional<Map<String, Object>> optional = agent.queryWith("select * from COLUMN_TYPE_TEST2").findFirst();
+		assertThat(optional.isPresent(), is(true));
+		Map<String, Object> row = optional.get();
+
+		assertThat(row.get("COL_CLOB"), is(clob));
+		assertThat(row.get("COL_NCLOB"), is(nclob));
+		assertThat(row.get("COL_BLOB"), is(blob));
+		assertThat(row.get("COL_ARRAY"), is(arr));
+
+	}
+
+}


### PR DESCRIPTION
The target column type is as follows
java.sql.Clob -> String
java.sql.NClob -> String
java.sql.Blob -> byte[]
java.sql.Array -> Object[]

In the case of java.sql.Array, it should be a type obtained by getBaseType(), but since Java class mapped to JDBCType can not be specified, Object[] is used.