### PR TITLE
In NioSqlManager, Add the presence or absence of the specified file monitoring

### DIFF
--- a/REPL/repl.properties
+++ b/REPL/repl.properties
@@ -4,6 +4,9 @@ db.password=
 
 sql.additionalClassPath=src/test/resources;target/test-classes;${user.home}/.m2/repository/com/h2database/h2/1.4.195/h2-1.4.195.jar
 sql.encoding=UTF-8
+#sql.loadPath=sql
+#sql.fileExtension=.sql
+#sql.detectChanges=true
 
 sqlContextFactory.constantClassNames=jp.co.future.uroborosql.context.test.TestConsts
 sqlContextFactory.enumConstantPackageNames=jp.co.future.uroborosql.context.test

--- a/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
@@ -14,6 +14,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -72,6 +73,7 @@ import ognl.ASTProperty;
 import ognl.Ognl;
 import ognl.OgnlException;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.time.DateUtils;
@@ -338,14 +340,18 @@ public class SqlREPL {
 			}
 		});
 
-		String sqlEncoding = p("sql.encoding", "");
-		if (StringUtils.isNotEmpty(sqlEncoding)) {
-			System.setProperty("file.encoding", sqlEncoding);
-		}
+		String url = p("db.url", "");
+		String user = p("db.user", "");
+		String password = p("db.password", "");
+		String schema = p("db.schema", null);
+		String loadPath = p("sql.loadPath", "sql");
+		String fileExtension = p("sql.fileExtension", ".sql");
+		Charset charset = Charset.forName(p("sql.encoding", "UTF-8"));
+		boolean detectChanges = BooleanUtils.toBoolean(p("sql.detectChanges", "true"));
 
 		// config
-		config = UroboroSQL.builder(p("db.url", ""), p("db.user", ""), p("db.password", ""), p("db.schema", null))
-				.setSqlManager(new NioSqlManagerImpl(p("sql.loadPath", "sql")))
+		config = UroboroSQL.builder(url, user, password, schema)
+				.setSqlManager(new NioSqlManagerImpl(loadPath, fileExtension, charset, detectChanges))
 				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new DumpResultSqlFilter())).build();
 
 		// sqlContextFactory

--- a/src/test/java/jp/co/future/uroborosql/store/NioSqlManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/store/NioSqlManagerTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.store;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -23,7 +24,7 @@ public class NioSqlManagerTest {
 	private static final String TARGET_TEST_CLASSES_SQL = "target/test-classes/sql/";
 
 	@Test
-	public void testConstractor() throws Exception {
+	public void testConstructor() throws Exception {
 		NioSqlManagerImpl manager = new NioSqlManagerImpl("sql", ".sql", Charset.defaultCharset());
 		assertThat(manager.getCharset(), is(Charset.defaultCharset()));
 
@@ -37,6 +38,8 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testGetSqlPathList() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		NioSqlManagerImpl manager = new NioSqlManagerImpl();
 		manager.setDialect(new H2Dialect());
 		manager.initialize();
@@ -94,6 +97,8 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testGetSqlH2() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		NioSqlManagerImpl manager = new NioSqlManagerImpl();
 		manager.setDialect(new H2Dialect());
 		manager.initialize();
@@ -118,6 +123,8 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testGetSqlPostgresql() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		NioSqlManagerImpl manager = new NioSqlManagerImpl();
 		manager.setDialect(new PostgresqlDialect());
 		manager.initialize();
@@ -142,12 +149,13 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testGetSqlWithWatcher() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
 
 		String sqlName = "test/ADD_WATCH";
 		Path newFilePath = Paths.get(TARGET_TEST_CLASSES_SQL, sqlName + ".sql");
 		Files.deleteIfExists(newFilePath);
 
-		NioSqlManagerImpl manager = new NioSqlManagerImpl();
+		NioSqlManagerImpl manager = new NioSqlManagerImpl(true);
 		manager.setDialect(new OracleDialect());
 		manager.initialize();
 
@@ -176,14 +184,46 @@ public class NioSqlManagerTest {
 	}
 
 	@Test
+	public void testGetSqlWithNoWatcher() throws Exception {
+
+		String sqlName = "test/ADD_WATCH";
+		Path newFilePath = Paths.get(TARGET_TEST_CLASSES_SQL, sqlName + ".sql");
+		Files.deleteIfExists(newFilePath);
+
+		NioSqlManagerImpl manager = new NioSqlManagerImpl();
+		manager.setDialect(new OracleDialect());
+		manager.initialize();
+
+		try {
+			assertThat(manager.existSql(sqlName), is(false));
+
+			Thread.sleep(WAIT_TIME);
+
+			Files.write(newFilePath, Arrays.asList("select * from ADD_WATCH"));
+
+			Thread.sleep(WAIT_TIME);
+
+			assertThat(manager.existSql(sqlName), is(false));
+
+			Thread.sleep(WAIT_TIME);
+
+			assertThat(manager.existSql("example/select_test"), is(true));
+		} finally {
+			manager.shutdown();
+		}
+	}
+
+	@Test
 	public void testAddDialectSqlFolder() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		String sqlName = "example/select_test";
 		Path dir = Paths.get(TARGET_TEST_CLASSES_SQL, "oracle", "example");
 		Path newFilePath = dir.resolve("select_test.sql");
 		Files.deleteIfExists(newFilePath);
 		Files.deleteIfExists(dir);
 
-		NioSqlManagerImpl manager = new NioSqlManagerImpl();
+		NioSqlManagerImpl manager = new NioSqlManagerImpl(true);
 		manager.setDialect(new OracleDialect());
 		manager.initialize();
 
@@ -223,6 +263,8 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testAddDefaultFolderAndDialectFolder() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		String sqlName = "unit_test/select_test";
 		Path defaultDir = Paths.get(TARGET_TEST_CLASSES_SQL, "unit_test");
 		Path dialectDir = Paths.get(TARGET_TEST_CLASSES_SQL, "oracle", "unit_test");
@@ -233,7 +275,7 @@ public class NioSqlManagerTest {
 		Files.deleteIfExists(dialectFilePath);
 		Files.deleteIfExists(dialectDir);
 
-		NioSqlManagerImpl manager = new NioSqlManagerImpl();
+		NioSqlManagerImpl manager = new NioSqlManagerImpl(true);
 		manager.setDialect(new OracleDialect());
 		manager.initialize();
 
@@ -291,6 +333,8 @@ public class NioSqlManagerTest {
 
 	@Test
 	public void testAddDialectFolderAndDefaultFolder() throws Exception {
+		assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("mac"));
+
 		String sqlName = "unit_test/select_test";
 		Path defaultDir = Paths.get(TARGET_TEST_CLASSES_SQL, "unit_test");
 		Path dialectDir = Paths.get(TARGET_TEST_CLASSES_SQL, "oracle", "unit_test");
@@ -301,7 +345,7 @@ public class NioSqlManagerTest {
 		Files.deleteIfExists(dialectFilePath);
 		Files.deleteIfExists(dialectDir);
 
-		NioSqlManagerImpl manager = new NioSqlManagerImpl();
+		NioSqlManagerImpl manager = new NioSqlManagerImpl(true);
 		manager.setDialect(new OracleDialect());
 		manager.initialize();
 


### PR DESCRIPTION
@shout-star @ota-meshi 
Since WatchService does not operate properly in mac
An exception occurred in NioSqlManager's file monitoring.

In order to avoid this, NioSqlManager can specify whether or not to monitor files, and file monitoring is not done when there is no designation.
We are adding a detectChanges argument to the constructor in order to perform the specified file monitoring.