### PR TITLE
Add `inserts(entities)` to SqlAgent

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgent.java
@@ -11,12 +11,14 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.coverage.CoverageHandler;
+import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.fluent.Procedure;
 import jp.co.future.uroborosql.fluent.SqlBatch;
 import jp.co.future.uroborosql.fluent.SqlEntityQuery;
@@ -37,7 +39,7 @@ public interface SqlAgent extends AutoCloseable, TransactionManager {
 	 * 文字列として{@link CoverageHandler}インタフェースの実装クラスが設定された場合はそのクラスを<br>
 	 * 利用してカバレッジの収集を行う。
 	 */
-	final String KEY_SQL_COVERAGE = "uroborosql.sql.coverage";
+	String KEY_SQL_COVERAGE = "uroborosql.sql.coverage";
 
 	/**
 	 * クエリ実行処理。
@@ -311,4 +313,87 @@ public interface SqlAgent extends AutoCloseable, TransactionManager {
 	 * @return SQL実行結果
 	 */
 	int delete(Object entity);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entityType エンティティの型
+	 * @param entities エンティティ
+	 * @param condition 一括更新用のフレームの判定条件
+	 * @param insertsType INSERT処理方法
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Class<E> entityType, Stream<E> entities, BiPredicate<Integer, ? super E> condition,
+			InsertsType insertsType);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entityType エンティティの型
+	 * @param entities エンティティ
+	 * @param condition 一括更新用のフレームの判定条件
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Class<E> entityType, Stream<E> entities, BiPredicate<Integer, ? super E> condition);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entityType エンティティの型
+	 * @param entities エンティティ
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Class<E> entityType, Stream<E> entities);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entityType エンティティの型
+	 * @param entities エンティティ
+	 * @param insertsType INSERT処理方法
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Class<E> entityType, Stream<E> entities, InsertsType insertsType);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entities エンティティ
+	 * @param condition 一括更新用のフレームの判定条件
+	 * @param insertsType INSERT処理方法
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Stream<E> entities, BiPredicate<Integer, ? super E> condition, InsertsType insertsType);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param <E> エンティティの型
+	 * @param entities エンティティ
+	 * @param condition 一括更新用のフレームの判定条件
+	 * @return SQL実行結果
+	 */
+	<E> int inserts(Stream<E> entities, BiPredicate<Integer, ? super E> condition);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param entities エンティティ
+	 * @return SQL実行結果
+	 */
+	int inserts(Stream<?> entities);
+
+	/**
+	 * 複数エンティティのINSERTを実行
+	 *
+	 * @param entities エンティティ
+	 * @param insertsType INSERT処理方法
+	 * @return SQL実行結果
+	 */
+	int inserts(Stream<?> entities, InsertsType insertsType);
 }

--- a/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
+++ b/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
@@ -22,6 +22,7 @@ import jp.co.future.uroborosql.context.SqlContextFactory;
 import jp.co.future.uroborosql.context.SqlContextFactoryImpl;
 import jp.co.future.uroborosql.dialect.DefaultDialect;
 import jp.co.future.uroborosql.dialect.Dialect;
+import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
 import jp.co.future.uroborosql.mapping.DefaultEntityHandler;
