### PR TITLE
add LIKE escape char replace string.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -29,8 +29,8 @@ import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.coverage.CoverageData;
 import jp.co.future.uroborosql.coverage.CoverageHandler;
-import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.exception.EntitySqlRuntimeException;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
@@ -82,6 +82,9 @@ public abstract class AbstractAgent implements SqlAgent {
 
 	/** カバレッジハンドラ */
 	private static AtomicReference<CoverageHandler> coverageHandlerRef = new AtomicReference<>();
+
+	/** LIKE句のエスケープ文字置換文字列名 */
+	protected static final String ESC_CHAR = "ESC_CHAR";
 
 	/** SQL設定管理クラス */
 	protected SqlConfig sqlConfig;
@@ -263,6 +266,7 @@ public abstract class AbstractAgent implements SqlAgent {
 		if (sqlContext.getParam(StringFunction.SHORT_NAME) == null) {
 			sqlContext.param(StringFunction.SHORT_NAME, getSqlConfig().getDialect().getExpressionFunction());
 		}
+		sqlContext.param(ESC_CHAR, getSqlConfig().getDialect().getEscapeChar());
 
 		// 自動パラメータバインド関数の呼出
 		if (sqlContext.batchCount() == 0) {

--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -83,9 +83,6 @@ public abstract class AbstractAgent implements SqlAgent {
 	/** カバレッジハンドラ */
 	private static AtomicReference<CoverageHandler> coverageHandlerRef = new AtomicReference<>();
 
-	/** LIKE句のエスケープ文字置換文字列名 */
-	protected static final String ESC_CHAR = "ESC_CHAR";
-
 	/** SQL設定管理クラス */
 	protected SqlConfig sqlConfig;
 
@@ -266,7 +263,8 @@ public abstract class AbstractAgent implements SqlAgent {
 		if (sqlContext.getParam(StringFunction.SHORT_NAME) == null) {
 			sqlContext.param(StringFunction.SHORT_NAME, getSqlConfig().getDialect().getExpressionFunction());
 		}
-		sqlContext.param(ESC_CHAR, getSqlConfig().getDialect().getEscapeChar());
+		sqlContext.param(AbstractExtractionCondition.PARAM_KEY_ESCAPE_CHAR,
+				getSqlConfig().getDialect().getEscapeChar());
 
 		// 自動パラメータバインド関数の呼出
 		if (sqlContext.batchCount() == 0) {

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -217,6 +217,22 @@ public class SqlAgentTest {
 	}
 
 	/**
+	 * LIKE句によるクエリ実行処理のテストケース。
+	 */
+	@Test
+	public void testQueryWithLikeClause() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		List<Map<String, Object>> result = agent.queryWith(
+				"select * from product where product_name like /*SF.contains(product_name)*/ escape /*#ESC_CHAR*/")
+				.param("product_name", "商品")
+				.collect();
+
+		assertThat(result.size(), is(2));
+	}
+
+	/**
 	 * クエリ実行処理のテストケース。
 	 */
 	@Test
@@ -708,7 +724,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 		try {
-			Product product = agent.query("example/select_product")
+			agent.query("example/select_product")
 					.paramList("product_id", 0, 1, 2, 3)
 					.one(Product.class);
 			assertTrue(false);


### PR DESCRIPTION
fixed #204 

Added `ESC_CHAR` as escape character replacement string.

example
```sql
select
  *
from product
where
  product_name like /*SF.contains(product_name)*/ escape /*#ESC_CHAR*/
```
