### PR TITLE
If SQL string is specified in SqlContext, SqlFilter#doTransformSql will not be called

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -225,9 +225,9 @@ public abstract class AbstractAgent implements SqlAgent {
 			if (StringUtils.isEmpty(originalSql)) {
 				throw new UroborosqlRuntimeException("sql file:[" + sqlContext.getSqlName() + "] is not found.");
 			}
-			originalSql = getSqlFilterManager().doTransformSql(sqlContext, originalSql);
-			sqlContext.setSql(originalSql);
 		}
+		originalSql = getSqlFilterManager().doTransformSql(sqlContext, originalSql);
+		sqlContext.setSql(originalSql);
 
 		// SQL-IDの付与
 		if (originalSql.contains(keySqlId)) {


### PR DESCRIPTION
SqlFilter#doTransformSql will not be called if SQL string was specified in SqlContext.  
This behavior does not match the behavior when specifying the SQL file.