### PR TITLE
Changed to `SqlBatch#paramStream` to accept beans stream

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlBatch.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlBatch.java
@@ -28,10 +28,10 @@ public interface SqlBatch extends SqlFluent<SqlBatch> {
 	/**
 	 * 一括更新用のパラメータをStream形式で設定する
 	 *
-	 * @param stream パラメータを格納したMapのStream
+	 * @param stream パラメータを格納したMapまたはBeanのStream
 	 * @return SqlBatch
 	 */
-	SqlBatch paramStream(Stream<Map<String, Object>> stream);
+	SqlBatch paramStream(Stream<?> stream);
 
 	/**
 	 * 一括更新用のバッチフレームの判定条件を設定する

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -924,6 +924,37 @@ public class SqlAgentTest {
 	}
 
 	/**
+	 * バッチ処理のテストケース(Bean Stream)。
+	 */
+	@Test
+	public void testExecuteBatchBeanStream() {
+		// 事前条件
+		truncateTable("PRODUCT");
+
+		// Entity生成のために一旦登録してSelect
+		List<Map<String, Object>> data = getDataFromFile(Paths.get("src/test/resources/data/expected/SqlAgent",
+				"testExecuteBatchStream.ltsv"));
+		agent.batch("example/insert_product").paramStream(data.stream()).count();
+		// 取得
+		List<Product> input = agent.query(Product.class).collect();
+		// 再度削除
+		truncateTable("PRODUCT");
+
+		// 処理実行
+		int count = agent.batch("example/insert_product_for_bean").paramStream(input.stream()).count();
+
+		assertEquals("データの登録件数が不正です。", 100, count);
+
+		// 検証処理
+		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
+				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchStream.ltsv"));
+		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
+				.stream(new MapResultSetConverter(CaseFormat.LOWER_SNAKE_CASE)).collect(Collectors.toList());
+
+		assertEquals(expectedDataList.toString(), actualDataList.toString());
+	}
+
+	/**
 	 * バッチ処理のテストケース(Stream)。
 	 */
 	@Test

--- a/src/test/resources/sql/example/insert_product_for_bean.sql
+++ b/src/test/resources/sql/example/insert_product_for_bean.sql
@@ -1,0 +1,22 @@
+INSERT
+INTO
+	PRODUCT
+(
+	PRODUCT_ID
+,	PRODUCT_NAME
+,	PRODUCT_KANA_NAME
+,	JAN_CODE
+,	PRODUCT_DESCRIPTION
+,	INS_DATETIME
+,	UPD_DATETIME
+,	VERSION_NO
+) VALUES (
+	/*productId*/
+,	/*productName*/
+,	/*productKanaName*/
+,	/*janCode*/
+,	/*productDescription*/
+,	/*insDatetime*/
+,	/*updDatetime*/
+,	/*versionNo*/
+)


### PR DESCRIPTION
This PR is changed that the following batch execution is possible.

```java
List<Product> input = list;
agent.batch("insert_product")
    .paramStream(input.stream()) // <- 
    .count();
```