### PR TITLE
Dialect#escapeLikePattern() return null when argument is null.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
@@ -130,8 +130,16 @@ public abstract class AbstractDialect implements Dialect {
 		return getDatabaseName().toLowerCase();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#escapeLikePattern(java.lang.CharSequence)
+	 */
 	@Override
 	public String escapeLikePattern(final CharSequence pattern) {
+		if (pattern == null) {
+			return null;
+		}
 		Matcher matcher = escapePattern.matcher(pattern);
 		return matcher.replaceAll(Matcher.quoteReplacement(String.valueOf(escapeChar)) + "$0");
 	}
@@ -180,5 +188,15 @@ public abstract class AbstractDialect implements Dialect {
 			type = JDBCType.OTHER;
 		}
 		return getJavaType(type, jdbcTypeName);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getEscapeChar()
+	 */
+	@Override
+	public char getEscapeChar() {
+		return escapeChar;
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -113,4 +113,11 @@ public interface Dialect {
 	 */
 	String getDatabaseType();
 
+	/**
+	 * LIKE句で指定するエスケープキャラクタを取得する
+	 *
+	 * @return エスケープキャラクタ
+	 */
+	char getEscapeChar();
+
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -58,6 +58,7 @@ public class DefaultDialectTest {
 	@Test
 	public void testEscapeLikePattern() {
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("$%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("$_pattern"));
@@ -73,6 +74,11 @@ public class DefaultDialectTest {
 	@Test
 	public void testGetDatabaseType() {
 		assertThat(dialect.getDatabaseType(), is("default"));
+	}
+
+	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('$'));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -19,6 +20,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class H2DialectTest {
+	private final Dialect dialect = new H2Dialect();
 
 	@Test
 	public void testAccept12() {
@@ -48,8 +50,8 @@ public class H2DialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new H2Dialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("$%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("$_pattern"));
@@ -63,8 +65,12 @@ public class H2DialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('$'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new H2Dialect();
 		assertThat(dialect.supportsBulkInsert(), is(true));
 		assertThat(dialect.supportsLimitClause(), is(true));
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));
@@ -74,7 +80,6 @@ public class H2DialectTest {
 
 	@Test
 	public void testGetLimitClause() {
-		Dialect dialect = new H2Dialect();
 		assertThat(dialect.getLimitClause(3, 5), is("LIMIT 3 OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -19,6 +20,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class MsSqlDialectTest {
+	private final Dialect dialect = new MsSqlDialect();
 
 	@Test
 	public void testAccept12() {
@@ -48,8 +50,8 @@ public class MsSqlDialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new MsSqlDialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("$%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("$_pattern"));
@@ -63,8 +65,12 @@ public class MsSqlDialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('$'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new MsSqlDialect();
 		assertThat(dialect.supportsBulkInsert(), is(false));
 		assertThat(dialect.supportsLimitClause(), is(false));
 		assertThat(dialect.supportsNullValuesOrdering(), is(false));
@@ -74,7 +80,6 @@ public class MsSqlDialectTest {
 
 	@Test
 	public void testGetLimitClause() {
-		Dialect dialect = new MsSqlDialect();
 		assertThat(dialect.getLimitClause(3, 5), is("LIMIT 3 OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));

--- a/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -19,6 +20,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class MySqlDialectTest {
+	private final Dialect dialect = new MySqlDialect();
 
 	@Test
 	public void testAccept12() {
@@ -48,8 +50,8 @@ public class MySqlDialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new MySqlDialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("$%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("$_pattern"));
@@ -63,8 +65,12 @@ public class MySqlDialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('$'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new MySqlDialect();
 		assertThat(dialect.supportsBulkInsert(), is(true));
 		assertThat(dialect.supportsLimitClause(), is(true));
 		assertThat(dialect.supportsNullValuesOrdering(), is(false));
@@ -74,7 +80,6 @@ public class MySqlDialectTest {
 
 	@Test
 	public void testGetLimitClause() {
-		Dialect dialect = new MySqlDialect();
 		assertThat(dialect.getLimitClause(3, 5), is("LIMIT 3 OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -20,6 +21,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class Oracle10DialectTest {
+	private final Dialect dialect = new Oracle10Dialect();
 
 	@Test
 	public void testAccept10() {
@@ -101,8 +103,8 @@ public class Oracle10DialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new Oracle10Dialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("\\%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("\\_pattern"));
@@ -116,13 +118,16 @@ public class Oracle10DialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('\\'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new Oracle10Dialect();
 		assertThat(dialect.supportsBulkInsert(), is(false));
 		assertThat(dialect.supportsLimitClause(), is(false));
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
 	}
-
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -20,6 +21,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class Oracle11DialectTest {
+	private final Dialect dialect = new Oracle11Dialect();
 
 	@Test
 	public void testAccept11() {
@@ -101,8 +103,8 @@ public class Oracle11DialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new Oracle11Dialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("\\%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("\\_pattern"));
@@ -116,8 +118,12 @@ public class Oracle11DialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('\\'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new Oracle11Dialect();
 		assertThat(dialect.supportsBulkInsert(), is(false));
 		assertThat(dialect.supportsLimitClause(), is(false));
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -20,6 +21,7 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  *
  */
 public class Oracle12DialectTest {
+	private final Dialect dialect = new Oracle12Dialect();
 
 	@Test
 	public void testAccept12() {
@@ -101,8 +103,8 @@ public class Oracle12DialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new Oracle12Dialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("\\%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("\\_pattern"));
@@ -116,8 +118,12 @@ public class Oracle12DialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('\\'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new Oracle12Dialect();
 		assertThat(dialect.supportsBulkInsert(), is(false));
 		assertThat(dialect.supportsLimitClause(), is(true));
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));
@@ -127,7 +133,6 @@ public class Oracle12DialectTest {
 
 	@Test
 	public void testGetLimitClause() {
-		Dialect dialect = new Oracle12Dialect();
 		assertThat(dialect.getLimitClause(3, 5), is("OFFSET 5 ROWS FETCH FIRST 3 ROWS ONLY" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5 ROWS" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("FETCH FIRST 3 ROWS ONLY" + System.lineSeparator()));

--- a/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
@@ -1,6 +1,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -21,6 +22,7 @@ import jp.co.future.uroborosql.mapping.JavaType;
  *
  */
 public class PostgresqlDialectTest {
+	private final Dialect dialect = new PostgresqlDialect();
 
 	@Test
 	public void testAccept12() {
@@ -50,8 +52,8 @@ public class PostgresqlDialectTest {
 
 	@Test
 	public void testEscapeLikePattern() {
-		Dialect dialect = new PostgresqlDialect();
 		assertThat(dialect.escapeLikePattern(""), is(""));
+		assertThat(dialect.escapeLikePattern(null), nullValue());
 		assertThat(dialect.escapeLikePattern("pattern"), is("pattern"));
 		assertThat(dialect.escapeLikePattern("%pattern"), is("$%pattern"));
 		assertThat(dialect.escapeLikePattern("_pattern"), is("$_pattern"));
@@ -65,8 +67,12 @@ public class PostgresqlDialectTest {
 	}
 
 	@Test
+	public void testGetEscapeChar() {
+		assertThat(dialect.getEscapeChar(), is('$'));
+	}
+
+	@Test
 	public void testSupports() {
-		Dialect dialect = new PostgresqlDialect();
 		assertThat(dialect.supportsBulkInsert(), is(true));
 		assertThat(dialect.supportsLimitClause(), is(true));
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));
@@ -76,7 +82,6 @@ public class PostgresqlDialectTest {
 
 	@Test
 	public void testGetLimitClause() {
-		Dialect dialect = new PostgresqlDialect();
 		assertThat(dialect.getLimitClause(3, 5), is("LIMIT 3 OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));
@@ -85,7 +90,6 @@ public class PostgresqlDialectTest {
 
 	@Test
 	public void testGetJavaType() {
-		Dialect dialect = new PostgresqlDialect();
 		assertEquals(dialect.getJavaType(JDBCType.OTHER, "json").getClass(), JavaType.of(String.class).getClass());
 		assertEquals(dialect.getJavaType(JDBCType.OTHER, "jsonb").getClass(), JavaType.of(String.class).getClass());
 		assertEquals(dialect.getJavaType(JDBCType.OTHER, "other").getClass(), JavaType.of(Object.class).getClass());


### PR DESCRIPTION
fixed #169

and add Dialect#getEscapeChar() method.
