### PR TITLE
Add SqlQuery#one, SqlQuery#findOne

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/exception/DataNonUniqueException.java
+++ b/src/main/java/jp/co/future/uroborosql/exception/DataNonUniqueException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.exception;
+
+/**
+ * 検索結果が2件以上で先頭行を取得しようとした場合にスローされる例外クラス
+ *
+ * @author hoshi-k
+ */
+public class DataNonUniqueException extends UroborosqlRuntimeException {
+
+	public DataNonUniqueException() {
+		super();
+	}
+
+	public DataNonUniqueException(final String message) {
+		super(message);
+	}
+
+	public DataNonUniqueException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public DataNonUniqueException(final Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlQuery.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
+import jp.co.future.uroborosql.exception.DataNonUniqueException;
 import jp.co.future.uroborosql.exception.DataNotFoundException;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
@@ -27,6 +28,111 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  * @author H.Sugimoto
  */
 public interface SqlQuery extends SqlFluent<SqlQuery> {
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @return 検索結果の先頭行をMapに詰めたもの. MapのキーはSnakeCase式に変換される.
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 */
+	Map<String, Object> first();
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @param caseFormat Mapのキーの変換書式
+	 * @return 検索結果の先頭行をMapに詰めたもの
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 */
+	Map<String, Object> first(CaseFormat caseFormat);
+
+	/**
+	 * 検索結果の先頭行をEntityとして取得（終端処理）
+	 *
+	 * @param <T> Entityの型
+	 * @param type 受け取りたいEntityの型
+	 * @return 検索結果の先頭行のEntity
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 */
+	<T> T first(Class<T> type);
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却. MapのキーはSnakeCase式に変換される.
+	 */
+	Optional<Map<String, Object>> findFirst();
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @param caseFormat Mapのキーの変換書式
+	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却
+	 */
+	Optional<Map<String, Object>> findFirst(CaseFormat caseFormat);
+
+	/**
+	 * 検索結果の先頭行をEntityとして取得（終端処理）
+	 *
+	 * @param <T> Entityの型
+	 * @param type 受け取りたいEntityの型
+	 * @return 検索結果の先頭行のEntityをOptionalとして返却
+	 */
+	<T> Optional<T> findFirst(Class<T> type);
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @return 検索結果の先頭行をMapに詰めたもの. MapのキーはSnakeCase式に変換される.
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 * @throws DataNonUniqueException 検索結果が２件以上の場合
+	 */
+	Map<String, Object> one();
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @param caseFormat Mapのキーの変換書式
+	 * @return 検索結果の先頭行をMapに詰めたもの
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 * @throws DataNonUniqueException 検索結果が２件以上の場合
+	 */
+	Map<String, Object> one(CaseFormat caseFormat);
+
+	/**
+	 * 検索結果の先頭行をEntityとして取得（終端処理）
+	 *
+	 * @param <T> Entityの型
+	 * @param type 受け取りたいEntityの型
+	 * @return 検索結果の先頭行のEntity
+	 * @throws DataNotFoundException 検索結果が０件の場合
+	 * @throws DataNonUniqueException 検索結果が２件以上の場合
+	 */
+	<T> T one(Class<T> type);
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却. MapのキーはSnakeCase式に変換される.
+	 */
+	Optional<Map<String, Object>> findOne();
+
+	/**
+	 * 検索結果の先頭行を取得（終端処理）
+	 *
+	 * @param caseFormat Mapのキーの変換書式
+	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却
+	 */
+	Optional<Map<String, Object>> findOne(CaseFormat caseFormat);
+
+	/**
+	 * 検索結果の先頭行をEntityとして取得（終端処理）
+	 *
+	 * @param <T> Entityの型
+	 * @param type 受け取りたいEntityの型
+	 * @return 検索結果の先頭行のEntityをOptionalとして返却
+	 */
+	<T> Optional<T> findOne(Class<T> type);
 
 	/**
 	 * ResultSetの取得（終端処理）
@@ -56,7 +162,7 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	/**
 	 * 検索結果の取得（終端処理）
 	 *
-	 * @param <T>  Entityの型
+	 * @param <T> Entityの型
 	 * @param type 受け取りたいEntityの型
 	 * @return 検索結果のリスト
 	 * @see SqlAgent#query(String)
@@ -64,60 +170,9 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	<T> List<T> collect(Class<T> type);
 
 	/**
-	 * 検索結果の先頭行を取得（終端処理）
-	 *
-	 * @param caseFormat Mapのキーの変換書式
-	 * @return 検索結果の先頭行をMapに詰めたもの
-	 * @throws DataNotFoundException 検索結果が０件の場合
-	 */
-	Map<String, Object> first(CaseFormat caseFormat);
-
-	/**
-	 * 検索結果の先頭行を取得（終端処理）
-	 *
-	 * @return 検索結果の先頭行をMapに詰めたもの. MapのキーはSnakeCase式に変換される.
-	 * @throws DataNotFoundException 検索結果が０件の場合
-	 */
-	Map<String, Object> first();
-
-	/**
-	 * 検索結果の先頭行をEntityとして取得（終端処理）
-	 *
-	 * @param <T>  Entityの型
-	 * @param type 受け取りたいEntityの型
-	 * @return 検索結果の先頭行のEntity
-	 * @throws DataNotFoundException 検索結果が０件の場合
-	 */
-	<T> T first(Class<T> type);
-
-	/**
-	 * 検索結果の先頭行を取得（終端処理）
-	 *
-	 * @param caseFormat Mapのキーの変換書式
-	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却
-	 */
-	Optional<Map<String, Object>> findFirst(CaseFormat caseFormat);
-
-	/**
-	 * 検索結果の先頭行を取得（終端処理）
-	 *
-	 * @return 検索結果の先頭行をMapに詰めたものをOptionalとして返却. MapのキーはSnakeCase式に変換される.
-	 */
-	Optional<Map<String, Object>> findFirst();
-
-	/**
-	 * 検索結果の先頭行をEntityとして取得（終端処理）
-	 *
-	 * @param <T>  Entityの型
-	 * @param type 受け取りたいEntityの型
-	 * @return 検索結果の先頭行のEntityをOptionalとして返却
-	 */
-	<T> Optional<T> findFirst(Class<T> type);
-
-	/**
 	 * 検索結果をStreamとして取得（終端処理）
 	 *
-	 * @param <T>       Streamの型
+	 * @param <T> Streamの型
 	 * @param converter ResultSetの各行を変換するための変換器
 	 * @return 検索結果を順次取得するStream
 	 */
@@ -141,7 +196,7 @@ public interface SqlQuery extends SqlFluent<SqlQuery> {
 	/**
 	 * 検索結果をEntityのStreamとして取得（終端処理）
 	 *
-	 * @param <T>       Streamの型
+	 * @param <T> Streamの型
 	 * @param type 受け取りたいEntityの型
 	 * @return 検索結果を順次取得するStream.
 	 */


### PR DESCRIPTION
fixes #198 

Added the following methods.

```java
Map<String, Object> one(CaseFormat caseFormat);
Map<String, Object> one();
<T> T one(Class<T> type);
Optional<Map<String, Object>> findOne(CaseFormat caseFormat);
Optional<Map<String, Object>> findOne();
<T> Optional<T> findOne(Class<T> type);
```

Improved so that `DataNonUniqueException` occurs when two or more results are returned.