### PR TITLE
Change the type of TableMetadata.Column.dataType field from JDBCType to int

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
@@ -9,6 +9,7 @@ package jp.co.future.uroborosql.dialect;
 import java.math.BigDecimal;
 import java.sql.JDBCType;
 import java.sql.Ref;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Timestamp;
 import java.time.LocalTime;
@@ -31,8 +32,8 @@ import jp.co.future.uroborosql.utils.StringFunction;
 public abstract class AbstractDialect implements Dialect {
 	private static final char[] DEFAULT_WILDCARDS = { '%', '_' };
 
-	/** JDBCTypeとJavaTyoeのマッピング */
-	protected static final Map<JDBCType, JavaType> DEFAULT_TYPE_MAP;
+	/** SQLTypeの値(int)とJavaTypeのマッピング */
+	protected static final Map<Integer, JavaType> DEFAULT_TYPE_MAP;
 
 	/** like検索時のエスケープ文字 */
 	private final char escapeChar;
@@ -43,50 +44,50 @@ public abstract class AbstractDialect implements Dialect {
 
 	private final StringFunction expressionFunction;
 
-	protected final Map<JDBCType, JavaType> typeMap;
+	protected final Map<Integer, JavaType> typeMap;
 
 	static {
 		// initialize DEFAULT_TYPE_MAP
 		DEFAULT_TYPE_MAP = new HashMap<>();
-		DEFAULT_TYPE_MAP.put(JDBCType.CHAR, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.VARCHAR, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.LONGVARCHAR, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.NCHAR, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.NVARCHAR, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.LONGNVARCHAR, JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.CHAR.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.VARCHAR.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.LONGVARCHAR.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.NCHAR.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.NVARCHAR.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.LONGNVARCHAR.getVendorTypeNumber(), JavaType.of(String.class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.NUMERIC, JavaType.of(BigDecimal.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.DECIMAL, JavaType.of(BigDecimal.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.NUMERIC.getVendorTypeNumber(), JavaType.of(BigDecimal.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.DECIMAL.getVendorTypeNumber(), JavaType.of(BigDecimal.class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.BIT, JavaType.of(Boolean.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.BOOLEAN, JavaType.of(Boolean.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.TINYINT, JavaType.of(byte.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.SMALLINT, JavaType.of(Short.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.INTEGER, JavaType.of(Integer.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.BIGINT, JavaType.of(Long.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.REAL, JavaType.of(Float.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.FLOAT, JavaType.of(Double.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.DOUBLE, JavaType.of(Double.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.BIT.getVendorTypeNumber(), JavaType.of(Boolean.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.BOOLEAN.getVendorTypeNumber(), JavaType.of(Boolean.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.TINYINT.getVendorTypeNumber(), JavaType.of(byte.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.SMALLINT.getVendorTypeNumber(), JavaType.of(Short.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.INTEGER.getVendorTypeNumber(), JavaType.of(Integer.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.BIGINT.getVendorTypeNumber(), JavaType.of(Long.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.REAL.getVendorTypeNumber(), JavaType.of(Float.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.FLOAT.getVendorTypeNumber(), JavaType.of(Double.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.DOUBLE.getVendorTypeNumber(), JavaType.of(Double.class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.BINARY, JavaType.of(byte[].class));
-		DEFAULT_TYPE_MAP.put(JDBCType.VARBINARY, JavaType.of(byte[].class));
-		DEFAULT_TYPE_MAP.put(JDBCType.LONGVARBINARY, JavaType.of(byte[].class));
+		DEFAULT_TYPE_MAP.put(JDBCType.BINARY.getVendorTypeNumber(), JavaType.of(byte[].class));
+		DEFAULT_TYPE_MAP.put(JDBCType.VARBINARY.getVendorTypeNumber(), JavaType.of(byte[].class));
+		DEFAULT_TYPE_MAP.put(JDBCType.LONGVARBINARY.getVendorTypeNumber(), JavaType.of(byte[].class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.DATE, JavaType.of(ZonedDateTime.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.TIME, JavaType.of(LocalTime.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.TIMESTAMP, JavaType.of(Timestamp.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.TIME_WITH_TIMEZONE, JavaType.of(OffsetTime.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.TIMESTAMP_WITH_TIMEZONE, JavaType.of(ZonedDateTime.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.DATE.getVendorTypeNumber(), JavaType.of(ZonedDateTime.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.TIME.getVendorTypeNumber(), JavaType.of(LocalTime.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.TIMESTAMP.getVendorTypeNumber(), JavaType.of(Timestamp.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.TIME_WITH_TIMEZONE.getVendorTypeNumber(), JavaType.of(OffsetTime.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.TIMESTAMP_WITH_TIMEZONE.getVendorTypeNumber(), JavaType.of(ZonedDateTime.class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.CLOB, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.BLOB, JavaType.of(byte[].class));
-		DEFAULT_TYPE_MAP.put(JDBCType.NCLOB, JavaType.of(String.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.REF, JavaType.of(Ref.class));
-		DEFAULT_TYPE_MAP.put(JDBCType.SQLXML, JavaType.of(SQLXML.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.CLOB.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.BLOB.getVendorTypeNumber(), JavaType.of(byte[].class));
+		DEFAULT_TYPE_MAP.put(JDBCType.NCLOB.getVendorTypeNumber(), JavaType.of(String.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.REF.getVendorTypeNumber(), JavaType.of(Ref.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.SQLXML.getVendorTypeNumber(), JavaType.of(SQLXML.class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.ARRAY, JavaType.of(Object[].class));
+		DEFAULT_TYPE_MAP.put(JDBCType.ARRAY.getVendorTypeNumber(), JavaType.of(Object[].class));
 
-		DEFAULT_TYPE_MAP.put(JDBCType.OTHER, JavaType.of(Object.class));
+		DEFAULT_TYPE_MAP.put(JDBCType.OTHER.getVendorTypeNumber(), JavaType.of(Object.class));
 	}
 
 	/**
@@ -189,11 +190,11 @@ public abstract class AbstractDialect implements Dialect {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.dialect.Dialect#getJavaType(java.sql.JDBCType, java.lang.String)
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getJavaType(java.sql.SQLType, java.lang.String)
 	 */
 	@Override
-	public JavaType getJavaType(final JDBCType jdbcType, final String jdbcTypeName) {
-		return this.typeMap.getOrDefault(jdbcType, JavaType.of(Object.class));
+	public JavaType getJavaType(final SQLType sqlType, final String sqlTypeName) {
+		return this.getJavaType(sqlType.getVendorTypeNumber(), sqlTypeName);
 	}
 
 	/**
@@ -202,14 +203,8 @@ public abstract class AbstractDialect implements Dialect {
 	 * @see jp.co.future.uroborosql.dialect.Dialect#getJavaType(int, java.lang.String)
 	 */
 	@Override
-	public JavaType getJavaType(final int jdbcType, final String jdbcTypeName) {
-		JDBCType type = null;
-		try {
-			type = JDBCType.valueOf(jdbcType);
-		} catch (IllegalArgumentException ex) {
-			type = JDBCType.OTHER;
-		}
-		return getJavaType(type, jdbcTypeName);
+	public JavaType getJavaType(final int sqlType, final String sqlTypeName) {
+		return this.typeMap.getOrDefault(sqlType, JavaType.of(Object.class));
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -6,7 +6,7 @@
  */
 package jp.co.future.uroborosql.dialect;
 
-import java.sql.JDBCType;
+import java.sql.SQLType;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.mapping.JavaType;
@@ -118,22 +118,22 @@ public interface Dialect {
 	String escapeLikePattern(CharSequence pattern);
 
 	/**
-	 * {@link JDBCType} を変換するJava型を取得する
+	 * {@link SQLType} を変換するJava型を取得する
 	 *
-	 * @param jdbcType JDBCType
-	 * @param jdbcTypeName データベース固有の型名
+	 * @param sqlType SQLType
+	 * @param sqlTypeName データベース固有の型名
 	 * @return 変換するJava型
 	 */
-	JavaType getJavaType(JDBCType jdbcType, String jdbcTypeName);
+	JavaType getJavaType(SQLType sqlType, String sqlTypeName);
 
 	/**
-	 * {@link JDBCType} を変換するJava型を取得する
+	 * {@link SQLType} を変換するJava型を取得する
 	 *
-	 * @param jdbcType JDBCTypeを表す数値
-	 * @param jdbcTypeName データベース固有の型名
+	 * @param sqlType SQLTypeを表す数値
+	 * @param sqlTypeName データベース固有の型名
 	 * @return 変換するJava型
 	 */
-	JavaType getJavaType(int jdbcType, String jdbcTypeName);
+	JavaType getJavaType(int sqlType, String sqlTypeName);
 
 	/**
 	 * Databaseの種別を表す名前を取得する

--- a/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
@@ -7,6 +7,7 @@
 package jp.co.future.uroborosql.dialect;
 
 import java.sql.JDBCType;
+import java.sql.SQLType;
 
 import jp.co.future.uroborosql.mapping.JavaType;
 
@@ -76,17 +77,27 @@ public class PostgresqlDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#getJavaType(java.sql.JDBCType, java.lang.String)
+	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#getJavaType(java.sql.SQLType, java.lang.String)
 	 */
 	@Override
-	public JavaType getJavaType(final JDBCType jdbcType, final String jdbcTypeName) {
-		if (JDBCType.OTHER.equals(jdbcType)) {
-			if ("json".equalsIgnoreCase(jdbcTypeName) || "jsonb".equalsIgnoreCase(jdbcTypeName)) {
+	public JavaType getJavaType(final SQLType sqlType, final String sqlTypeName) {
+		return this.getJavaType(sqlType.getVendorTypeNumber(), sqlTypeName);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#getJavaType(int, java.lang.String)
+	 */
+	@Override
+	public JavaType getJavaType(final int sqlType, final String sqlTypeName) {
+		if (JDBCType.OTHER.getVendorTypeNumber().equals(sqlType)) {
+			if ("json".equalsIgnoreCase(sqlTypeName) || "jsonb".equalsIgnoreCase(sqlTypeName)) {
 				// JSON型の場合、文字列として扱う
-				return super.getJavaType(JDBCType.NVARCHAR, jdbcTypeName);
+				return super.getJavaType(JDBCType.NVARCHAR, sqlTypeName);
 			}
 		}
-		return super.getJavaType(jdbcType, jdbcTypeName);
+		return super.getJavaType(sqlType, sqlTypeName);
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -672,9 +672,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 	 * @param type JDBC上の型
 	 * @return 文字列型の場合<code>true</code>
 	 */
-	private boolean isStringType(final JDBCType type) {
-		return JDBCType.CHAR.equals(type) || JDBCType.NCHAR.equals(type) || JDBCType.VARCHAR.equals(type)
-				|| JDBCType.NVARCHAR.equals(type) || JDBCType.LONGNVARCHAR.equals(type);
+	private boolean isStringType(final int type) {
+		return JDBCType.CHAR.getVendorTypeNumber().equals(type) || JDBCType.NCHAR.getVendorTypeNumber().equals(type)
+				|| JDBCType.VARCHAR.getVendorTypeNumber().equals(type)
+				|| JDBCType.NVARCHAR.getVendorTypeNumber().equals(type)
+				|| JDBCType.LONGNVARCHAR.getVendorTypeNumber().equals(type);
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
@@ -8,7 +8,6 @@ package jp.co.future.uroborosql.mapping;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Comparator;
@@ -61,9 +60,9 @@ public interface TableMetadata {
 		/**
 		 * カラム型取得
 		 *
-		 * @return カラム型
+		 * @return カラム型を表す値
 		 */
-		JDBCType getDataType();
+		int getDataType();
 
 		/**
 		 * 主キー内の連番取得 (値1は主キーの最初の列、値2は主キーの2番目の列を表す)。

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
@@ -28,7 +28,7 @@ public class TableMetadataImpl implements TableMetadata {
 		private String columnName;
 		private String camelName;
 		private String identifier;
-		private JDBCType dataType;
+		private int dataType;
 		private Integer keySeq = null;
 		private final String identifierQuoteString;
 		private final String remarks;
@@ -47,17 +47,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 */
 		public Column(final String columnName, final JDBCType dataType, final String remarks, final String nullable,
 				final int ordinalPosition, final String identifierQuoteString) {
-			this.columnName = columnName;
-			this.dataType = dataType;
-			this.remarks = remarks;
-			this.nullable = "YES".equalsIgnoreCase(nullable);
-			this.ordinalPosition = ordinalPosition;
-
-			if (StringUtils.isEmpty(identifierQuoteString)) {
-				this.identifierQuoteString = "";
-			} else {
-				this.identifierQuoteString = identifierQuoteString;
-			}
+			this(columnName, dataType.getVendorTypeNumber(), remarks, nullable, ordinalPosition, identifierQuoteString);
 		}
 
 		/**
@@ -72,7 +62,17 @@ public class TableMetadataImpl implements TableMetadata {
 		 */
 		public Column(final String columnName, final int dataType, final String remarks, final String nullable,
 				final int ordinalPosition, final String identifierQuoteString) {
-			this(columnName, JDBCType.valueOf(dataType), remarks, nullable, ordinalPosition, identifierQuoteString);
+			this.columnName = columnName;
+			this.dataType = dataType;
+			this.remarks = remarks;
+			this.nullable = "YES".equalsIgnoreCase(nullable);
+			this.ordinalPosition = ordinalPosition;
+
+			if (StringUtils.isEmpty(identifierQuoteString)) {
+				this.identifierQuoteString = "";
+			} else {
+				this.identifierQuoteString = identifierQuoteString;
+			}
 		}
 
 		/**
@@ -134,7 +134,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getDataType()
 		 */
 		@Override
-		public JDBCType getDataType() {
+		public int getDataType() {
 			return this.dataType;
 		}
 
@@ -143,7 +143,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 *
 		 * @param dataType タイプ
 		 */
-		public void setDataType(final JDBCType dataType) {
+		public void setDataType(final int dataType) {
 			this.dataType = dataType;
 		}
 

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
@@ -6,7 +6,7 @@
  */
 package jp.co.future.uroborosql.mapping;
 
-import java.sql.JDBCType;
+import java.sql.SQLType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +45,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param ordinalPosition 列インデックス
 		 * @param identifierQuoteString SQL識別子を引用するのに使用する文字列
 		 */
-		public Column(final String columnName, final JDBCType dataType, final String remarks, final String nullable,
+		public Column(final String columnName, final SQLType dataType, final String remarks, final String nullable,
 				final int ordinalPosition, final String identifierQuoteString) {
 			this(columnName, dataType.getVendorTypeNumber(), remarks, nullable, ordinalPosition, identifierQuoteString);
 		}
@@ -85,7 +85,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param ordinalPosition 列インデックス
 		 */
 		@Deprecated
-		public Column(final String columnName, final JDBCType dataType, final String remarks, final String nullable,
+		public Column(final String columnName, final SQLType dataType, final String remarks, final String nullable,
 				final int ordinalPosition) {
 			this(columnName, dataType, remarks, nullable, ordinalPosition, null);
 		}

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.*;
 import java.math.BigDecimal;
 import java.sql.JDBCType;
 import java.sql.Ref;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Timestamp;
 import java.time.LocalTime;
@@ -88,7 +89,7 @@ public class DefaultDialectTest {
 	}
 
 	@Test
-	public void getJavaType() {
+	public void getJavaTypeWithSQLType() {
 		assertEquals(dialect.getJavaType(JDBCType.CHAR, "").getClass(), JavaType.of(String.class).getClass());
 		assertEquals(dialect.getJavaType(JDBCType.VARCHAR, "").getClass(), JavaType.of(String.class).getClass());
 		assertEquals(dialect.getJavaType(JDBCType.LONGVARCHAR, "").getClass(), JavaType.of(String.class).getClass());
@@ -130,6 +131,95 @@ public class DefaultDialectTest {
 		assertEquals(dialect.getJavaType(JDBCType.ARRAY, "").getClass(), JavaType.of(Object[].class).getClass());
 
 		assertEquals(dialect.getJavaType(JDBCType.OTHER, "").getClass(), JavaType.of(Object.class).getClass());
+		assertEquals(dialect.getJavaType(new SQLType() {
+
+			@Override
+			public Integer getVendorTypeNumber() {
+				return 999;
+			}
+
+			@Override
+			public String getVendor() {
+				return "dummy";
+			}
+
+			@Override
+			public String getName() {
+				return "dummy";
+			}
+		}, "").getClass(), JavaType.of(Object.class).getClass());
+	}
+
+	@Test
+	public void getJavaTypeWithVendorTypeNumber() {
+		assertEquals(dialect.getJavaType(JDBCType.CHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.VARCHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.LONGVARCHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.NCHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.NVARCHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.LONGNVARCHAR.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.NUMERIC.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(BigDecimal.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.DECIMAL.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(BigDecimal.class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.BIT.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Boolean.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.BOOLEAN.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Boolean.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.TINYINT.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(byte.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.SMALLINT.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Short.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.INTEGER.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Integer.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.BIGINT.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Long.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.REAL.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Float.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.FLOAT.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Double.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.DOUBLE.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Double.class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.BINARY.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(byte[].class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.VARBINARY.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(byte[].class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.LONGVARBINARY.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(byte[].class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.DATE.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(ZonedDateTime.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.TIME.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(LocalTime.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.TIMESTAMP.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Timestamp.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.TIME_WITH_TIMEZONE.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(OffsetTime.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.TIMESTAMP_WITH_TIMEZONE.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(ZonedDateTime.class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.CLOB.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.BLOB.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(byte[].class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.NCLOB.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(String.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.REF.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Ref.class).getClass());
+		assertEquals(dialect.getJavaType(JDBCType.SQLXML.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(SQLXML.class).getClass());
+
+		assertEquals(dialect.getJavaType(JDBCType.ARRAY.getVendorTypeNumber(), "").getClass(),
+				JavaType.of(Object[].class).getClass());
 
 		assertEquals(dialect.getJavaType(JDBCType.OTHER.getVendorTypeNumber(), "").getClass(),
 				JavaType.of(Object.class).getClass());


### PR DESCRIPTION
fixed #191 

An exception occurs when a value not defined in JDBCType is specified,  
so it is fixed to hold as a field of Column as int type.