### PR TITLE
EntityHandler add emptyStringEqualsNull property

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -29,7 +29,34 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 
 	private static Map<Class<?>, TableMetadata> CONTEXTS = new ConcurrentHashMap<>();
 	private final PropertyMapperManager propertyMapperManager = new PropertyMapperManager();
+	private boolean emptyStringEqualsNull = true;
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#isEmptyStringEqualsNull()
+	 */
+	@Override
+	public boolean isEmptyStringEqualsNull() {
+		return emptyStringEqualsNull;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#setEmptyStringEqualsNull(boolean)
+	 */
+	@Override
+	public EntityHandler<Object> setEmptyStringEqualsNull(final boolean emptyStringEqualsNull) {
+		this.emptyStringEqualsNull = emptyStringEqualsNull;
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#createSelectContext(jp.co.future.uroborosql.SqlAgent, jp.co.future.uroborosql.mapping.TableMetadata, java.lang.Class)
+	 */
 	@Override
 	public SqlContext createSelectContext(final SqlAgent agent, final TableMetadata metadata,
 			final Class<? extends Object> entityType) {
@@ -37,6 +64,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.getSqlIdKeyName())).setSqlId(createSqlId(metadata, entityType));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#doSelect(jp.co.future.uroborosql.SqlAgent, jp.co.future.uroborosql.context.SqlContext, java.lang.Class)
+	 */
 	@Override
 	public <E> Stream<E> doSelect(final SqlAgent agent, final SqlContext context, final Class<? extends E> entityType)
 			throws SQLException {
@@ -44,6 +76,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				propertyMapperManager)));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#createInsertContext(jp.co.future.uroborosql.SqlAgent, jp.co.future.uroborosql.mapping.TableMetadata, java.lang.Class)
+	 */
 	@Override
 	public SqlContext createInsertContext(final SqlAgent agent, final TableMetadata metadata,
 			final Class<? extends Object> entityType) {
@@ -51,6 +88,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.getSqlIdKeyName())).setSqlId(createSqlId(metadata, entityType));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#createUpdateContext(jp.co.future.uroborosql.SqlAgent, jp.co.future.uroborosql.mapping.TableMetadata, java.lang.Class)
+	 */
 	@Override
 	public SqlContext createUpdateContext(final SqlAgent agent, final TableMetadata metadata,
 			final Class<? extends Object> entityType) {
@@ -58,6 +100,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.getSqlIdKeyName())).setSqlId(createSqlId(metadata, entityType));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#createDeleteContext(jp.co.future.uroborosql.SqlAgent, jp.co.future.uroborosql.mapping.TableMetadata, java.lang.Class)
+	 */
 	@Override
 	public SqlContext createDeleteContext(final SqlAgent agent, final TableMetadata metadata,
 			final Class<? extends Object> entityType) {
@@ -65,21 +112,41 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				.getSqlIdKeyName())).setSqlId(createSqlId(metadata, entityType));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#setInsertParams(jp.co.future.uroborosql.context.SqlContext, java.lang.Object)
+	 */
 	@Override
 	public void setInsertParams(final SqlContext context, final Object entity) {
 		setFields(context, entity, SqlStatement.INSERT);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#setUpdateParams(jp.co.future.uroborosql.context.SqlContext, java.lang.Object)
+	 */
 	@Override
 	public void setUpdateParams(final SqlContext context, final Object entity) {
 		setFields(context, entity, SqlStatement.UPDATE);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#setDeleteParams(jp.co.future.uroborosql.context.SqlContext, java.lang.Object)
+	 */
 	@Override
 	public void setDeleteParams(final SqlContext context, final Object entity) {
 		setFields(context, entity, SqlStatement.DELETE);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#getEntityType()
+	 */
 	@Override
 	public Class<Object> getEntityType() {
 		return Object.class;
@@ -96,12 +163,22 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		return context;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#addPropertyMapper(jp.co.future.uroborosql.mapping.mapper.PropertyMapper)
+	 */
 	@Override
 	public EntityHandler<Object> addPropertyMapper(final PropertyMapper<?> propertyMapper) {
 		propertyMapperManager.addMapper(propertyMapper);
 		return this;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#removePropertyMapper(jp.co.future.uroborosql.mapping.mapper.PropertyMapper)
+	 */
 	@Override
 	public EntityHandler<Object> removePropertyMapper(final PropertyMapper<?> propertyMapper) {
 		propertyMapperManager.removeMapper(propertyMapper);
@@ -438,10 +515,16 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 	private StringBuilder wrapIfComment(final StringBuilder original, final StringBuilder addParts,
 			final TableMetadata.Column col) {
 		String camelColName = col.getCamelColumnName();
+		// フィールドがセットされていない場合はカラム自体を削る
 		if (isStringType(col.getDataType())) {
-			original.append("/*IF SF.isNotEmpty(").append(camelColName).append(") */").append(System.lineSeparator());// フィールドがセットされていない場合はカラム自体を削る
+			if (emptyStringEqualsNull) {
+				original.append("/*IF SF.isNotEmpty(").append(camelColName).append(") */")
+						.append(System.lineSeparator());
+			} else {
+				original.append("/*IF ").append(camelColName).append(" != null */").append(System.lineSeparator());
+			}
 		} else {
-			original.append("/*IF ").append(camelColName).append(" != null */").append(System.lineSeparator());// フィールドがセットされていない場合はカラム自体を削る
+			original.append("/*IF ").append(camelColName).append(" != null */").append(System.lineSeparator());
 		}
 		original.append(addParts);
 		original.append("/*END*/").append(System.lineSeparator());

--- a/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
@@ -164,4 +164,19 @@ public interface EntityHandler<ENTITY> {
 	 * @return EntityHandler
 	 */
 	EntityHandler<ENTITY> removePropertyMapper(PropertyMapper<?> propertyMapper);
+
+	/**
+	 * 空文字とNULLを同じに扱うかどうかを取得する
+	 *
+	 * @return 空文字とNULLを同じに扱う場合<code>true</code>
+	 */
+	boolean isEmptyStringEqualsNull();
+
+	/**
+	 * 空文字とNULLを同じに扱うかどうかを設定する
+	 *
+	 * @param emptyStringEqualsNull 空文字とNULLを同じに扱う場合に<code>true</code>を指定
+	 * @return EntityHandler
+	 */
+	EntityHandler<ENTITY> setEmptyStringEqualsNull(boolean emptyStringEqualsNull);
 }

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -464,9 +464,39 @@ public class DefaultEntityHandlerTest {
 			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
 					MappingUtils.getTable(TestEntity.class));
 			SqlContext ctx = handler.createSelectContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, containsString("SF.isNotEmpty"));
+
 			try (ResultSet rs = agent.query(ctx)) {
 				assertThat(rs.next(), is(true));
 			}
+		}
+	}
+
+	@Test
+	public void testCreateSelectContextEmptyNotEqualsNull() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+					.of("memo1"));
+			agent.insert(test);
+
+			agent.commit();
+
+			EntityHandler<?> handler = config.getEntityHandler();
+			handler.setEmptyStringEqualsNull(false);
+			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
+					MappingUtils.getTable(TestEntity.class));
+			SqlContext ctx = handler.createSelectContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, not(containsString("SF.isNotEmpty")));
+
+			try (ResultSet rs = agent.query(ctx)) {
+				assertThat(rs.next(), is(true));
+			}
+
+			handler.setEmptyStringEqualsNull(true);
 		}
 	}
 
