### PR TITLE
add SqlEntityQuery#forUpdate method.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -81,6 +81,12 @@ public interface SqlAgentFactory {
 	String PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION = "forceUpdateWithinTransaction";
 
 	/**
+	 * プロパティ:明示的な行ロック時の待機時間(s)デフォルト値<br>
+	 * デフォルトは<code>10</code>
+	 */
+	String PROPS_KEY_DEFAULT_FOR_UPDATE_WAIT_SECONDS = "defaultForUpdateWaitSeconds";
+
+	/**
 	 * SQL実行クラス生成。
 	 *
 	 * @return SqlAgent
@@ -273,4 +279,20 @@ public interface SqlAgentFactory {
 	 * @return SqlAgentFactory
 	 */
 	SqlAgentFactory setForceUpdateWithinTransaction(boolean forceUpdateWithinTransaction);
+
+	/**
+	 * 明示的な行ロック時の待機時間(s)デフォルト値を取得します
+	 *
+	 * @return 明示的な行ロック時の待機時間(s)デフォルト値
+	 */
+	int getDefaultForUpdateWaitSeconds();
+
+	/**
+	 * 明示的な行ロック時の待機時間(s)デフォルト値を設定する
+	 *
+	 * @param defaultForUpdateWaitSeconds 明示的な行ロック時の待機時間(s)デフォルト値
+	 * @return SqlAgentFactory
+	 */
+	SqlAgentFactory setDefaultForUpdateWaitSeconds(final int defaultForUpdateWaitSeconds);
+
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -346,4 +346,25 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 		return defaultProps;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#getDefaultForUpdateWaitSeconds()
+	 */
+	@Override
+	public int getDefaultForUpdateWaitSeconds() {
+		return Integer.parseInt(getDefaultProps().getOrDefault(PROPS_KEY_DEFAULT_FOR_UPDATE_WAIT_SECONDS, "10"));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#setDefaultForUpdateWaitSeconds(int)
+	 */
+	@Override
+	public SqlAgentFactory setDefaultForUpdateWaitSeconds(final int defaultForUpdateWaitSeconds) {
+		getDefaultProps().put(PROPS_KEY_DEFAULT_FOR_UPDATE_WAIT_SECONDS, String.valueOf(defaultForUpdateWaitSeconds));
+		return this;
+	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/AbstractDialect.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jp.co.future.uroborosql.enums.ForUpdateType;
 import jp.co.future.uroborosql.mapping.JavaType;
 import jp.co.future.uroborosql.utils.StringFunction;
 
@@ -215,5 +216,23 @@ public abstract class AbstractDialect implements Dialect {
 	@Override
 	public char getEscapeChar() {
 		return escapeChar;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#addForUpdateClause(java.lang.StringBuilder, jp.co.future.uroborosql.enums.ForUpdateType, int)
+	 */
+	@Override
+	public StringBuilder addForUpdateClause(final StringBuilder sql, final ForUpdateType forUpdateType,
+			final int waitSeconds) {
+		switch (forUpdateType) {
+		case WAIT:
+			return new StringBuilder().append(sql.toString()).append("FOR UPDATE WAIT ").append(waitSeconds);
+		case NOWAIT:
+			return new StringBuilder().append(sql.toString()).append("FOR UPDATE NOWAIT");
+		default:
+			return new StringBuilder().append(sql.toString()).append("FOR UPDATE");
+		}
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/DefaultDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/DefaultDialect.java
@@ -45,6 +45,16 @@ public class DefaultDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateWait()
+	 */
+	@Override
+	public boolean supportsForUpdateWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#accept(jp.co.future.uroborosql.connection.ConnectionSupplier)
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -9,6 +9,7 @@ package jp.co.future.uroborosql.dialect;
 import java.sql.SQLType;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 import jp.co.future.uroborosql.mapping.JavaType;
 import jp.co.future.uroborosql.utils.StringFunction;
 
@@ -98,6 +99,30 @@ public interface Dialect {
 		return true;
 	}
 
+	/**
+	 * 明示的な行ロックをサポートしているか
+	 * @return 明示的な行ロックをサポートしている場合<code>true</code>
+	 */
+	default boolean supportsForUpdate() {
+		return true;
+	}
+
+	/**
+	 * 明示的な行ロック（待機なし）をサポートしているか
+	 * @return 明示的な行ロック（待機なし）をサポートしている場合<code>true</code>
+	 */
+	default boolean supportsForUpdateNoWait() {
+		return true;
+	}
+
+	/**
+	 * 明示的な行ロック（待機あり）をサポートしているか
+	 * @return 明示的な行ロック（待機あり）をサポートしている場合<code>true</code>
+	 */
+	default boolean supportsForUpdateWait() {
+		return true;
+	}
+
 	String getSequenceNextValSql(String sequenceName);
 
 	/**
@@ -149,4 +174,13 @@ public interface Dialect {
 	 */
 	char getEscapeChar();
 
+	/**
+	 * FOR UPDATE句の文字列をSQLに追加する
+	 *
+	 * @param sql 追加対象のSQL文
+	 * @param forUpdateType forUpdateのタイプ
+	 * @param waitSeconds 待機時間
+	 * @return FOR UPDATE句を追加したSQL文
+	 */
+	StringBuilder addForUpdateClause(StringBuilder sql, ForUpdateType forUpdateType, int waitSeconds);
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
@@ -62,10 +62,31 @@ public class H2Dialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateNoWait()
+	 */
+	@Override
+	public boolean supportsForUpdateNoWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateWait()
+	 */
+	@Override
+	public boolean supportsForUpdateWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#getSequenceNextValSql(java.lang.String)
 	 */
 	@Override
 	public String getSequenceNextValSql(final String sequenceName) {
 		return "nextval('" + sequenceName + "')";
 	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
@@ -6,6 +6,8 @@
  */
 package jp.co.future.uroborosql.dialect;
 
+import jp.co.future.uroborosql.enums.ForUpdateType;
+
 /**
  * Microsoft SQLServer用のDialect
  *
@@ -56,10 +58,40 @@ public class MsSqlDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateWait()
+	 */
+	@Override
+	public boolean supportsForUpdateWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#getSequenceNextValSql(java.lang.String)
 	 */
 	@Override
 	public String getSequenceNextValSql(final String sequenceName) {
 		return "next value for " + sequenceName;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#addForUpdateClause(java.lang.StringBuilder, jp.co.future.uroborosql.enums.ForUpdateType, int)
+	 */
+	@Override
+	public StringBuilder addForUpdateClause(final StringBuilder sql, final ForUpdateType forUpdateType,
+			final int waitSeconds) {
+		StringBuilder forUpdate = new StringBuilder("$1 WITH (UPDLOCK, ROWLOCK");
+		if (forUpdateType == ForUpdateType.NORMAL) {
+			forUpdate.append(") ");
+		} else if (forUpdateType == ForUpdateType.NOWAIT) {
+			forUpdate.append(", NOWAIT) ");
+		}
+
+		String origSql = sql.toString();
+		return new StringBuilder(origSql.replaceFirst("((FROM|from)\\s+\\w+)\\s+", forUpdate.toString()));
+
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
@@ -64,10 +64,21 @@ public class MySqlDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateWait()
+	 */
+	@Override
+	public boolean supportsForUpdateWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#getSequenceNextValSql(java.lang.String)
 	 */
 	@Override
 	public String getSequenceNextValSql(final String sequenceName) {
 		throw new UroborosqlRuntimeException("MySql does not support Sequence.");
 	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
@@ -77,6 +77,16 @@ public class PostgresqlDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsForUpdateWait()
+	 */
+	@Override
+	public boolean supportsForUpdateWait() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.AbstractDialect#getJavaType(java.sql.SQLType, java.lang.String)
 	 */
 	@Override
@@ -109,5 +119,4 @@ public class PostgresqlDialect extends AbstractDialect {
 	public String getSequenceNextValSql(final String sequenceName) {
 		return "nextval('" + sequenceName + "')";
 	}
-
 }

--- a/src/main/java/jp/co/future/uroborosql/enums/ForUpdateType.java
+++ b/src/main/java/jp/co/future/uroborosql/enums/ForUpdateType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.enums;
+
+/**
+ * SELECT FOR UPDATEのオプションを表す列挙型
+ *
+ * @author H.Sugimoto
+ * @since v0.14.0
+ */
+public enum ForUpdateType {
+	/** 標準 */
+	NORMAL,
+	/** 待機 */
+	WAIT,
+	/** 待機しない */
+	NOWAIT;
+}

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.SqlAgentFactory;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 
 /**
@@ -172,4 +173,35 @@ public interface SqlEntityQuery<E> extends ExtractionCondition<SqlEntityQuery<E>
 	 * @return SqlEntityQuery
 	 */
 	SqlEntityQuery<E> offset(long offset);
+
+	/**
+	 * 明示的な行ロックを行う
+	 *
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> forUpdate();
+
+	/**
+	 * 明示的な行ロックを行う（待機なし）
+	 *
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> forUpdateNoWait();
+
+	/**
+	 * 明示的な行ロックを行う（待機時間指定）<br>
+	 * 待機時間は{@link SqlAgentFactory#setDefaultForUpdateWaitSeconds(int)}で設定した値を使用する
+	 *
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> forUpdateWait();
+
+	/**
+	 * 明示的な行ロックを行う（待機時間指定）
+	 *
+	 * @param waitSeconds 待機時間（秒）
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> forUpdateWait(int waitSeconds);
+
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -16,6 +16,7 @@ import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import jp.co.future.uroborosql.enums.ForUpdateType;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.mapping.JavaType;
 
@@ -77,6 +78,9 @@ public class DefaultDialectTest {
 		assertThat(dialect.supportsSequence(), is(false));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(false));
 	}
 
 	@Test
@@ -225,5 +229,16 @@ public class DefaultDialectTest {
 				JavaType.of(Object.class).getClass());
 		assertEquals(dialect.getJavaType(999, "error type").getClass(),
 				JavaType.of(Object.class).getClass());
+	}
+
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
@@ -12,6 +12,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 
 /**
  * H2Dialectの個別実装部分のテストケース
@@ -83,6 +84,9 @@ public class H2DialectTest {
 		assertThat(dialect.supportsSequence(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(false));
+		assertThat(dialect.supportsForUpdateWait(), is(false));
 	}
 
 	@Test
@@ -91,6 +95,17 @@ public class H2DialectTest {
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 0), is(""));
+	}
+
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -12,6 +12,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 
 /**
  * H2Dialectの個別実装部分のテストケース
@@ -83,6 +84,9 @@ public class MsSqlDialectTest {
 		assertThat(dialect.supportsSequence(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(false));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(false));
 	}
 
 	@Test
@@ -91,6 +95,15 @@ public class MsSqlDialectTest {
 		assertThat(dialect.getLimitClause(0, 5), is("OFFSET 5" + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(3, 0), is("LIMIT 3 " + System.lineSeparator()));
 		assertThat(dialect.getLimitClause(0, 0), is(""));
+	}
+
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WITH (UPDLOCK, ROWLOCK) WHERE 1 = 1 ORDER id" + System.lineSeparator()));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WITH (UPDLOCK, ROWLOCK, NOWAIT) WHERE 1 = 1 ORDER id" + System.lineSeparator()));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
@@ -12,6 +12,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 
 /**
@@ -84,6 +85,9 @@ public class MySqlDialectTest {
 		assertThat(dialect.supportsSequence(), is(false));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(false));
 	}
 
 	@Test
@@ -94,4 +98,14 @@ public class MySqlDialectTest {
 		assertThat(dialect.getLimitClause(0, 0), is(""));
 	}
 
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
@@ -13,6 +13,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 
 /**
  * Oracle10Dialectの個別実装部分のテストケース
@@ -136,5 +137,19 @@ public class Oracle10DialectTest {
 		assertThat(dialect.supportsSequence(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(true));
+	}
+
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -13,6 +13,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 
 /**
  * Oracle10Dialectの個別実装部分のテストケース
@@ -136,5 +137,19 @@ public class Oracle11DialectTest {
 		assertThat(dialect.supportsSequence(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(true));
+	}
+
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
@@ -13,6 +13,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 
 /**
  * Oracle10Dialectの個別実装部分のテストケース
@@ -136,6 +137,9 @@ public class Oracle12DialectTest {
 		assertThat(dialect.supportsSequence(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(false));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(true));
 	}
 
 	@Test
@@ -146,4 +150,14 @@ public class Oracle12DialectTest {
 		assertThat(dialect.getLimitClause(0, 0), is(""));
 	}
 
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
@@ -13,6 +13,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Test;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
+import jp.co.future.uroborosql.enums.ForUpdateType;
 import jp.co.future.uroborosql.mapping.JavaType;
 
 /**
@@ -78,6 +79,9 @@ public class PostgresqlDialectTest {
 		assertThat(dialect.supportsNullValuesOrdering(), is(true));
 		assertThat(dialect.isRemoveTerminator(), is(true));
 		assertThat(dialect.isRollbackToSavepointBeforeRetry(), is(true));
+		assertThat(dialect.supportsForUpdate(), is(true));
+		assertThat(dialect.supportsForUpdateNoWait(), is(true));
+		assertThat(dialect.supportsForUpdateWait(), is(false));
 	}
 
 	@Test
@@ -95,4 +99,14 @@ public class PostgresqlDialectTest {
 		assertEquals(dialect.getJavaType(JDBCType.OTHER, "other").getClass(), JavaType.of(Object.class).getClass());
 	}
 
+	@Test
+	public void testAddForUpdateClause() {
+		StringBuilder sql = new StringBuilder("SELECT * FROM test WHERE 1 = 1 ORDER id").append(System.lineSeparator());
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NORMAL, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.NOWAIT, -1).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE NOWAIT"));
+		assertThat(dialect.addForUpdateClause(sql, ForUpdateType.WAIT, 10).toString(),
+				is("SELECT * FROM test WHERE 1 = 1 ORDER id" + System.lineSeparator() + "FOR UPDATE WAIT 10"));
+	}
 }


### PR DESCRIPTION
fixed #178 

Support pessimistic locking.

```java
SqlEntityQuery<E> forUpdate();  // select for update.
SqlEntityQuery<E> forUpdateNoWait();  // select for update nowait.
SqlEntityQuery<E> forUpdateWait();  // select for update wait. use wait time default. 
SqlEntityQuery<E> forUpdateWait(int waitSeconds);  // select for update wait 10.
```
If the `FOR UPDATE` option (nowait / wait) is not supported by DB, throw UroborosqlRuntimeException.
