### PR TITLE
Added onlyUpdatableWithinTransaction option to SqlAgentFactory

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -29,8 +29,8 @@ import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.coverage.CoverageData;
 import jp.co.future.uroborosql.coverage.CoverageHandler;
-import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.exception.EntitySqlRuntimeException;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
@@ -148,8 +148,7 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	public AbstractAgent(final SqlConfig sqlConfig, final Map<String, String> defaultProps) {
 		this.sqlConfig = sqlConfig;
-		this.transactionManager = new LocalTransactionManager(sqlConfig.getConnectionSupplier(),
-				sqlConfig.getSqlFilterManager());
+		this.transactionManager = new LocalTransactionManager(sqlConfig);
 
 		// デフォルトプロパティ設定
 		if (defaultProps.containsKey(SqlAgentFactory.PROPS_KEY_FETCH_SIZE)) {

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -11,6 +11,7 @@ import java.util.List;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.exception.UroborosqlTransactionException;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.mapping.EntityHandler;
 import jp.co.future.uroborosql.store.SqlManager;
@@ -23,55 +24,61 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  */
 public interface SqlAgentFactory {
 	/** ファクトリBean名 */
-	final String FACTORY_BEAN_NAME = "sqlAagentFactory";
+	String FACTORY_BEAN_NAME = "sqlAagentFactory";
 
 	/**
 	 * プロパティ:SQL実行でエラーが発生した場合にリトライ対象とするSQLエラーコード<br>
 	 * デフォルトは指定なし
 	 */
-	final String PROPS_KEY_SQL_RETRY_CODES = "sqlRetryCodes";
+	String PROPS_KEY_SQL_RETRY_CODES = "sqlRetryCodes";
 
 	/**
 	 * プロパティ:SQL実行エラー時の最大リトライ回数デフォルト値<br>
 	 * デフォルトは<code>0</code>
 	 */
-	final String PROPS_KEY_DEFAULT_MAX_RETRY_COUNT = "defaultMaxRetryCount";
+	String PROPS_KEY_DEFAULT_MAX_RETRY_COUNT = "defaultMaxRetryCount";
 
 	/**
 	 * プロパティ:SQL実行リトライ時の待機時間(ms)デフォルト値<br>
 	 * デフォルトは<code>0</code>
 	 */
-	final String PROPS_KEY_DEFAULT_SQL_RETRY_WAIT_TIME = "defaultSqlRetryWaitTime";
+	String PROPS_KEY_DEFAULT_SQL_RETRY_WAIT_TIME = "defaultSqlRetryWaitTime";
 
 	/**
 	 * プロパティ:フェッチサイズ（数値）<br>
 	 * デフォルトは指定なし
 	 */
-	final String PROPS_KEY_FETCH_SIZE = "fetchSize";
+	String PROPS_KEY_FETCH_SIZE = "fetchSize";
 
 	/**
 	 * プロパティ:クエリータイムアウト（ms）（数値）<br>
 	 * デフォルトは指定なし
 	 */
-	final String PROPS_KEY_QUERY_TIMEOUT = "queryTimeout";
+	String PROPS_KEY_QUERY_TIMEOUT = "queryTimeout";
 
 	/**
 	 * プロパティ:SQL_IDを置換するためのKEY文字列<br>
 	 * デフォルトは "_SQL_ID_"
 	 */
-	final String PROPS_KEY_SQL_ID_KEY_NAME = "sqlIdKeyName";
+	String PROPS_KEY_SQL_ID_KEY_NAME = "sqlIdKeyName";
 
 	/**
 	 * プロパティ:Queryの結果を格納するMapのキーを生成する際に使用するCaseFormat<br>
 	 * デフォルトは "UPPER_SNAKE_CASE"
 	 */
-	final String PROPS_KEY_DEFAULT_MAP_KEY_CASE_FORMAT = "defaultMapKeyCaseFormat";
+	String PROPS_KEY_DEFAULT_MAP_KEY_CASE_FORMAT = "defaultMapKeyCaseFormat";
 
 	/**
 	 * プロパティ:デフォルトの{@link InsertsType}<br>
 	 * デフォルトは "BULK"
 	 */
-	final String PROPS_KEY_DEFAULT_INSERTS_TYPE = "defaultInsertsType";
+	String PROPS_KEY_DEFAULT_INSERTS_TYPE = "defaultInsertsType";
+
+	/**
+	 * プロパティ:トランザクション内でのみ更新可能とするかどうか<br>
+	 * デフォルトは false
+	 */
+	String PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION = "onlyUpdatableWithinTransaction";
 
 	/**
 	 * SQL実行クラス生成。
@@ -251,4 +258,19 @@ public interface SqlAgentFactory {
 	 * @see jp.co.future.uroborosql.enums.InsertsType
 	 */
 	SqlAgentFactory setDefaultInsertsType(InsertsType defaultInsertsType);
+
+	/**
+	 * トランザクション内でのみ更新可能とするかどうかを取得する
+	 * @return トランザクション内でのみ更新可能とする場合<true>
+	 */
+	boolean isOnlyUpdatableWithinTransaction();
+
+	/**
+	 * トランザクション内でのみ更新可能とするかどうかを設定する<br>
+	 * <code>true</code>を指定するとトランザクションを開始していない場合は SELECT文以外のSQLを発行すると {@link UroborosqlTransactionException}をスローする
+	 *
+	 * @param onlyUpdatableWithinTransaction トランザクション内でのみ更新可能とするかどうか。
+	 * @return SqlAgentFactory
+	 */
+	SqlAgentFactory setOnlyUpdatableWithinTransaction(boolean onlyUpdatableWithinTransaction);
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -75,10 +75,10 @@ public interface SqlAgentFactory {
 	String PROPS_KEY_DEFAULT_INSERTS_TYPE = "defaultInsertsType";
 
 	/**
-	 * プロパティ:トランザクション内でのみ更新可能とするかどうか<br>
+	 * プロパティ:トランザクション内での更新を強制するかどうか<br>
 	 * デフォルトは false
 	 */
-	String PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION = "onlyUpdatableWithinTransaction";
+	String PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION = "forceUpdateWithinTransaction";
 
 	/**
 	 * SQL実行クラス生成。
@@ -260,17 +260,17 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setDefaultInsertsType(InsertsType defaultInsertsType);
 
 	/**
-	 * トランザクション内でのみ更新可能とするかどうかを取得する
+	 * トランザクション内での更新を強制するかどうかを取得する
 	 * @return トランザクション内でのみ更新可能とする場合<true>
 	 */
-	boolean isOnlyUpdatableWithinTransaction();
+	boolean isForceUpdateWithinTransaction();
 
 	/**
-	 * トランザクション内でのみ更新可能とするかどうかを設定する<br>
-	 * <code>true</code>を指定するとトランザクションを開始していない場合は SELECT文以外のSQLを発行すると {@link UroborosqlTransactionException}をスローする
+	 * トランザクション内での更新を強制するかどうかを設定する<br>
+	 * <code>true</code>を指定するとトランザクションを開始していない状態で SELECT文以外のSQLを発行すると {@link UroborosqlTransactionException}をスローする
 	 *
-	 * @param onlyUpdatableWithinTransaction トランザクション内でのみ更新可能とするかどうか。
+	 * @param forceUpdateWithinTransaction トランザクション内でのみ更新可能とするかどうか。
 	 * @return SqlAgentFactory
 	 */
-	SqlAgentFactory setOnlyUpdatableWithinTransaction(boolean onlyUpdatableWithinTransaction);
+	SqlAgentFactory setForceUpdateWithinTransaction(boolean forceUpdateWithinTransaction);
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -309,7 +309,7 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	 * @see jp.co.future.uroborosql.SqlAgentFactory#setDefaultInsertsType(InsertsType)
 	 */
 	@Override
-	public SqlAgentFactory setDefaultInsertsType(InsertsType defaultInsertsType) {
+	public SqlAgentFactory setDefaultInsertsType(final InsertsType defaultInsertsType) {
 		getDefaultProps().put(PROPS_KEY_DEFAULT_INSERTS_TYPE, defaultInsertsType.toString());
 		return this;
 	}
@@ -321,6 +321,19 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	 */
 	protected Map<String, String> getDefaultProps() {
 		return defaultProps;
+	}
+
+	@Override
+	public boolean isOnlyUpdatableWithinTransaction() {
+		return Boolean
+				.parseBoolean(getDefaultProps().getOrDefault(PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION, "FALSE"));
+	}
+
+	@Override
+	public SqlAgentFactory setOnlyUpdatableWithinTransaction(final boolean onlyUpdatableWithinTransaction) {
+		getDefaultProps().put(PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION,
+				Boolean.toString(onlyUpdatableWithinTransaction));
+		return this;
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -315,25 +315,35 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#isForceUpdateWithinTransaction()
+	 */
+	@Override
+	public boolean isForceUpdateWithinTransaction() {
+		return Boolean
+				.parseBoolean(getDefaultProps().getOrDefault(PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION, "FALSE"));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#setForceUpdateWithinTransaction(boolean)
+	 */
+	@Override
+	public SqlAgentFactory setForceUpdateWithinTransaction(final boolean forceUpdateWithinTransaction) {
+		getDefaultProps().put(PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION,
+				Boolean.toString(forceUpdateWithinTransaction));
+		return this;
+	}
+
+	/**
 	 * defaultProps を取得します
 	 *
 	 * @return defaultProps
 	 */
 	protected Map<String, String> getDefaultProps() {
 		return defaultProps;
-	}
-
-	@Override
-	public boolean isOnlyUpdatableWithinTransaction() {
-		return Boolean
-				.parseBoolean(getDefaultProps().getOrDefault(PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION, "FALSE"));
-	}
-
-	@Override
-	public SqlAgentFactory setOnlyUpdatableWithinTransaction(final boolean onlyUpdatableWithinTransaction) {
-		getDefaultProps().put(PROPS_KEY_ONLY_UPDATABLE_WITHIN_TRANSACTION,
-				Boolean.toString(onlyUpdatableWithinTransaction));
-		return this;
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -87,6 +87,10 @@ public class SqlAgentImpl extends AbstractAgent {
 		// パラメータログを出力する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.FALSE.toString());
 
+		if (SqlKind.NONE.equals(sqlContext.getSqlKind())) {
+			sqlContext.setSqlKind(SqlKind.SELECT);
+		}
+
 		// コンテキスト変換
 		transformContext(sqlContext, true);
 
@@ -242,6 +246,10 @@ public class SqlAgentImpl extends AbstractAgent {
 		// パラメータログを出力する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.FALSE.toString());
 
+		if (SqlKind.NONE.equals(sqlContext.getSqlKind())) {
+			sqlContext.setSqlKind(SqlKind.UPDATE);
+		}
+
 		// コンテキスト変換
 		transformContext(sqlContext, false);
 
@@ -364,6 +372,10 @@ public class SqlAgentImpl extends AbstractAgent {
 	public int[] batch(final SqlContext sqlContext) throws SQLException {
 		// バッチ処理の場合大量のログが出力されるため、パラメータログの出力を抑止する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.TRUE.toString());
+
+		if (SqlKind.NONE.equals(sqlContext.getSqlKind())) {
+			sqlContext.setSqlKind(SqlKind.BATCH_INSERT);
+		}
 
 		// コンテキスト変換
 		transformContext(sqlContext, false);
@@ -493,6 +505,10 @@ public class SqlAgentImpl extends AbstractAgent {
 
 		// procedureやfunctionの場合、SQL文法エラーになるためバインドパラメータコメントを出力しない
 		sqlContext.contextAttrs().put(CTX_ATTR_KEY_OUTPUT_BIND_COMMENT, false);
+
+		if (SqlKind.NONE.equals(sqlContext.getSqlKind())) {
+			sqlContext.setSqlKind(SqlKind.PROCEDURE);
+		}
 
 		// コンテキスト変換
 		transformContext(sqlContext, false);

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -141,7 +141,7 @@ public class SqlContextImpl implements SqlContext {
 	private int resultSetConcurrency = ResultSet.CONCUR_READ_ONLY;
 
 	/** 実行するSQLの種別 */
-	private SqlKind sqlKind = SqlKind.SELECT;
+	private SqlKind sqlKind = SqlKind.NONE;
 
 	/** 自動採番するキーカラム名の配列 */
 	private String[] generatedKeyColumns;

--- a/src/main/java/jp/co/future/uroborosql/enums/SqlKind.java
+++ b/src/main/java/jp/co/future/uroborosql/enums/SqlKind.java
@@ -22,6 +22,8 @@ public enum SqlKind {
 	BATCH_INSERT,
 	/** BULK_INSERT */
 	BULK_INSERT,
+	/** PROCEDURE */
+	PROCEDURE,
 	/** NONE */
 	NONE,
 }

--- a/src/main/java/jp/co/future/uroborosql/exception/UroborosqlTransactionException.java
+++ b/src/main/java/jp/co/future/uroborosql/exception/UroborosqlTransactionException.java
@@ -1,0 +1,27 @@
+package jp.co.future.uroborosql.exception;
+
+/**
+ * トランザクションに関連する実行時例外クラス
+ *
+ * @author H.Sugimoto
+ * @since v0.14.0
+ */
+public class UroborosqlTransactionException extends UroborosqlRuntimeException {
+
+	public UroborosqlTransactionException() {
+		super();
+	}
+
+	public UroborosqlTransactionException(final String message) {
+		super(message);
+	}
+
+	public UroborosqlTransactionException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public UroborosqlTransactionException(final Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -14,9 +14,8 @@ import java.util.Deque;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.filter.SqlFilterManager;
 
 /**
  * ローカルトランザクションマネージャ
@@ -24,11 +23,8 @@ import jp.co.future.uroborosql.filter.SqlFilterManager;
  * @author ota
  */
 public class LocalTransactionManager implements TransactionManager {
-	/** コネクション供給クラス */
-	private final ConnectionSupplier connectionSupplier;
-
-	/** SQLフィルタ管理クラス */
-	private final SqlFilterManager sqlFilterManager;
+	/** SQL設定クラス */
+	private final SqlConfig sqlConfig;
 
 	/** トランザクションコンテキストのスタック */
 	private final Deque<LocalTransactionContext> txCtxStack = new ConcurrentLinkedDeque<>();
@@ -36,17 +32,16 @@ public class LocalTransactionManager implements TransactionManager {
 	/** トランザクション管理外の接続に利用する便宜上のトランザクション */
 	private Optional<LocalTransactionContext> unmanagedTransaction = Optional.empty();
 
+	private final boolean updatable;
+
 	/**
 	 * コンストラクタ
 	 *
-	 * @param connectionSupplier コネクション供給クラス
-	 * @param sqlFilterManager SQLフィルタ管理クラス
+	 * @param sqlConfig SQL設定クラス
 	 */
-	public LocalTransactionManager(final ConnectionSupplier connectionSupplier,
-			final SqlFilterManager sqlFilterManager) {
-		this.connectionSupplier = connectionSupplier;
-		this.sqlFilterManager = sqlFilterManager;
-
+	public LocalTransactionManager(final SqlConfig sqlConfig) {
+		this.sqlConfig = sqlConfig;
+		this.updatable = !sqlConfig.getSqlAgentFactory().isOnlyUpdatableWithinTransaction();
 	}
 
 	/**
@@ -192,7 +187,7 @@ public class LocalTransactionManager implements TransactionManager {
 			} else {
 				if (!this.unmanagedTransaction.isPresent()) {
 					this.unmanagedTransaction = Optional
-							.of(new LocalTransactionContext(this.connectionSupplier, this.sqlFilterManager));
+							.of(new LocalTransactionContext(this.sqlConfig, this.updatable));
 				}
 				return this.unmanagedTransaction.get().getConnection();
 			}
@@ -216,7 +211,7 @@ public class LocalTransactionManager implements TransactionManager {
 			} else {
 				if (!this.unmanagedTransaction.isPresent()) {
 					this.unmanagedTransaction = Optional
-							.of(new LocalTransactionContext(this.connectionSupplier, this.sqlFilterManager));
+							.of(new LocalTransactionContext(this.sqlConfig, this.updatable));
 				}
 				return this.unmanagedTransaction.get().getConnection(alias);
 			}
@@ -239,8 +234,7 @@ public class LocalTransactionManager implements TransactionManager {
 			return txContext.get().getPreparedStatement(sqlContext);
 		} else {
 			if (!this.unmanagedTransaction.isPresent()) {
-				this.unmanagedTransaction = Optional
-						.of(new LocalTransactionContext(this.connectionSupplier, this.sqlFilterManager));
+				this.unmanagedTransaction = Optional.of(new LocalTransactionContext(this.sqlConfig, this.updatable));
 			}
 			return this.unmanagedTransaction.get().getPreparedStatement(sqlContext);
 		}
@@ -259,8 +253,7 @@ public class LocalTransactionManager implements TransactionManager {
 			return txContext.get().getCallableStatement(sqlContext);
 		} else {
 			if (!this.unmanagedTransaction.isPresent()) {
-				this.unmanagedTransaction = Optional
-						.of(new LocalTransactionContext(this.connectionSupplier, this.sqlFilterManager));
+				this.unmanagedTransaction = Optional.of(new LocalTransactionContext(this.sqlConfig, this.updatable));
 			}
 			return this.unmanagedTransaction.get().getCallableStatement(sqlContext);
 		}
@@ -335,8 +328,7 @@ public class LocalTransactionManager implements TransactionManager {
 	 * @return 処理の結果
 	 */
 	private <R> R runInNewTx(final SQLSupplier<R> supplier) {
-		try (LocalTransactionContext txContext = new LocalTransactionContext(this.connectionSupplier,
-				this.sqlFilterManager)) {
+		try (LocalTransactionContext txContext = new LocalTransactionContext(this.sqlConfig, true)) {
 			this.txCtxStack.push(txContext);
 			try {
 				return supplier.get();

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -41,7 +41,7 @@ public class LocalTransactionManager implements TransactionManager {
 	 */
 	public LocalTransactionManager(final SqlConfig sqlConfig) {
 		this.sqlConfig = sqlConfig;
-		this.updatable = !sqlConfig.getSqlAgentFactory().isOnlyUpdatableWithinTransaction();
+		this.updatable = !sqlConfig.getSqlAgentFactory().isForceUpdateWithinTransaction();
 	}
 
 	/**

--- a/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
@@ -386,7 +386,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testSelectWithinTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -398,7 +398,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testSelectWithinNewTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.requiresNew(() -> {
@@ -410,7 +410,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testSelectWithinNotSupportedTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.notSupported(() -> {
@@ -422,7 +422,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testSelectWithoutTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			select(agent);
@@ -432,7 +432,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testInsertWithinTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -462,7 +462,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testInsertWithinNewTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.requiresNew(() -> {
@@ -492,7 +492,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testInsertWithinNotSupportedTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.notSupported(() -> {
@@ -558,7 +558,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testInsertWithoutTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			try {
@@ -622,7 +622,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testUpdateWithinTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -637,7 +637,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testUpdateWithinNewTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -654,7 +654,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testUpdateWithinNotSupportedTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -685,7 +685,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testUpdateWithoutTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -714,7 +714,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testDeleteWithinTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -731,7 +731,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testDeleteWithinNewTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -750,7 +750,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testDeleteWithinNotSupportedTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -799,7 +799,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testDeleteWithoutTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -846,7 +846,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testCallStoredFunctionWithinTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -870,7 +870,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testCallStoredFunctionWithinNewTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -896,7 +896,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testCallStoredFunctionWithinNotSupportedTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
@@ -924,7 +924,7 @@ public class LocalTxManagerTest {
 
 	@Test
 	public void testCallStoredFunctionWithoutTransaction() {
-		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+		config.getSqlAgentFactory().setForceUpdateWithinTransaction(true);
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {

--- a/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
@@ -1,20 +1,29 @@
 package jp.co.future.uroborosql.tx;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.junit.Assert.*;
 
+import java.sql.JDBCType;
+import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import jp.co.future.uroborosql.exception.UroborosqlTransactionException;
+import jp.co.future.uroborosql.mapping.annotations.Table;
 
 public class LocalTxManagerTest {
 	/**
@@ -26,12 +35,48 @@ public class LocalTxManagerTest {
 	public void setUp() {
 		config = UroboroSQL.builder("jdbc:h2:mem:LocalTxManagerTest;DB_CLOSE_DELAY=-1", "sa", null).build();
 		try (SqlAgent agent = config.agent()) {
-			agent.updateWith("create table if not exists emp ( \n id VARCHAR(30) \n )").count();
+			agent.updateWith("create table if not exists emp ( id integer, name VARCHAR(30), PRIMARY KEY (id) )")
+					.count();
 
 			agent.required(() -> {
-				del(agent);
+				del(agent, -1);
 			});
 		}
+	}
+
+	@Table(name = "emp")
+	public static class Emp {
+		private int id;
+		private String name;
+
+		public Emp() {
+		}
+
+		public Emp(final int id) {
+			this.id = id;
+		}
+
+		public Emp(final int id, final String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(final int id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
 	}
 
 	@After
@@ -45,7 +90,7 @@ public class LocalTxManagerTest {
 			agent.required(() -> {
 				//トランザクション開始
 
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 
 				//トランザクション終了 commit
 			});
@@ -54,7 +99,7 @@ public class LocalTxManagerTest {
 			agent.required(() -> {
 				//トランザクション開始
 
-				del(agent);
+				del(agent, 1);
 
 				//トランザクション終了 commit
 			});
@@ -69,14 +114,14 @@ public class LocalTxManagerTest {
 			agent.required(() -> {
 				//トランザクション開始
 
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 
 				assertThat(select(agent), is(Arrays.asList("ABC")));
 
 				agent.requiresNew(() -> {
 					//新しい トランザクション開始
 
-					ins(agent, "DEF");
+					ins(agent, 2, "DEF");
 
 					//上で登録した"ABC"は別Connectionのため入らない
 					assertThat(select(agent), is(Arrays.asList("DEF")));
@@ -99,7 +144,7 @@ public class LocalTxManagerTest {
 			agent.required(() -> {
 				//トランザクション開始
 
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 
 				agent.setRollbackOnly();//ロールバックを指示
 
@@ -121,7 +166,7 @@ public class LocalTxManagerTest {
 				agent.required(() -> {
 					//トランザクション開始
 
-					ins(agent, "ABC");
+					ins(agent, 1, "ABC");
 
 					//エラーが起こった場合、ロールバックされる
 					throw new IllegalArgumentException();//トランザクション終了 rollback
@@ -140,10 +185,10 @@ public class LocalTxManagerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				ins(agent, "A");
-				ins(agent, "B");
+				ins(agent, 1, "A");
+				ins(agent, 2, "B");
 				agent.setSavepoint("sp");
-				ins(agent, "C");
+				ins(agent, 3, "C");
 
 				assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
 
@@ -160,14 +205,14 @@ public class LocalTxManagerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 
 				assertThat(select(agent), is(Arrays.asList("ABC")));
 
 				assertThat(agent.required(() -> {
 					//同Connection
-						return select(agent);
-					}), is(Arrays.asList("ABC")));
+					return select(agent);
+				}), is(Arrays.asList("ABC")));
 
 				agent.requiresNew(() -> {
 					//別Connection
@@ -176,8 +221,8 @@ public class LocalTxManagerTest {
 
 				assertThat(agent.requiresNew(() -> {
 					//別Connection
-						return select(agent);
-					}), is(Arrays.asList()));
+					return select(agent);
+				}), is(Arrays.asList()));
 
 				agent.notSupported(() -> {
 					//別Connection
@@ -186,8 +231,8 @@ public class LocalTxManagerTest {
 
 				assertThat(agent.notSupported(() -> {
 					//別Connection
-						return select(agent);
-					}), is(Arrays.asList()));
+					return select(agent);
+				}), is(Arrays.asList()));
 			});
 		}
 	}
@@ -197,13 +242,13 @@ public class LocalTxManagerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 			});//commit
 			assertThat(select(agent), is(Arrays.asList("ABC")));
 
 			agent.required(() -> {
 				agent.notSupported(() -> {
-					ins(agent, "DEF");
+					ins(agent, 2, "DEF");
 				});//commitされないはず
 
 				assertThat(select(agent), is(Arrays.asList("ABC")));
@@ -216,14 +261,14 @@ public class LocalTxManagerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				ins(agent, "ABC");
+				ins(agent, 1, "ABC");
 				agent.setRollbackOnly();//ロールバックを予約
 			});
 			assertThat(select(agent), is(Arrays.asList()));
 
 			try {
 				agent.required(() -> {
-					ins(agent, "ABC");
+					ins(agent, 1, "ABC");
 					throw new UroborosqlRuntimeException();//エラーのためロールバック
 				});
 			} catch (UroborosqlRuntimeException e) {
@@ -238,11 +283,11 @@ public class LocalTxManagerTest {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
 				agent.setSavepoint("X");
-				ins(agent, "A");
+				ins(agent, 1, "A");
 				agent.setSavepoint("A");
-				ins(agent, "B");
+				ins(agent, 2, "B");
 				agent.setSavepoint("B");
-				ins(agent, "C");
+				ins(agent, 3, "C");
 				agent.setSavepoint("C");
 
 				assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
@@ -257,9 +302,9 @@ public class LocalTxManagerTest {
 
 			agent.required(() -> {
 				agent.setSavepoint("X");
-				ins(agent, "B");
+				ins(agent, 2, "B");
 				agent.setSavepoint("B");
-				ins(agent, "C");
+				ins(agent, 3, "C");
 				agent.setSavepoint("C");
 
 				assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
@@ -270,9 +315,9 @@ public class LocalTxManagerTest {
 
 				agent.releaseSavepoint("B");
 
-				ins(agent, "B");
+				ins(agent, 2, "B");
 				agent.setSavepoint("B");
-				ins(agent, "C");
+				ins(agent, 3, "C");
 				agent.setSavepoint("C");
 
 				agent.rollback("B");
@@ -289,10 +334,10 @@ public class LocalTxManagerTest {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
 				agent.notSupported(() -> {
-					ins(agent, "ABC");
+					ins(agent, 1, "ABC");
 				});
 				agent.notSupported(() -> {
-					ins(agent, "DEF");
+					ins(agent, 2, "DEF");
 					agent.commit();//明示的にcommit
 					//notSupportedは常に同じConnectionが利用されている
 				});
@@ -301,7 +346,7 @@ public class LocalTxManagerTest {
 			});
 
 			agent.required(() -> {
-				ins(agent, "GHI");
+				ins(agent, 3, "GHI");
 				agent.commit();//Commit
 
 				agent.requiresNew(() -> {
@@ -318,8 +363,8 @@ public class LocalTxManagerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				ins(agent, "ABC");
-				ins(agent, "DEF");
+				ins(agent, 1, "ABC");
+				ins(agent, 2, "DEF");
 
 				assertThat(select(agent), is(Arrays.asList("ABC", "DEF")));
 
@@ -328,8 +373,8 @@ public class LocalTxManagerTest {
 				assertThat(select(agent), is(Arrays.asList()));
 			});
 
-			ins(agent, "ABC");
-			ins(agent, "DEF");
+			ins(agent, 1, "ABC");
+			ins(agent, 2, "DEF");
 
 			assertThat(select(agent), is(Arrays.asList("ABC", "DEF")));
 
@@ -339,16 +384,594 @@ public class LocalTxManagerTest {
 		}
 	}
 
-	private void ins(final SqlAgent agent, final String id) {
-		agent.updateWith("insert into emp (id) values (/*id*/'A')").param("id", id).count();
+	@Test
+	public void testSelectWithinTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				select(agent);
+				assertThat(agent.query(Emp.class).collect().size(), is(0));
+			});
+		}
 	}
 
-	private void del(final SqlAgent agent) {
-		agent.updateWith("delete from emp").count();
+	@Test
+	public void testSelectWithinNewTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.requiresNew(() -> {
+				select(agent);
+				assertThat(agent.query(Emp.class).collect().size(), is(0));
+			});
+		}
+	}
+
+	@Test
+	public void testSelectWithinNotSupportedTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.notSupported(() -> {
+				select(agent);
+				assertThat(agent.query(Emp.class).collect().size(), is(0));
+			});
+		}
+	}
+
+	@Test
+	public void testSelectWithoutTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			select(agent);
+			assertThat(agent.query(Emp.class).collect().size(), is(0));
+		}
+	}
+
+	@Test
+	public void testInsertWithinTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ins(agent, 1, "ABC");
+
+				Emp emp = new Emp();
+				emp.setId(2);
+				emp.setName("DEF");
+				agent.insert(emp);
+
+				agent.batchWith("insert into emp (id, name) values (/*id*/, /*name*/)")
+						.paramStream(IntStream.range(10, 20).mapToObj(i -> {
+							Map<String, Object> map = new HashMap<>();
+							map.put("id", i);
+							map.put("name", "name" + String.valueOf(i));
+							return map;
+						})).count();
+
+				agent.inserts(IntStream.range(21, 30).mapToObj(i -> new Emp(i, "name" + i)),
+						InsertsType.BATCH);
+
+				agent.inserts(IntStream.range(31, 40).mapToObj(i -> new Emp(i, "name" + i)),
+						InsertsType.BULK);
+			});
+		}
+	}
+
+	@Test
+	public void testInsertWithinNewTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.requiresNew(() -> {
+				ins(agent, 1, "ABC");
+
+				Emp emp = new Emp();
+				emp.setId(2);
+				emp.setName("DEF");
+				agent.insert(emp);
+
+				agent.batchWith("insert into emp (id, name) values (/*id*/, /*name*/)")
+						.paramStream(IntStream.range(10, 20).mapToObj(i -> {
+							Map<String, Object> map = new HashMap<>();
+							map.put("id", i);
+							map.put("name", "name" + String.valueOf(i));
+							return map;
+						})).count();
+
+				agent.inserts(IntStream.range(21, 30).mapToObj(i -> new Emp(i, "name" + i)),
+						InsertsType.BATCH);
+
+				agent.inserts(IntStream.range(31, 40).mapToObj(i -> new Emp(i, "name" + i)),
+						InsertsType.BULK);
+			});
+		}
+	}
+
+	@Test
+	public void testInsertWithinNotSupportedTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.notSupported(() -> {
+				try {
+					ins(agent, 1, "ABC");
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					Emp emp = new Emp();
+					emp.setId(2);
+					emp.setName("DEF");
+					agent.insert(emp);
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.batchWith("insert into emp (id, name) values (/*id*/, /*name*/)")
+							.paramStream(IntStream.range(10, 20).mapToObj(i -> {
+								Map<String, Object> map = new HashMap<>();
+								map.put("id", i);
+								map.put("name", "name" + i);
+								return map;
+							}))
+							.errorWhen((agt, ctx, ex) -> {
+								throw (UroborosqlTransactionException) ex;
+							}).count();
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BATCH);
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testInsertWithoutTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			try {
+				ins(agent, 1, "ABC");
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				Emp emp = new Emp();
+				emp.setId(2);
+				emp.setName("DEF");
+				agent.insert(emp);
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.batchWith("insert into emp (id, name) values (/*id*/, /*name*/)")
+						.paramStream(IntStream.range(10, 20).mapToObj(i -> {
+							Map<String, Object> map = new HashMap<>();
+							map.put("id", i);
+							map.put("name", "name" + i);
+							return map;
+						}))
+						.errorWhen((agt, ctx, ex) -> {
+							throw (UroborosqlTransactionException) ex;
+						}).count();
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BATCH);
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+		}
+	}
+
+	@Test
+	public void testUpdateWithinTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+
+				assertThat(upd(agent, 1, "abc"), is(1));
+
+				assertThat(agent.update(new Emp(2, "def")), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateWithinNewTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			agent.requiresNew(() -> {
+				assertThat(upd(agent, 1, "abc"), is(1));
+
+				assertThat(agent.update(new Emp(2, "def")), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateWithinNotSupportedTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			agent.notSupported(() -> {
+				try {
+					upd(agent, 1, "abc");
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.update(new Emp(2, "def"));
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateWithoutTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			try {
+				upd(agent, 1, "abc");
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.update(new Emp(2, "def"));
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+		}
+	}
+
+	@Test
+	public void testDeleteWithinTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+
+				assertThat(del(agent, 1), is(1));
+
+				assertThat(agent.delete(new Emp(2)), is(1));
+				assertThat(agent.delete(Emp.class, 3), is(1));
+				assertThat(agent.delete(Emp.class).equal("name", "name4").count(), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteWithinNewTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			agent.requiresNew(() -> {
+				assertThat(del(agent, 1), is(1));
+
+				assertThat(agent.delete(new Emp(2)), is(1));
+				assertThat(agent.delete(Emp.class, 3), is(1));
+				assertThat(agent.delete(Emp.class).equal("name", "name4").count(), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteWithinNotSupportedTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			agent.notSupported(() -> {
+				try {
+					del(agent, 1);
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.delete(new Emp(2));
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.delete(Emp.class, 3);
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+
+				try {
+					agent.delete(Emp.class).equal("name", "name4").count();
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (Throwable th) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteWithoutTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.inserts(IntStream.range(1, 10).mapToObj(i -> new Emp(i, "name" + i)), InsertsType.BULK);
+			});
+
+			try {
+				del(agent, 1);
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.delete(new Emp(2));
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.delete(Emp.class, 3);
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+
+			try {
+				agent.delete(Emp.class).equal("name", "name4").count();
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (Throwable th) {
+				Assert.fail();
+			}
+		}
+	}
+
+	@Test
+	public void testCallStoredFunctionWithinTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.updateWith("DROP ALIAS IF EXISTS MYFUNCTION").count();
+				agent.updateWith("CREATE ALIAS MYFUNCTION AS $$\r\n" +
+						"String toUpperCase(String lower) throws Exception {\r\n" +
+						"    return lower.toUpperCase();\r\n" +
+						"}\r\n" +
+						"$$;").count();
+
+				try {
+					Map<String, Object> ans = agent.procWith("{/*ret*/ = call MYFUNCTION(/*param1*/)}")
+							.outParam("ret", JDBCType.VARCHAR).param("param1", "test1").call();
+					assertThat(ans.get("ret"), is("TEST1"));
+				} catch (SQLException ex) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testCallStoredFunctionWithinNewTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.updateWith("DROP ALIAS IF EXISTS MYFUNCTION").count();
+				agent.updateWith("CREATE ALIAS MYFUNCTION AS $$\r\n" +
+						"String toUpperCase(String lower) throws Exception {\r\n" +
+						"    return lower.toUpperCase();\r\n" +
+						"}\r\n" +
+						"$$;").count();
+			});
+
+			agent.requiresNew(() -> {
+				try {
+					Map<String, Object> ans = agent.procWith("{/*ret*/ = call MYFUNCTION(/*param1*/)}")
+							.outParam("ret", JDBCType.VARCHAR).param("param1", "test1").call();
+					assertThat(ans.get("ret"), is("TEST1"));
+				} catch (SQLException ex) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testCallStoredFunctionWithinNotSupportedTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.updateWith("DROP ALIAS IF EXISTS MYFUNCTION").count();
+				agent.updateWith("CREATE ALIAS MYFUNCTION AS $$\r\n" +
+						"String toUpperCase(String lower) throws Exception {\r\n" +
+						"    return lower.toUpperCase();\r\n" +
+						"}\r\n" +
+						"$$;").count();
+			});
+
+			agent.notSupported(() -> {
+				try {
+					agent.procWith("{/*ret*/ = call MYFUNCTION(/*param1*/)}")
+							.outParam("ret", JDBCType.VARCHAR).param("param1", "test1").call();
+					Assert.fail();
+				} catch (UroborosqlTransactionException ex) {
+					// OK
+				} catch (SQLException ex) {
+					Assert.fail();
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testCallStoredFunctionWithoutTransaction() {
+		config.getSqlAgentFactory().setOnlyUpdatableWithinTransaction(true);
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				agent.updateWith("DROP ALIAS IF EXISTS MYFUNCTION").count();
+				agent.updateWith("CREATE ALIAS MYFUNCTION AS $$\r\n" +
+						"String toUpperCase(String lower) throws Exception {\r\n" +
+						"    return lower.toUpperCase();\r\n" +
+						"}\r\n" +
+						"$$;").count();
+			});
+
+			try {
+				agent.procWith("{/*ret*/ = call MYFUNCTION(/*param1*/)}")
+						.outParam("ret", JDBCType.VARCHAR).param("param1", "test1").call();
+				Assert.fail();
+			} catch (UroborosqlTransactionException ex) {
+				// OK
+			} catch (SQLException ex) {
+				Assert.fail();
+			}
+		}
+	}
+
+	private int ins(final SqlAgent agent, final int id, final String name) {
+		return agent.updateWith("insert into emp (id, name) values (/*id*/0, /*name*/'A')")
+				.param("id", id)
+				.param("name", name)
+				.count();
+	}
+
+	private int upd(final SqlAgent agent, final int id, final String name) {
+		return agent.updateWith("update emp set name = /*name*/ where id = /*id*/")
+				.param("id", id)
+				.param("name", name)
+				.count();
+	}
+
+	private int del(final SqlAgent agent, final int id) {
+		return agent.updateWith("delete from emp where 1 = 1 /*IF id >= 0*/ and id = /*id*/0/*END*/")
+				.param("id", id)
+				.count();
 	}
 
 	private List<String> select(final SqlAgent agent) {
-		return agent.queryWith("select id from emp order by id").stream().map(m -> m.get("ID").toString())
+		return agent.queryWith("select name from emp order by id")
+				.stream()
+				.map(m -> m.get("NAME").toString())
 				.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
fixed #202 

Added onlyUpdatableWithinTransaction option to SqlAgentFactory.  
If onlyUpdatableWithinTransaction option is set to true (default false),  
UroborosqlTransactionException is thrown when insert / update / delete / procedure is executed when transaction is not started.