@@ -102,6 +103,7 @@ public final class UroboroSQL {
 		private SqlAgentFactory sqlAgentFactory;
 		private EntityHandler<?> entityHandler;
 		private Dialect dialect;
+		private InsertsType defaultInsertsType;
 
 		UroboroSQLBuilder() {
 			this.connectionSupplier = null;
@@ -190,6 +192,18 @@ public final class UroboroSQL {
 			return this;
 		}
 
+
+		/**
+		 * デフォルトの{@link InsertsType}の設定
+		 *
+		 * @param defaultInsertsType InsertsType
+		 * @return UroboroSQLBuilder
+		 */
+		public UroboroSQLBuilder setDefaultInsertsType(final InsertsType defaultInsertsType) {
+			this.defaultInsertsType = defaultInsertsType;
+			return this;
+		}
+
 		/**
 		 * Builderに設定された内容を元にSqlConfigを構築する
 		 *
@@ -202,7 +216,8 @@ public final class UroboroSQL {
 			}
 
 			return new InternalConfig(this.connectionSupplier, this.sqlManager, this.sqlContextFactory,
-					this.sqlAgentFactory, this.sqlFilterManager, this.entityHandler, this.dialect);
+					this.sqlAgentFactory, this.sqlFilterManager, this.entityHandler, this.dialect,
+					this.defaultInsertsType);
 		}
 
 	}
@@ -243,10 +258,15 @@ public final class UroboroSQL {
 		 */
 		private final Dialect dialect;
 
+		/**
+		 * デフォルトの{@link InsertsType}
+		 */
+		private final InsertsType defaultInsertsType;
+
 		InternalConfig(final ConnectionSupplier connectionSupplier, final SqlManager sqlManager,
 				final SqlContextFactory sqlContextFactory, final SqlAgentFactory sqlAgentFactory,
 				final SqlFilterManager sqlFilterManager,
-				final EntityHandler<?> entityHandler, final Dialect dialect) {
+				final EntityHandler<?> entityHandler, final Dialect dialect, final InsertsType defaultInsertsType) {
 			this.connectionSupplier = connectionSupplier;
 			this.sqlManager = sqlManager;
 			this.sqlContextFactory = sqlContextFactory;
@@ -260,6 +280,7 @@ public final class UroboroSQL {
 			} else {
 				this.dialect = dialect;
 			}
+			this.defaultInsertsType = defaultInsertsType != null ? defaultInsertsType : InsertsType.BULK;
 
 			this.sqlManager.setDialect(this.dialect);
 			this.sqlManager.initialize();
@@ -401,6 +422,15 @@ public final class UroboroSQL {
 			throw new UnsupportedOperationException();
 		}
 
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.config.SqlConfig#getDefaultInsertsType()
+		 */
+		@Override
+		public InsertsType getDefaultInsertsType() {
+			return defaultInsertsType;
+		}
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
+++ b/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
@@ -15,6 +15,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.context.SqlContextFactory;
 import jp.co.future.uroborosql.dialect.Dialect;
+import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.mapping.EntityHandler;
 import jp.co.future.uroborosql.store.SqlManager;
@@ -123,4 +124,14 @@ public interface SqlConfig {
 	 */
 	@Deprecated
 	void setEntityHandler(EntityHandler<?> entityHandler);
+
+	/**
+	 * デフォルトの{@link InsertsType}を取得します
+	 *
+	 * @return insertsType
+	 * @see jp.co.future.uroborosql.enums.InsertsType
+	 */
+	default InsertsType getDefaultInsertsType() {
+		return InsertsType.BULK;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -42,6 +42,14 @@ public interface Dialect {
 	default boolean isRollbackToSavepointBeforeRetry() { return false; }
 
 	/**
+	 * BULK INSERTをサポートするかどうか
+	 * @return BULK INSERTをサポートする場合<code>true</code>
+	 */
+	default boolean supportsBulkInsert() {
+		return false;
+	}
+
+	/**
 	 * Dialect名を取得する
 	 *
 	 * @return Dialect名

--- a/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
@@ -24,4 +24,9 @@ public class H2Dialect extends AbstractDialect {
 	public String getDatabaseName() {
 		return "H2";
 	}
+
+	@Override
+	public boolean supportsBulkInsert() {
+		return true;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
@@ -24,4 +24,8 @@ public class MySqlDialect extends AbstractDialect {
 		return "MySQL";
 	}
 
+	@Override
+	public boolean supportsBulkInsert() {
+		return true;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
@@ -29,4 +29,8 @@ public class PostgresqlDialect extends AbstractDialect {
 		return "PostgreSQL";
 	}
 
+	@Override
+	public boolean supportsBulkInsert() {
+		return true;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/enums/InsertsType.java
+++ b/src/main/java/jp/co/future/uroborosql/enums/InsertsType.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.enums;
+
+/**
+ * 複数件のINSERTの処理方法
+ */
+public enum InsertsType {
+	/**
+	 * BULK INSERT<br>
+	 * e.g. {@code INSERT INTO ... VALUES ( ... ), ( ... )}<br>
+	 * この形式をサポートしていないDatabase方言の場合自動的に{@link #BATCH}の処理に切り替えられます。
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsBulkInsert()
+	 */
+	BULK,
+	/**
+	 * BATCH INSERT<br>
+	 * {@link java.sql.PreparedStatement#executeBatch()}で処理します。
+	 */
+	BATCH
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
@@ -7,6 +7,7 @@
 package jp.co.future.uroborosql.mapping;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.SqlAgent;
@@ -152,6 +153,63 @@ public interface EntityHandler<ENTITY> {
 	 * @throws SQLException SQL例外
 	 */
 	default int doDelete(final SqlAgent agent, final SqlContext context, final ENTITY entity) throws SQLException {
+		return agent.update(context);
+	}
+
+	/**
+	 * エンティティタイプからバッチ用INSERT SQLコンテキストを生成します。
+	 *
+	 * @param agent SqlAgent
+	 * @param metadata エンティティメタ情報
+	 * @param entityType エンティティタイプ
+	 * @return INSERT SQLコンテキスト
+	 */
+	SqlContext createBatchInsertContext(SqlAgent agent, TableMetadata metadata, Class<? extends ENTITY> entityType);
+
+	/**
+	 * BATCH INSERTを実行します。
+	 *
+	 * @param agent SqlAgent
+	 * @param context SQLコンテキスト
+	 * @return SQL実行結果
+	 * @throws SQLException SQL例外
+	 */
+	default int[] doBatchInsert(final SqlAgent agent, final SqlContext context) throws SQLException {
+		return agent.batch(context);
+	}
+
+	/**
+	 * エンティティタイプからBULK INSERT SQLコンテキストを生成します。
+	 *
+	 * @param agent SqlAgent
+	 * @param metadata エンティティメタ情報
+	 * @param entityType エンティティタイプ
+	 * @param numberOfRecords レコード行数
+	 * @return INSERT SQLコンテキスト
+	 */
+	SqlContext createBulkInsertContext(SqlAgent agent, TableMetadata metadata, Class<? extends ENTITY> entityType,
+			int numberOfRecords);
+
+	/**
+	 * SqlContextのパラメーターににエンティティの値をセットします。
+	 *
+	 * @param context SQLコンテキスト
+	 * @param entity エンティティ
+	 * @param entityIndex エンティティのインデックス
+	 */
+	void setBulkInsertParams(final SqlContext context, final ENTITY entity, int entityIndex);
+
+	/**
+	 * DELETEを実行します。
+	 *
+	 * @param agent SqlAgent
+	 * @param context SQLコンテキスト
+	 * @param entities エンティティ
+	 * @return SQL実行結果
+	 * @throws SQLException SQL例外
+	 */
+	default int doBulkInsert(final SqlAgent agent, final SqlContext context, final List<ENTITY> entities)
+			throws SQLException {
 		return agent.update(context);
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -13,11 +13,13 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.exception.OptimisticLockException;
 import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
 import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
@@ -408,6 +410,241 @@ public class DefaultEntityHandlerTest {
 
 				data = agent.find(TestEntityLockVersion.class).orElse(null);
 				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsert() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsert2() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(TestEntityForInserts.class, Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsert3() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), (c, r) -> c > 0,
+						InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertEmpty() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				int count = agent.inserts(Stream.empty(), InsertsType.BATCH);
+				assertThat(count, is(0));
+
+				assertThat(agent.query(TestEntityForInserts.class).collect().size(), is(0));
+			});
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBatchInsertTypeError1() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts();
+
+				agent.inserts((Class) TestEntity.class, Stream.of(test1), InsertsType.BATCH);
+
+			});
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBatchInsertTypeError2() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts();
+
+				agent.inserts((Class) int.class, Stream.of(test1), InsertsType.BATCH);
+
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsert() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3));
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsert2() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(TestEntityForInserts.class, Stream.of(test1, test2, test3));
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsert3() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+						"memo1");
+				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						null);
+				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+						"memo3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), (c, r) -> c > 0);
+				assertThat(count, is(3));
+
+				TestEntityForInserts data = agent.find(TestEntityForInserts.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityForInserts.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityForInserts.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsertEmpty() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				int count = agent.inserts(Stream.empty());
+				assertThat(count, is(0));
+
+				assertThat(agent.query(TestEntityForInserts.class).collect().size(), is(0));
+			});
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBulkInsertTypeError1() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts();
+
+				agent.inserts((Class) TestEntity.class, Stream.of(test1));
+
+			});
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBulkInsertTypeError2() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityForInserts test1 = new TestEntityForInserts();
+
+				agent.inserts((Class) int.class, Stream.of(test1));
+
 			});
 		}
 	}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityForInserts.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityForInserts.java