@@ -477,9 +507,33 @@ public class DefaultEntityHandlerTest {
 			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
 					MappingUtils.getTable(TestEntity.class));
 			SqlContext ctx = handler.createInsertContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, containsString("SF.isNotEmpty"));
+
 			ctx.param("id", 1).param("name", "name1").param("age", 20)
 					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
 			assertThat(agent.update(ctx), is(1));
+		}
+	}
+
+	@Test
+	public void testCreateInsertContextEmptyNotEqualsNull() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			EntityHandler<?> handler = config.getEntityHandler();
+			handler.setEmptyStringEqualsNull(false);
+			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
+					MappingUtils.getTable(TestEntity.class));
+			SqlContext ctx = handler.createInsertContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, not(containsString("SF.isNotEmpty")));
+
+			ctx.param("id", 1).param("name", "name1").param("age", 20)
+					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
+			assertThat(agent.update(ctx), is(1));
+
+			handler.setEmptyStringEqualsNull(true);
 		}
 	}
 
@@ -496,9 +550,39 @@ public class DefaultEntityHandlerTest {
 			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
 					MappingUtils.getTable(TestEntity.class));
 			SqlContext ctx = handler.createUpdateContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, containsString("SF.isNotEmpty"));
+
 			ctx.param("id", 1).param("name", "updatename");
 			assertThat(agent.update(ctx), is(1));
 			assertThat(agent.query(TestEntity.class).param("id", 1).first().orElse(null).getName(), is("updatename"));
+		}
+	}
+
+	@Test
+	public void testCreateUpdateContextEmptyStringEqualsNull() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+					.of("memo1"));
+			agent.insert(test);
+
+			agent.commit();
+
+			EntityHandler<?> handler = config.getEntityHandler();
+			handler.setEmptyStringEqualsNull(false);
+			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent,
+					MappingUtils.getTable(TestEntity.class));
+			SqlContext ctx = handler.createUpdateContext(agent, metadata, null);
+
+			String sql = ctx.getSql();
+			assertThat(sql, not(containsString("SF.isNotEmpty")));
+
+			ctx.param("id", 1).param("name", "updatename");
+			assertThat(agent.update(ctx), is(1));
+			assertThat(agent.query(TestEntity.class).param("id", 1).first().orElse(null).getName(), is("updatename"));
+
+			handler.setEmptyStringEqualsNull(true);
 		}
 	}
 


### PR DESCRIPTION
Added property to specify EntityHandler how to handle EmptyString and Null.

- when EntityHandler#setEmptyStringEqualsNull = true
  if branch in generated sql is /*IF SF.isNotEmpty(...) */
- when EntityHandler#setEmptyStringEqualsNull = false
  if branch in generated sql is /*IF ... != null */
