### PR TITLE
fix #118 to SecretColumnSqlFilter support URL

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilter.java
+++ b/src/main/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilter.java
@@ -2,7 +2,6 @@ package jp.co.future.uroborosql.filter;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
@@ -17,7 +16,6 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Objects;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -49,9 +47,6 @@ public class SecretColumnSqlFilter extends AbstractSqlFilter {
 
 	/** 秘密鍵を格納したKeyStoreファイルのパス. KeyStoreはJCEKSタイプであること。 */
 	private String keyStoreFilePath = null;
-
-	/** 秘密鍵を格納したKeyStoreファイルのURI. KeyStoreはJCEKSタイプであること。 */
-	private URI keyStoreFileURI = null;
 
 	/** KeyStoreにアクセスするためのストアパスワード. Base64エンコードした値を指定する */
 	private String storePassword = null;
@@ -99,30 +94,19 @@ public class SecretColumnSqlFilter extends AbstractSqlFilter {
 
 		KeyStore store;
 		try {
-			if (StringUtils.isBlank(getKeyStoreFilePath()) && Objects.isNull(getKeyStoreFileURI())) {
+			if (StringUtils.isBlank(getKeyStoreFilePath())) {
 				LOG.error("Invalid KeyStore file path. Path:{}", getKeyStoreFilePath());
 				setSkipFilter(true);
 				return;
 			}
-
-			Path storeFile = null;
-			String storeFilePath = null;
-			if(getKeyStoreFilePath() != null) {
-				storeFilePath = getKeyStoreFilePath();
-				storeFile = Paths.get(getKeyStoreFilePath());
-			}
-			if(getKeyStoreFileURI() != null) {
-				storeFilePath = getKeyStoreFileURI().toString();
-				storeFile = toPath(getKeyStoreFileURI());
-			}
-
+			Path storeFile = toPath(getKeyStoreFilePath());
 			if (!Files.exists(storeFile)) {
-				LOG.error("Not found KeyStore file path. Path:{}", storeFilePath);
+				LOG.error("Not found KeyStore file path. Path:{}", getKeyStoreFilePath());
 				setSkipFilter(true);
 				return;
 			}
 			if (Files.isDirectory(storeFile)) {
-				LOG.error("Invalid KeyStore file path. Path:{}", storeFilePath);
+				LOG.error("Invalid KeyStore file path. Path:{}", getKeyStoreFilePath());
 				setSkipFilter(true);
 				return;
 			}
@@ -240,27 +224,6 @@ public class SecretColumnSqlFilter extends AbstractSqlFilter {
 	 */
 	public void setKeyStoreFilePath(final String keyStoreFilePath) {
 		this.keyStoreFilePath = keyStoreFilePath;
-		this.keyStoreFileURI = null;
-	}
-
-	/**
-	 * 秘密鍵を格納したKeyStoreファイルのURI. KeyStoreはJCEKSタイプであること。を取得します。
-	 *
-	 * @return 秘密鍵を格納したKeyStoreファイルのパス. KeyStoreはJCEKSタイプであること。
-	 */
-	public URI getKeyStoreFileURI() {
-		return keyStoreFileURI;
-	}
-
-	/**
-	 * 秘密鍵を格納したKeyStoreファイルのパス. KeyStoreはJCEKSタイプであること。を設定します。
-	 *
-	 * @param keyStoreFilePath
-	 *            秘密鍵を格納したKeyStoreファイルのパス. KeyStoreはJCEKSタイプであること。
-	 */
-	public void setKeyStoreFileURI(final URI keyStoreFileURI) {
-		this.keyStoreFilePath = null;
-		this.keyStoreFileURI = keyStoreFileURI;
 	}
 
 	/**
@@ -405,12 +368,12 @@ public class SecretColumnSqlFilter extends AbstractSqlFilter {
 	}
 
 	/**
-	 * URI から Path オブジェクトに変換します。 {@link FileSystemProvider} の走査方法をカスタマイズしたい場合等にオーバーライドします。
+	 * 文字列から Path オブジェクトに変換します。 {@link FileSystemProvider} の走査方法をカスタマイズしたい場合等にオーバーライドします。
 	 *
-	 * @param uri 変換元URI
+	 * @param path 変換元文字列
 	 * @return Path オブジェクト
 	 */
-	protected Path toPath(URI uri) {
-		return Paths.get(uri);
+	protected Path toPath(String path) {
+		return Paths.get(path);
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
@@ -3,18 +3,16 @@ package jp.co.future.uroborosql.filter;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.net.URI;
 import java.sql.DriverManager;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.testlog.TestAppender;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class SecretColumnSqlFilterInitializeTest {
 	private SqlConfig config;
@@ -117,43 +115,6 @@ public class SecretColumnSqlFilterInitializeTest {
 		assertThat(log, is(Arrays.asList(
 				"KeyStoreにアクセスするためのエイリアスが指定されていません。",
 				"No alias for access KeyStore.")));
-		assertThat(filter.isSkipFilter(), is(true));
-	}
-
-	@Test
-	public void testInitialize07() throws Exception {
-		filter.setCryptColumnNames(Arrays.asList("product_id", "product_name"));
-		List<String> log = TestAppender.getLogbackLogs(() -> {
-			// 下記コマンドでkeystoreファイル生成
-			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
-			// -storepass password -keypass password -keyalg AES -keysize 128
-				filter.setKeyStoreFileURI(new File("./src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks").getAbsoluteFile().toURI());
-				//filter.setKeyStoreFilePath("src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
-				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
-				filter.setAlias("testexample");
-				filter.setCharset("UTF-8");
-				filter.setTransformationType("AES/ECB/PKCS5Padding");
-				sqlFilterManager.initialize();
-			});
-		assertThat(log, is(Arrays.asList()));
-		assertThat(filter.isSkipFilter(), is(false));
-	}
-
-	@Test
-	public void testInitialize08() throws Exception {
-		filter.setCryptColumnNames(Arrays.asList("product_id", "product_name"));
-		List<String> log = TestAppender.getLogbackLogs(() -> {
-			// 下記コマンドでkeystoreファイル生成
-			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
-			// -storepass password -keypass password -keyalg AES -keysize 128
-				filter.setKeyStoreFileURI(new URI("invalidscheme://xxxxxxxxxxx"));
-				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
-				filter.setAlias("testexample");
-				filter.setCharset("UTF-8");
-				filter.setTransformationType("AES/ECB/PKCS5Padding");
-				sqlFilterManager.initialize();
-			});
-		assertThat(log, is(Arrays.asList("Failed to acquire secret key. Cause：Provider \"invalidscheme\" not installed")));
 		assertThat(filter.isSkipFilter(), is(true));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
@@ -3,6 +3,7 @@ package jp.co.future.uroborosql.filter;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.sql.DriverManager;
 import java.util.Arrays;
 import java.util.List;
@@ -116,5 +117,24 @@ public class SecretColumnSqlFilterInitializeTest {
 				"KeyStoreにアクセスするためのエイリアスが指定されていません。",
 				"No alias for access KeyStore.")));
 		assertThat(filter.isSkipFilter(), is(true));
+	}
+
+	@Test
+	public void testInitialize07() throws Exception {
+		filter.setCryptColumnNames(Arrays.asList("product_id", "product_name"));
+		List<String> log = TestAppender.getLogbackLogs(() -> {
+			// 下記コマンドでkeystoreファイル生成
+			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
+			// -storepass password -keypass password -keyalg AES -keysize 128
+				filter.setKeyStoreFilePath("file:///" + (new File(".").getAbsoluteFile().getParent()).replace(File.separator, "/") + "/src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
+				//filter.setKeyStoreFilePath("src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
+				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
+				filter.setAlias("testexample");
+				filter.setCharset("UTF-8");
+				filter.setTransformationType("AES/ECB/PKCS5Padding");
+				sqlFilterManager.initialize();
+			});
+		assertThat(log, is(Arrays.asList()));
+		assertThat(filter.isSkipFilter(), is(false));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
@@ -126,7 +126,7 @@ public class SecretColumnSqlFilterInitializeTest {
 			// 下記コマンドでkeystoreファイル生成
 			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
 			// -storepass password -keypass password -keyalg AES -keysize 128
-				filter.setKeyStoreFilePath("file:///" + (new File(".").getAbsoluteFile().getParent()).replace(File.separator, "/") + "/src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
+				filter.setKeyStoreFilePath(new File("./src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks").toURI().toString());
 				//filter.setKeyStoreFilePath("src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
 				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
 				filter.setAlias("testexample");
@@ -136,5 +136,23 @@ public class SecretColumnSqlFilterInitializeTest {
 			});
 		assertThat(log, is(Arrays.asList()));
 		assertThat(filter.isSkipFilter(), is(false));
+	}
+
+	@Test
+	public void testInitialize08() throws Exception {
+		filter.setCryptColumnNames(Arrays.asList("product_id", "product_name"));
+		List<String> log = TestAppender.getLogbackLogs(() -> {
+			// 下記コマンドでkeystoreファイル生成
+			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
+			// -storepass password -keypass password -keyalg AES -keysize 128
+				filter.setKeyStoreFilePath("invalidscheme://xxxxxxxxxxx");
+				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
+				filter.setAlias("testexample");
+				filter.setCharset("UTF-8");
+				filter.setTransformationType("AES/ECB/PKCS5Padding");
+				sqlFilterManager.initialize();
+			});
+		assertThat(log, is(Arrays.asList("Failed to acquire secret key. Cause：Provider \"invalidscheme\" not found")));
+		assertThat(filter.isSkipFilter(), is(true));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/SecretColumnSqlFilterInitializeTest.java
@@ -4,16 +4,17 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.net.URI;
 import java.sql.DriverManager;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.testlog.TestAppender;
-
-import org.junit.Before;
-import org.junit.Test;
 
 public class SecretColumnSqlFilterInitializeTest {
 	private SqlConfig config;
@@ -126,7 +127,7 @@ public class SecretColumnSqlFilterInitializeTest {
 			// 下記コマンドでkeystoreファイル生成
 			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
 			// -storepass password -keypass password -keyalg AES -keysize 128
-				filter.setKeyStoreFilePath(new File("./src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks").toURI().toString());
+				filter.setKeyStoreFileURI(new File("./src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks").getAbsoluteFile().toURI());
 				//filter.setKeyStoreFilePath("src/test/resources/data/expected/SecretColumnSqlFilter/keystore.jceks");
 				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
 				filter.setAlias("testexample");
@@ -145,14 +146,14 @@ public class SecretColumnSqlFilterInitializeTest {
 			// 下記コマンドでkeystoreファイル生成
 			// keytool -genseckey -keystore C:\keystore.jceks -storetype JCEKS -alias testexample
 			// -storepass password -keypass password -keyalg AES -keysize 128
-				filter.setKeyStoreFilePath("invalidscheme://xxxxxxxxxxx");
+				filter.setKeyStoreFileURI(new URI("invalidscheme://xxxxxxxxxxx"));
 				filter.setStorePassword("cGFzc3dvcmQ="); // 文字列「password」をBase64で暗号化
 				filter.setAlias("testexample");
 				filter.setCharset("UTF-8");
 				filter.setTransformationType("AES/ECB/PKCS5Padding");
 				sqlFilterManager.initialize();
 			});
-		assertThat(log, is(Arrays.asList("Failed to acquire secret key. Cause：Provider \"invalidscheme\" not found")));
+		assertThat(log, is(Arrays.asList("Failed to acquire secret key. Cause：Provider \"invalidscheme\" not installed")));
 		assertThat(filter.isSkipFilter(), is(true));
 	}
 }


### PR DESCRIPTION
Fixed `SecretColumnSqlFilter` to make using `java.net.URL` and  `java.nio.Paths`.