### PR TITLE
Support of Oracle 'OFFSET n ROWS' and 'FETCH FIRST n ROWS ONLY'

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/dialect/Oracle12Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Oracle12Dialect.java
@@ -44,6 +44,39 @@ public class Oracle12Dialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsLimitClause()
+	 */
+	@Override
+	public boolean supportsLimitClause() {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#getLimitClause(long, long)
+	 */
+	@Override
+	public String getLimitClause(final long limit, final long offset) {
+		StringBuilder builder = new StringBuilder();
+		if (offset > 0) {
+			builder.append("OFFSET ").append(offset).append(" ROWS");
+			if (limit > 0) {
+				builder.append(" ");
+			}
+		}
+		if (limit > 0) {
+			builder.append("FETCH FIRST ").append(limit).append(" ROWS ONLY");
+		}
+		if (builder.length() > 0) {
+			builder.append(System.lineSeparator());
+		}
+		return builder.toString();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#accept(jp.co.future.uroborosql.connection.ConnectionSupplier)
 	 */
 	@Override

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
@@ -1,6 +1,8 @@
 package jp.co.future.uroborosql.dialect;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
 
 import java.sql.Connection;
@@ -111,6 +113,16 @@ public class Oracle10DialectTest {
 		assertThat(dialect.escapeLikePattern("pat[]tern"), is("pat[]tern"));
 		assertThat(dialect.escapeLikePattern("pat％tern"), is("pat％tern"));
 		assertThat(dialect.escapeLikePattern("pat＿tern"), is("pat＿tern"));
+	}
+
+	@Test
+	public void testSupports() {
+		Dialect dialect = new Oracle10Dialect();
+		assertThat(dialect.supportsBulkInsert(), is(false));
+		assertThat(dialect.supportsLimitClause(), is(false));
+		assertThat(dialect.supportsNullValuesOrdering(), is(true));
+		assertThat(dialect.isRemoveTerminator(), is(true));
+		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -115,4 +115,13 @@ public class Oracle11DialectTest {
 		assertThat(dialect.escapeLikePattern("pat＿tern"), is("pat\\＿tern"));
 	}
 
+	@Test
+	public void testSupports() {
+		Dialect dialect = new Oracle11Dialect();
+		assertThat(dialect.supportsBulkInsert(), is(false));
+		assertThat(dialect.supportsLimitClause(), is(false));
+		assertThat(dialect.supportsNullValuesOrdering(), is(true));
+		assertThat(dialect.isRemoveTerminator(), is(true));
+		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
@@ -115,4 +115,23 @@ public class Oracle12DialectTest {
 		assertThat(dialect.escapeLikePattern("pat＿tern"), is("pat\\＿tern"));
 	}
 
+	@Test
+	public void testSupports() {
+		Dialect dialect = new Oracle12Dialect();
+		assertThat(dialect.supportsBulkInsert(), is(false));
+		assertThat(dialect.supportsLimitClause(), is(true));
+		assertThat(dialect.supportsNullValuesOrdering(), is(true));
+		assertThat(dialect.isRemoveTerminator(), is(true));
+		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+	}
+
+	@Test
+	public void testGetLimitClause() {
+		Dialect dialect = new Oracle12Dialect();
+		assertThat(dialect.getLimitClause(3, 5), is("OFFSET 5 ROWS FETCH FIRST 3 ROWS ONLY" + System.lineSeparator()));
+		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5 ROWS" + System.lineSeparator()));
+		assertThat(dialect.getLimitClause(3, 0), is("FETCH FIRST 3 ROWS ONLY" + System.lineSeparator()));
+		assertThat(dialect.getLimitClause(0, 0), is(""));
+	}
+
 }


### PR DESCRIPTION
fixed #159

Oracle12 supports `OFFSET n ROWS` and `FETCH FIRST n ROWS ONLY`