@@ -1,0 +1,85 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.time.LocalDate;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+
+@Table(name = "TEST")
+public class TestEntityForInserts {
+	private long id;
+	private String name;
+	private int age;
+	private LocalDate birthday;
+	private String memo;
+
+	public TestEntityForInserts() {
+	}
+
+	public TestEntityForInserts(final long id, final String name, final int age, final LocalDate birthday,
+			final String memo) {
+		this.id = id;
+		this.name = name;
+		this.age = age;
+		this.birthday = birthday;
+		this.memo = memo;
+	}
+
+	public long getId() {
+		return this.id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public int getAge() {
+		return this.age;
+	}
+
+	public LocalDate getBirthday() {
+		return this.birthday;
+	}
+
+	public String getMemo() {
+		return this.memo;
+	}
+
+	public void setId(final long id) {
+		this.id = id;
+	}
+
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public void setAge(final int age) {
+		this.age = age;
+	}
+
+	public void setBirthday(final LocalDate birthday) {
+		this.birthday = birthday;
+	}
+
+	public void setMemo(final String memo) {
+		this.memo = memo;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this, true);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj, true);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+}


### PR DESCRIPTION
This PR adds insertion methods for multiple entities.

- `SqlAgent#inserts(entities)` ... Insert multiple entities.
- `SqlAgent#inserts(entities, condition)` ... The `condition` limits the number of records for each execution.

The method of insert is switched by `jp.co.future.uroborosql.enums.InsertsType` selection.

- `BULK` ... BULK INSERT. e.g. `INSERT INTO ... VALUES ( ... ), ( ... )`
- `BATCH` ... BATCH INSERT

By setting the default value of `jp.co.future.uroborosql.enums.InsertsType`, users can use it without being conscious. (default `BULK `)
The default value can be set with `UroboroSQLBuilder#setDefaultInsertsType`.

You can also select by calling method. `SqlAgent#inserts(entities, insertsType)`

---

This API solves one of issue #102 .