### PR TITLE
fix #114 SqlAgent#close() commit/rollback before Connection#close()

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
@@ -262,13 +262,17 @@ class LocalTransactionContext implements AutoCloseable {
 	public void close() {
 		if (connection != null) {
 			try {
+				if (!isRollbackOnly()) {
+					commit();
+				} else {
+					rollback();
+				}
 				connection.close();
 			} catch (SQLException e) {
-				//nop
+				throw new UroborosqlSQLException(e);
 			}
 			connection = null;
 		}
-		clearState();
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -339,11 +339,6 @@ public class LocalTransactionManager implements TransactionManager {
 				throw ex;
 			} finally {
 				try {
-					if (!txContext.isRollbackOnly()) {
-						txContext.commit();
-					} else {
-						txContext.rollback();
-					}
 					txContext.close();
 				} finally {
 					this.txCtxStack.pop();


### PR DESCRIPTION
In SqlAgent#close(), commit or rollback before connection.close().