### PR TITLE
add paramArray and Setting the type parameter to the param methods.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
@@ -9,6 +9,7 @@ package jp.co.future.uroborosql;
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLType;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -47,49 +48,26 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.lang.Object[])
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramArray(final String paramName, final V... value) {
-		context().paramArray(paramName, value);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.util.function.Supplier)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramArray(final String paramName, final Supplier<V[]> supplier) {
-		context().paramArray(paramName, supplier);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArrayIfAbsent(java.lang.String, java.lang.Object[])
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramArrayIfAbsent(final String paramName, final V... value) {
-		context().paramArrayIfAbsent(paramName, value);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Object[])
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
 	@Deprecated
 	public <V> T paramList(final String paramName, final V... value) {
-		context().paramArray(paramName, value);
+		context().param(paramName, Arrays.asList(value));
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.util.function.Supplier)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	@Deprecated
+	public <V> T paramList(final String paramName, final Supplier<Iterable<V>> supplier) {
+		context().param(paramName, supplier);
 		return (T) this;
 	}
 
@@ -102,43 +80,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	@Override
 	@Deprecated
 	public <V> T paramListIfAbsent(final String paramName, final V... value) {
-		context().paramArrayIfAbsent(paramName, value);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Iterable)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramList(final String paramName, final Iterable<V> value) {
-		context().paramList(paramName, value);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.util.function.Supplier)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramList(final String paramName, final Supplier<Iterable<V>> supplier) {
-		context().paramList(paramName, supplier);
-		return (T) this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(java.lang.String, java.lang.Object[])
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <V> T paramListIfAbsent(final String paramName, final Iterable<V> value) {
-		context().paramListIfAbsent(paramName, value);
+		context().paramIfAbsent(paramName, Arrays.asList(value));
 		return (T) this;
 	}
 

--- a/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
@@ -9,7 +9,6 @@ package jp.co.future.uroborosql;
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLType;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -48,11 +47,73 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.lang.Object[])
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public <V> T paramArray(final String paramName, final V... value) {
+		context().paramArray(paramName, value);
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.util.function.Supplier)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public <V> T paramArray(final String paramName, final Supplier<V[]> supplier) {
+		context().paramArray(paramName, supplier);
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArrayIfAbsent(java.lang.String, java.lang.Object[])
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public <V> T paramArrayIfAbsent(final String paramName, final V... value) {
+		context().paramArrayIfAbsent(paramName, value);
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Object[])
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramList(final String paramName, final Object... value) {
+	@Deprecated
+	public <V> T paramList(final String paramName, final V... value) {
+		context().paramArray(paramName, value);
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(java.lang.String, java.lang.Object[])
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	@Deprecated
+	public <V> T paramListIfAbsent(final String paramName, final V... value) {
+		context().paramArrayIfAbsent(paramName, value);
+		return (T) this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Iterable)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public <V> T paramList(final String paramName, final Iterable<V> value) {
 		context().paramList(paramName, value);
 		return (T) this;
 	}
@@ -60,11 +121,11 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Supplier)
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.util.function.Supplier)
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramList(final String paramName, final Supplier<List<?>> supplier) {
+	public <V> T paramList(final String paramName, final Supplier<Iterable<V>> supplier) {
 		context().paramList(paramName, supplier);
 		return (T) this;
 	}
@@ -76,7 +137,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramListIfAbsent(final String paramName, final Object... value) {
+	public <V> T paramListIfAbsent(final String paramName, final Iterable<V> value) {
 		context().paramListIfAbsent(paramName, value);
 		return (T) this;
 	}
@@ -102,7 +163,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramBean(final Object bean) {
+	public <V> T paramBean(final V bean) {
 		if (bean != null) {
 			BeanAccessor.fields(bean.getClass()).stream()
 					.forEach(f -> param(f.getName(), BeanAccessor.value(f, bean)));
@@ -127,7 +188,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T param(final String paramName, final Object value, final int sqlType) {
+	public <V> T param(final String paramName, final V value, final int sqlType) {
 		context().param(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -139,7 +200,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramIfAbsent(final String paramName, final Object value, final int sqlType) {
+	public <V> T paramIfAbsent(final String paramName, final V value, final int sqlType) {
 		context().paramIfAbsent(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -151,7 +212,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T param(final String paramName, final Object value, final SQLType sqlType) {
+	public <V> T param(final String paramName, final V value, final SQLType sqlType) {
 		context().param(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -163,7 +224,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramIfAbsent(final String paramName, final Object value, final SQLType sqlType) {
+	public <V> T paramIfAbsent(final String paramName, final V value, final SQLType sqlType) {
 		context().paramIfAbsent(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -175,7 +236,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T param(final String paramName, final Object value) {
+	public <V> T param(final String paramName, final V value) {
 		context().param(paramName, value);
 		return (T) this;
 	}
@@ -187,7 +248,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T param(final String paramName, final Supplier<Object> supplier) {
+	public <V> T param(final String paramName, final Supplier<V> supplier) {
 		context().param(paramName, supplier);
 		return (T) this;
 	}
@@ -199,7 +260,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramIfAbsent(final String paramName, final Object value) {
+	public <V> T paramIfAbsent(final String paramName, final V value) {
 		context().paramIfAbsent(paramName, value);
 		return (T) this;
 	}
@@ -235,7 +296,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T inOutParam(final String paramName, final Object value, final int sqlType) {
+	public <V> T inOutParam(final String paramName, final V value, final int sqlType) {
 		context().inOutParam(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -247,7 +308,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T inOutParamIfAbsent(final String paramName, final Object value, final int sqlType) {
+	public <V> T inOutParamIfAbsent(final String paramName, final V value, final int sqlType) {
 		context().inOutParamIfAbsent(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -259,7 +320,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T inOutParam(final String paramName, final Object value, final SQLType sqlType) {
+	public <V> T inOutParam(final String paramName, final V value, final SQLType sqlType) {
 		context().inOutParam(paramName, value, sqlType);
 		return (T) this;
 	}
@@ -271,7 +332,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T inOutParamIfAbsent(final String paramName, final Object value, final SQLType sqlType) {
+	public <V> T inOutParamIfAbsent(final String paramName, final V value, final SQLType sqlType) {
 		context().inOutParamIfAbsent(paramName, value, sqlType);
 		return (T) this;
 	}

--- a/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
@@ -9,6 +9,7 @@ package jp.co.future.uroborosql.client;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -104,7 +105,7 @@ public final class SqlParamUtils {
 			for (int i = 0; i < parts.length; i++) {
 				vals[i] = convertSingleValue(parts[i]);
 			}
-			ctx.paramList(key, vals);
+			ctx.param(key, Arrays.asList(vals));
 		} else {
 			ctx.param(key, convertSingleValue(val));
 		}

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -474,46 +474,23 @@ public class SqlContextImpl implements SqlContext {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.lang.Object[])
-	 */
-	@Override
-	public <V> SqlContext paramArray(final String parameterName, @SuppressWarnings("unchecked") final V... value) {
-		return param(new Parameter(parameterName, Arrays.asList(value)));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.util.function.Supplier)
-	 */
-	@Override
-	public <V> SqlContext paramArray(final String parameterName, final Supplier<V[]> supplier) {
-		return param(new Parameter(parameterName, Arrays.asList(supplier.get())));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArrayIfAbsent(java.lang.String, java.lang.Object[])
-	 */
-	@Override
-	public <V> SqlContext paramArrayIfAbsent(final String parameterName,
-			@SuppressWarnings("unchecked") final V... value) {
-		if (!hasParam(parameterName)) {
-			paramArray(parameterName, value);
-		}
-		return this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Object...)
 	 */
 	@Override
 	@Deprecated
 	public <V> SqlContext paramList(final String parameterName, @SuppressWarnings("unchecked") final V... value) {
-		return paramArray(parameterName, value);
+		return param(parameterName, Arrays.asList(value));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.util.function.Supplier)
+	 */
+	@Override
+	@Deprecated
+	public <V> SqlContext paramList(final String parameterName, final Supplier<Iterable<V>> supplier) {
+		return param(parameterName, supplier);
 	}
 
 	/**
@@ -525,43 +502,7 @@ public class SqlContextImpl implements SqlContext {
 	@Deprecated
 	public <V> SqlContext paramListIfAbsent(final String parameterName,
 			@SuppressWarnings("unchecked") final V... value) {
-		if (!hasParam(parameterName)) {
-			paramArray(parameterName, value);
-		}
-		return this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Iterable)
-	 */
-	@Override
-	public <V> SqlContext paramList(final String parameterName, final Iterable<V> value) {
-		return param(new Parameter(parameterName, value));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Supplier)
-	 */
-	@Override
-	public <V> SqlContext paramList(final String parameterName, final Supplier<Iterable<V>> supplier) {
-		return param(new Parameter(parameterName, supplier.get()));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(java.lang.String, java.lang.Iterable)
-	 */
-	@Override
-	public <V> SqlContext paramListIfAbsent(final String parameterName, final Iterable<V> value) {
-		if (!hasParam(parameterName)) {
-			paramList(parameterName, value);
-		}
-		return this;
+		return paramIfAbsent(parameterName, Arrays.asList(value));
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -434,7 +434,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.parser.TransformContext#param(java.lang.String, java.lang.Object)
 	 */
 	@Override
-	public SqlContext param(final String parameterName, final Object value) {
+	public <V> SqlContext param(final String parameterName, final V value) {
 		if (value instanceof Optional) {
 			Optional<?> optionalValue = (Optional<?>) value;
 			if (optionalValue.isPresent()) {
@@ -454,7 +454,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(String, Supplier)
 	 */
 	@Override
-	public SqlContext param(final String paramName, final Supplier<Object> supplier) {
+	public <V> SqlContext param(final String paramName, final Supplier<V> supplier) {
 		return this.param(paramName, supplier != null ? supplier.get() : null);
 	}
 
@@ -464,9 +464,43 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object)
 	 */
 	@Override
-	public SqlContext paramIfAbsent(final String parameterName, final Object value) {
+	public <V> SqlContext paramIfAbsent(final String parameterName, final V value) {
 		if (!hasParam(parameterName)) {
 			param(parameterName, value);
+		}
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.lang.Object[])
+	 */
+	@Override
+	public <V> SqlContext paramArray(final String parameterName, @SuppressWarnings("unchecked") final V... value) {
+		return param(new Parameter(parameterName, Arrays.asList(value)));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArray(java.lang.String, java.util.function.Supplier)
+	 */
+	@Override
+	public <V> SqlContext paramArray(final String parameterName, final Supplier<V[]> supplier) {
+		return param(new Parameter(parameterName, Arrays.asList(supplier.get())));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramArrayIfAbsent(java.lang.String, java.lang.Object[])
+	 */
+	@Override
+	public <V> SqlContext paramArrayIfAbsent(final String parameterName,
+			@SuppressWarnings("unchecked") final V... value) {
+		if (!hasParam(parameterName)) {
+			paramArray(parameterName, value);
 		}
 		return this;
 	}
@@ -477,18 +511,9 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Object...)
 	 */
 	@Override
-	public SqlContext paramList(final String parameterName, final Object... value) {
-		return param(new Parameter(parameterName, Arrays.asList(value)));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Supplier)
-	 */
-	@Override
-	public SqlContext paramList(final String parameterName, final Supplier<List<?>> supplier) {
-		return param(new Parameter(parameterName, supplier.get()));
+	@Deprecated
+	public <V> SqlContext paramList(final String parameterName, @SuppressWarnings("unchecked") final V... value) {
+		return paramArray(parameterName, value);
 	}
 
 	/**
@@ -497,7 +522,42 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(String, Object...)
 	 */
 	@Override
-	public SqlContext paramListIfAbsent(final String parameterName, final Object... value) {
+	@Deprecated
+	public <V> SqlContext paramListIfAbsent(final String parameterName,
+			@SuppressWarnings("unchecked") final V... value) {
+		if (!hasParam(parameterName)) {
+			paramArray(parameterName, value);
+		}
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Iterable)
+	 */
+	@Override
+	public <V> SqlContext paramList(final String parameterName, final Iterable<V> value) {
+		return param(new Parameter(parameterName, value));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(String, Supplier)
+	 */
+	@Override
+	public <V> SqlContext paramList(final String parameterName, final Supplier<Iterable<V>> supplier) {
+		return param(new Parameter(parameterName, supplier.get()));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(java.lang.String, java.lang.Iterable)
+	 */
+	@Override
+	public <V> SqlContext paramListIfAbsent(final String parameterName, final Iterable<V> value) {
 		if (!hasParam(parameterName)) {
 			paramList(parameterName, value);
 		}
@@ -518,7 +578,7 @@ public class SqlContextImpl implements SqlContext {
 	}
 
 	@Override
-	public SqlContext paramBean(final Object bean) {
+	public <V> SqlContext paramBean(final V bean) {
 		if (bean != null) {
 			BeanAccessor.fields(bean.getClass()).stream()
 					.forEach(f -> param(f.getName(), BeanAccessor.value(f, bean)));
@@ -532,7 +592,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.lang.Object, java.sql.SQLType)
 	 */
 	@Override
-	public SqlContext param(final String parameterName, final Object value, final SQLType sqlType) {
+	public <V> SqlContext param(final String parameterName, final V value, final SQLType sqlType) {
 		if (value instanceof Optional) {
 			Optional<?> optionalValue = (Optional<?>) value;
 			if (optionalValue.isPresent()) {
@@ -552,7 +612,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object, java.sql.SQLType)
 	 */
 	@Override
-	public SqlContext paramIfAbsent(final String parameterName, final Object value, final SQLType sqlType) {
+	public <V> SqlContext paramIfAbsent(final String parameterName, final V value, final SQLType sqlType) {
 		if (!hasParam(parameterName)) {
 			param(parameterName, value, sqlType);
 		}
@@ -565,7 +625,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.lang.Object, int)
 	 */
 	@Override
-	public SqlContext param(final String parameterName, final Object value, final int sqlType) {
+	public <V> SqlContext param(final String parameterName, final V value, final int sqlType) {
 		if (value instanceof Optional) {
 			Optional<?> optionalValue = (Optional<?>) value;
 			if (optionalValue.isPresent()) {
@@ -585,7 +645,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object, int)
 	 */
 	@Override
-	public SqlContext paramIfAbsent(final String parameterName, final Object value, final int sqlType) {
+	public <V> SqlContext paramIfAbsent(final String parameterName, final V value, final int sqlType) {
 		if (!hasParam(parameterName)) {
 			param(parameterName, value, sqlType);
 		}
@@ -627,7 +687,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#inOutParam(java.lang.String, java.lang.Object, java.sql.SQLType)
 	 */
 	@Override
-	public SqlContext inOutParam(final String parameterName, final Object value, final SQLType sqlType) {
+	public <V> SqlContext inOutParam(final String parameterName, final V value, final SQLType sqlType) {
 		if (value instanceof Optional) {
 			Optional<?> optionalValue = (Optional<?>) value;
 			if (optionalValue.isPresent()) {
@@ -647,7 +707,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#inOutParamIfAbsent(java.lang.String, java.lang.Object, java.sql.SQLType)
 	 */
 	@Override
-	public SqlContext inOutParamIfAbsent(final String parameterName, final Object value, final SQLType sqlType) {
+	public <V> SqlContext inOutParamIfAbsent(final String parameterName, final V value, final SQLType sqlType) {
 		if (!hasParam(parameterName)) {
 			inOutParam(parameterName, value, sqlType);
 		}
@@ -660,7 +720,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#inOutParam(java.lang.String, java.lang.Object, int)
 	 */
 	@Override
-	public SqlContext inOutParam(final String parameterName, final Object value, final int sqlType) {
+	public <V> SqlContext inOutParam(final String parameterName, final V value, final int sqlType) {
 		if (value instanceof Optional) {
 			Optional<?> optionalValue = (Optional<?>) value;
 			if (optionalValue.isPresent()) {
@@ -680,7 +740,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#inOutParamIfAbsent(java.lang.String, java.lang.Object, int)
 	 */
 	@Override
-	public SqlContext inOutParamIfAbsent(final String parameterName, final Object value, final int sqlType) {
+	public <V> SqlContext inOutParamIfAbsent(final String parameterName, final V value, final int sqlType) {
 		if (!hasParam(parameterName)) {
 			inOutParam(parameterName, value, sqlType);
 		}

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
@@ -74,6 +74,8 @@ public interface SqlFluent<T> {
 	/**
 	 * パラメータ配列の追加<br>
 	 *
+	 * @deprecated {@link SqlFluent#param(String, Object)}を使ってください。その際、valueを Arrays#asList()、もしくは List#of() を使用してList型に格納してください。
+	 *
 	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 配列として追加する
@@ -84,6 +86,8 @@ public interface SqlFluent<T> {
 
 	/**
 	 * パラメータListの追加<br>
+	 *
+	 * @deprecated {@link SqlFluent#param(String, Supplier)}を使ってください。
 	 *
 	 * @param <V> 値の型
 	 * @param paramName パラメータ名
@@ -97,6 +101,8 @@ public interface SqlFluent<T> {
 	 * パラメータ配列の追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
+	 *
+	 * @deprecated {@link SqlFluent#paramIfAbsent(String, Object)}を使ってください。その際、valueを Arrays#asList()、もしくは List#of() を使用してList型に格納してください。
 	 *
 	 * @param <V> 値の型
 	 * @param paramName パラメータ名

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
@@ -12,7 +12,6 @@ package jp.co.future.uroborosql.fluent;
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLType;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -43,60 +42,122 @@ public interface SqlFluent<T> {
 	/**
 	 * パラメータの追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @return T
 	 */
-	T param(String paramName, Object value);
+	<V> T param(String paramName, V value);
 
 	/**
 	 * パラメータの追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param supplier パラメータ値を提供するSupplier
 	 * @return T
 	 */
-	T param(String paramName, Supplier<Object> supplier);
+	<V> T param(String paramName, Supplier<V> supplier);
 
 	/**
 	 * パラメータの追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @return T
 	 */
-	T paramIfAbsent(String paramName, Object value);
+	<V> T paramIfAbsent(String paramName, V value);
 
 	/**
 	 * パラメータ配列の追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 配列として追加する
 	 * @return T
 	 */
-	T paramList(String paramName, Object... value);
+	<V> T paramArray(String paramName, @SuppressWarnings("unchecked") V... value);
 
 	/**
 	 * パラメータ配列の追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
-	 * @param supplier パラメータ値のListを提供するSupplier
+	 * @param supplier パラメータ値の配列を提供するSupplier
 	 * @return T
 	 */
-	T paramList(String paramName, Supplier<List<?>> supplier);
+	<V> T paramArray(String paramName, Supplier<V[]> supplier);
 
 	/**
 	 * パラメータ配列の追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 配列として追加する
 	 * @return T
 	 */
-	T paramListIfAbsent(String paramName, Object... value);
+	<V> T paramArrayIfAbsent(String paramName, @SuppressWarnings("unchecked") V... value);
+
+	/**
+	 * パラメータ配列の追加<br>
+	 *
+	 * @param <V> 値の型
+	 * @param paramName パラメータ名
+	 * @param value 配列として追加する
+	 * @return T
+	 */
+	@Deprecated
+	<V> T paramList(String paramName, @SuppressWarnings("unchecked") V... value);
+
+	/**
+	 * パラメータ配列の追加<br>
+	 *
+	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
+	 *
+	 * @param <V> 値の型
+	 * @param paramName パラメータ名
+	 * @param value 配列として追加する
+	 * @return T
+	 */
+	@Deprecated
+	<V> T paramListIfAbsent(String paramName, @SuppressWarnings("unchecked") V... value);
+
+	/**
+	 * パラメータListの追加<br>
+	 *
+	 * @param <V> 値の型
+	 * @param paramName パラメータ名
+	 * @param value Listとして追加する
+	 * @return T
+	 */
+	<V> T paramList(String paramName, Iterable<V> value);
+
+	/**
+	 * パラメータListの追加<br>
+	 *
+	 * @param <V> 値の型
+	 * @param paramName パラメータ名
+	 * @param supplier パラメータ値のListを提供するSupplier
+	 * @return T
+	 */
+	<V> T paramList(String paramName, Supplier<Iterable<V>> supplier);
+
+	/**
+	 * パラメータListの追加<br>
+	 *
+	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
+	 *
+	 * @param <V> 値の型
+	 * @param paramName パラメータ名
+	 * @param value Listとして追加する
+	 * @return T
+	 */
+	<V> T paramListIfAbsent(String paramName, Iterable<V> value);
 
 	/**
 	 * 引数として渡されたMapの[key, value]のセットをパラメータに追加<br>
@@ -109,54 +170,59 @@ public interface SqlFluent<T> {
 	/**
 	 * 引数として渡されたObjectのフィールド名と値のセットをパラメータに追加<br>
 	 *
+	 * @param <V> Beanの型
 	 * @param bean パラメータとなるオブジェクト
 	 * @return T
 	 */
-	T paramBean(Object bean);
+	<V> T paramBean(V bean);
 
 	/**
 	 * 型指定のパラメータ追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.SQLType}で表されるSQLの型
 	 * @return T
 	 */
-	T param(String paramName, Object value, SQLType sqlType);
+	<V> T param(String paramName, V value, SQLType sqlType);
 
 	/**
 	 * 型指定のパラメータ追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.SQLType}で表されるSQLの型
 	 * @return T
 	 */
-	T paramIfAbsent(String paramName, Object value, SQLType sqlType);
+	<V> T paramIfAbsent(String paramName, V value, SQLType sqlType);
 
 	/**
 	 * 型指定のパラメータ追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.Types}で表されるSQLの型
 	 * @return T
 	 */
-	T param(String paramName, Object value, int sqlType);
+	<V> T param(String paramName, V value, int sqlType);
 
 	/**
 	 * 型指定のパラメータ追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.Types}で表されるSQLの型
 	 * @return T
 	 */
-	T paramIfAbsent(String paramName, Object value, int sqlType);
+	<V> T paramIfAbsent(String paramName, V value, int sqlType);
 
 	/**
 	 * 出力パラメータ追加<br>
@@ -179,46 +245,50 @@ public interface SqlFluent<T> {
 	/**
 	 * 入出力パラメータ追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.SQLType}で表されるSQLの型
 	 * @return T
 	 */
-	T inOutParam(String paramName, Object value, SQLType sqlType);
+	<V> T inOutParam(String paramName, V value, SQLType sqlType);
 
 	/**
 	 * 入出力パラメータ追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.SQLType}で表されるSQLの型
 	 * @return T
 	 */
-	T inOutParamIfAbsent(String paramName, Object value, SQLType sqlType);
+	<V> T inOutParamIfAbsent(String paramName, V value, SQLType sqlType);
 
 	/**
 	 * 入出力パラメータ追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.Types}で表されるSQLの型
 	 * @return T
 	 */
-	T inOutParam(String paramName, Object value, int sqlType);
+	<V> T inOutParam(String paramName, V value, int sqlType);
 
 	/**
 	 * 入出力パラメータ追加<br>
 	 *
 	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @param sqlType {@link java.sql.Types}で表されるSQLの型
 	 * @return T
 	 */
-	T inOutParamIfAbsent(String paramName, Object value, int sqlType);
+	<V> T inOutParamIfAbsent(String paramName, V value, int sqlType);
 
 	/**
 	 * BLOBパラメータ追加<br>

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
@@ -79,40 +79,19 @@ public interface SqlFluent<T> {
 	 * @param value 配列として追加する
 	 * @return T
 	 */
-	<V> T paramArray(String paramName, @SuppressWarnings("unchecked") V... value);
+	@Deprecated
+	<V> T paramList(String paramName, @SuppressWarnings("unchecked") V... value);
 
 	/**
-	 * パラメータ配列の追加<br>
+	 * パラメータListの追加<br>
 	 *
 	 * @param <V> 値の型
 	 * @param paramName パラメータ名
-	 * @param supplier パラメータ値の配列を提供するSupplier
-	 * @return T
-	 */
-	<V> T paramArray(String paramName, Supplier<V[]> supplier);
-
-	/**
-	 * パラメータ配列の追加<br>
-	 *
-	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
-	 *
-	 * @param <V> 値の型
-	 * @param paramName パラメータ名
-	 * @param value 配列として追加する
-	 * @return T
-	 */
-	<V> T paramArrayIfAbsent(String paramName, @SuppressWarnings("unchecked") V... value);
-
-	/**
-	 * パラメータ配列の追加<br>
-	 *
-	 * @param <V> 値の型
-	 * @param paramName パラメータ名
-	 * @param value 配列として追加する
+	 * @param supplier パラメータ値を提供するSupplier
 	 * @return T
 	 */
 	@Deprecated
-	<V> T paramList(String paramName, @SuppressWarnings("unchecked") V... value);
+	<V> T paramList(String paramName, Supplier<Iterable<V>> supplier);
 
 	/**
 	 * パラメータ配列の追加<br>
@@ -126,38 +105,6 @@ public interface SqlFluent<T> {
 	 */
 	@Deprecated
 	<V> T paramListIfAbsent(String paramName, @SuppressWarnings("unchecked") V... value);
-
-	/**
-	 * パラメータListの追加<br>
-	 *
-	 * @param <V> 値の型
-	 * @param paramName パラメータ名
-	 * @param value Listとして追加する
-	 * @return T
-	 */
-	<V> T paramList(String paramName, Iterable<V> value);
-
-	/**
-	 * パラメータListの追加<br>
-	 *
-	 * @param <V> 値の型
-	 * @param paramName パラメータ名
-	 * @param supplier パラメータ値のListを提供するSupplier
-	 * @return T
-	 */
-	<V> T paramList(String paramName, Supplier<Iterable<V>> supplier);
-
-	/**
-	 * パラメータListの追加<br>
-	 *
-	 * 指定したパラメータ名がまだ登録されていない場合に値を追加する
-	 *
-	 * @param <V> 値の型
-	 * @param paramName パラメータ名
-	 * @param value Listとして追加する
-	 * @return T
-	 */
-	<V> T paramListIfAbsent(String paramName, Iterable<V> value);
 
 	/**
 	 * 引数として渡されたMapの[key, value]のセットをパラメータに追加<br>

--- a/src/main/java/jp/co/future/uroborosql/node/ParenBindVariableNode.java
+++ b/src/main/java/jp/co/future/uroborosql/node/ParenBindVariableNode.java
@@ -7,6 +7,7 @@
 package jp.co.future.uroborosql.node;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.List;
 
 import jp.co.future.uroborosql.exception.ParameterNotFoundRuntimeException;
@@ -33,14 +34,17 @@ public class ParenBindVariableNode extends ExpressionNode {
 	 * @see jp.co.future.uroborosql.node.Node#accept(jp.co.future.uroborosql.parser.TransformContext)
 	 */
 	@Override
-	@SuppressWarnings({ "rawtypes" })
 	public void accept(final TransformContext transformContext) {
 		Object var = eval(transformContext);
 
 		if (var == null) {
 			throw new ParameterNotFoundRuntimeException("Parameter is not set. [" + expression + "]");
-		} else if (var instanceof List) {
-			bindArray(transformContext, ((List) var).toArray());
+		} else if (var instanceof Iterable) {
+			List<Object> list = new ArrayList<>();
+			for (Object v : (Iterable<?>) var) {
+				list.add(v);
+			}
+			bindArray(transformContext, list.toArray());
 		} else if (var.getClass().isArray()) {
 			bindArray(transformContext, var);
 		} else {

--- a/src/main/java/jp/co/future/uroborosql/parameter/Parameter.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/Parameter.java
@@ -12,7 +12,6 @@ import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLType;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -157,8 +156,8 @@ public class Parameter {
 	protected int setInParameter(final PreparedStatement preparedStatement, final int index,
 			final BindParameterMapperManager parameterMapperManager) throws SQLException {
 		int parameterIndex = index;
-		if (value instanceof List) {
-			for (Object e : (List<?>) value) {
+		if (value instanceof Iterable) {
+			for (Object e : (Iterable<?>) value) {
 				setParameterObject(preparedStatement, parameterIndex, e, parameterMapperManager);
 
 				parameterLog(parameterIndex);

--- a/src/main/java/jp/co/future/uroborosql/parser/TransformContext.java
+++ b/src/main/java/jp/co/future/uroborosql/parser/TransformContext.java
@@ -83,11 +83,12 @@ public interface TransformContext {
 	/**
 	 * バインドパラメータの追加<br>
 	 *
+	 * @param <V> 値の型
 	 * @param paramName パラメータ名
 	 * @param value 値
 	 * @return T
 	 */
-	TransformContext param(String paramName, Object value);
+	<V> TransformContext param(String paramName, V value);
 
 	/**
 	 * バインド変数名のリストを取得する

--- a/src/test/java/jp/co/future/uroborosql/AbstractSqlFluentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/AbstractSqlFluentTest.java
@@ -52,11 +52,11 @@ public class AbstractSqlFluentTest {
 
 	@SuppressWarnings("deprecation")
 	@Test
-	public void testParamArray() throws Exception {
+	public void testparamList() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			SqlQuery query = null;
 			query = agent.query("select * from dummy");
-			query.paramArray("key1", "value1");
+			query.paramList("key1", "value1");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1")));
 
 			query = agent.query("select * from dummy");
@@ -64,7 +64,7 @@ public class AbstractSqlFluentTest {
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1")));
 
 			query = agent.query("select * from dummy");
-			query.paramArray("key1", "value1", "value2");
+			query.paramList("key1", "value1", "value2");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 			query = agent.query("select * from dummy");
@@ -73,24 +73,25 @@ public class AbstractSqlFluentTest {
 
 			String[] values = { "value1", "value2" };
 			query = agent.query("select * from dummy");
-			query.paramArray("key1", () -> {
-				return values;
+			query.paramList("key1", () -> {
+				return Arrays.asList(values);
 			});
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 		}
 
 	}
 
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testParamList() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			SqlQuery query = null;
 			query = agent.query("select * from dummy");
-			query.paramList("key1", Arrays.asList("value1"));
+			query.paramList("key1", "value1");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1")));
 
 			query = agent.query("select * from dummy");
-			query.paramList("key1", Arrays.asList("value1", "value2"));
+			query.paramList("key1", "value1", "value2");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 			Set<String> values = new HashSet<>();
@@ -98,7 +99,7 @@ public class AbstractSqlFluentTest {
 			values.add("value2");
 
 			query = agent.query("select * from dummy");
-			query.paramList("key1", values);
+			query.param("key1", values);
 			assertThat(query.context().getParam("key1").getValue(), is(values));
 
 			query = agent.query("select * from dummy");
@@ -109,6 +110,7 @@ public class AbstractSqlFluentTest {
 		}
 	}
 
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testIfAbsent() throws Exception {
 		try (SqlAgent agent = config.agent()) {
@@ -132,15 +134,9 @@ public class AbstractSqlFluentTest {
 			assertThat(query.context().getParam("key1").getValue(), is("value1"));
 
 			query = agent.query("select * from dummy");
-			query.paramArrayIfAbsent("key1", "value1", "value2");
+			query.paramListIfAbsent("key1", "value1", "value2");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-			query.paramArrayIfAbsent("key1", "value11", "value22");
-			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-
-			query = agent.query("select * from dummy");
-			query.paramArrayIfAbsent("key1", "value1", "value2");
-			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-			query.paramArrayIfAbsent("key1", "value11", "value22");
+			query.paramListIfAbsent("key1", "value11", "value22");
 			assertThat(query.context().getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 			query = agent.query("select * from dummy");
@@ -207,6 +203,7 @@ public class AbstractSqlFluentTest {
 		}
 	}
 
+	@SuppressWarnings({ "deprecation", })
 	@Test
 	public void testParamWithSupplier() throws Exception {
 		try (SqlAgent agent = config.agent()) {

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
@@ -62,12 +62,13 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryNoWait() throws Exception {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 60));
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount + 1);
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount + 1);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
 	}
@@ -75,12 +76,13 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryNoWaitSqlState() throws Exception {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 0, "60"));
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount + 1);
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount + 1);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
 	}
@@ -88,12 +90,13 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（待機あり）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryWait() throws Exception {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 60));
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1)
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1)
 				.retry(retryCount + 1, 10);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
@@ -102,12 +105,13 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（待機あり）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryWaitSqlState() throws Exception {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 0, "60"));
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1)
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1)
 				.retry(retryCount + 1, 10);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
@@ -116,6 +120,7 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（リトライ回数上限）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryOver() throws Exception {
 		int retryCount = 3;
@@ -124,7 +129,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -136,6 +141,7 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（リトライ回数上限）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryRetryOverSqlState() throws Exception {
 		int retryCount = 3;
@@ -145,7 +151,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -158,6 +164,7 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（リトライ対象外のエラー発生）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryNoRetry() throws Exception {
 		int retryCount = 3;
@@ -166,7 +173,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -178,6 +185,7 @@ public class SqlAgentRetryTest {
 	/**
 	 * クエリ実行のリトライ（リトライ対象外のエラー発生）
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testQueryNoRetrySqlState() throws Exception {
 		int retryCount = 3;
@@ -187,7 +195,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
@@ -67,7 +67,7 @@ public class SqlAgentRetryTest {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 60));
 
-		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount + 1);
+		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount + 1);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
 	}
@@ -80,7 +80,7 @@ public class SqlAgentRetryTest {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 0, "60"));
 
-		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount + 1);
+		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount + 1);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
 	}
@@ -93,7 +93,7 @@ public class SqlAgentRetryTest {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 60));
 
-		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1)
+		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.retry(retryCount + 1, 10);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
@@ -107,7 +107,7 @@ public class SqlAgentRetryTest {
 		int retryCount = 3;
 		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, 0, "60"));
 
-		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1)
+		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.retry(retryCount + 1, 10);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
@@ -124,7 +124,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -145,7 +145,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -166,7 +166,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -187,7 +187,7 @@ public class SqlAgentRetryTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentRetryWithRollbackTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentRetryWithRollbackTest.java
@@ -76,12 +76,13 @@ public class SqlAgentRetryWithRollbackTest {
 	/**
 	 * クエリ実行のリトライ
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryRetryNoWait() throws Exception {
 		int retryCount = 3;
 		setRetryFilter(retryCount, 60);
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount + 1);
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount + 1);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
 	}
@@ -89,12 +90,13 @@ public class SqlAgentRetryWithRollbackTest {
 	/**
 	 * クエリ実行のリトライ（待機あり）
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryRetryWait() throws Exception {
 		int retryCount = 3;
 		setRetryFilter(retryCount, 60);
 
-		SqlQuery query = agent.query("example/select_product").paramArray("product_id", 0, 1)
+		SqlQuery query = agent.query("example/select_product").paramList("product_id", 0, 1)
 				.retry(retryCount + 1, 10);
 		query.collect();
 		assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount));
@@ -103,6 +105,7 @@ public class SqlAgentRetryWithRollbackTest {
 	/**
 	 * クエリ実行のリトライ（リトライ回数上限）
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryRetryOver() throws Exception {
 		int retryCount = 3;
@@ -111,7 +114,7 @@ public class SqlAgentRetryWithRollbackTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {
@@ -123,6 +126,7 @@ public class SqlAgentRetryWithRollbackTest {
 	/**
 	 * クエリ実行のリトライ（リトライ対象外のエラー発生）
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryNoRetry() throws Exception {
 		int retryCount = 3;
@@ -131,7 +135,7 @@ public class SqlAgentRetryWithRollbackTest {
 
 		SqlQuery query = null;
 		try {
-			query = agent.query("example/select_product").paramArray("product_id", 0, 1).retry(retryCount - 1);
+			query = agent.query("example/select_product").paramList("product_id", 0, 1).retry(retryCount - 1);
 			query.collect();
 			fail();
 		} catch (UroborosqlSQLException ex) {

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -19,10 +19,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -144,36 +146,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース。
 	 */
-	@Test
-	public void testQueryParamArray() throws Exception {
-		// 事前条件
-		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
-
-		SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
-				.setSqlId("test_sql_id");
-
-		ResultSet rs = agent.query(ctx);
-		assertNotNull("ResultSetが取得できませんでした。", rs);
-		assertTrue("結果が0件です。", rs.next());
-		assertEquals("0", rs.getString("PRODUCT_ID"));
-		assertEquals("商品名0", rs.getString("PRODUCT_NAME"));
-		assertEquals("ショウヒンメイゼロ", rs.getString("PRODUCT_KANA_NAME"));
-		assertEquals("1234567890123", rs.getString("JAN_CODE"));
-		assertEquals("0番目の商品", rs.getString("PRODUCT_DESCRIPTION"));
-		assertFalse("結果が複数件です。", rs.next());
-	}
-
-	/**
-	 * クエリ実行処理のテストケース。
-	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryParamList() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramList("product_id", Arrays.asList(new BigDecimal("0"), new BigDecimal("2")))
+				.paramList("product_id", new BigDecimal("0"), new BigDecimal("2"))
 				.setSqlId("test_sql_id");
 
 		ResultSet rs = agent.query(ctx);
@@ -190,6 +170,33 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース。
 	 */
+	@Test
+	public void testQueryParamListWithSet() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		Set<BigDecimal> params = new HashSet<>();
+		params.add(new BigDecimal("0"));
+		params.add(new BigDecimal("2"));
+		SqlContext ctx = agent.contextFrom("example/select_product")
+				.param("product_id", params)
+				.setSqlId("test_sql_id");
+
+		ResultSet rs = agent.query(ctx);
+		assertNotNull("ResultSetが取得できませんでした。", rs);
+		assertTrue("結果が0件です。", rs.next());
+		assertEquals("0", rs.getString("PRODUCT_ID"));
+		assertEquals("商品名0", rs.getString("PRODUCT_NAME"));
+		assertEquals("ショウヒンメイゼロ", rs.getString("PRODUCT_KANA_NAME"));
+		assertEquals("1234567890123", rs.getString("JAN_CODE"));
+		assertEquals("0番目の商品", rs.getString("PRODUCT_DESCRIPTION"));
+		assertFalse("結果が複数件です。", rs.next());
+	}
+
+	/**
+	 * クエリ実行処理のテストケース。
+	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFilter() throws Exception {
 		// 事前条件
@@ -202,7 +209,7 @@ public class SqlAgentTest {
 		manager.addSqlFilter(filter);
 
 		SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramArray("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
+				.paramList("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
 				.param("maxRowCount", 1);
 
 		ResultSet rs = agent.query(ctx);
@@ -259,31 +266,11 @@ public class SqlAgentTest {
 	 * クエリ実行処理のテストケース。
 	 */
 	@Test
-	public void testQueryArray() throws Exception {
-		// 事前条件
-		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
-
-		SqlContext ctx = agent.contextFrom("example/select_product").paramArray("product_id", 0, 1, 2, 3);
-
-		ResultSet rs = agent.query(ctx);
-		assertNotNull("ResultSetが取得できませんでした。", rs);
-		assertTrue("結果が0件です。", rs.next());
-		assertEquals("0", rs.getString("PRODUCT_ID"));
-		assertEquals("商品名0", rs.getString("PRODUCT_NAME"));
-		assertEquals("ショウヒンメイゼロ", rs.getString("PRODUCT_KANA_NAME"));
-		assertEquals("1234567890123", rs.getString("JAN_CODE"));
-		assertEquals("0番目の商品", rs.getString("PRODUCT_DESCRIPTION"));
-	}
-
-	/**
-	 * クエリ実行処理のテストケース。
-	 */
-	@Test
 	public void testQueryList() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		SqlContext ctx = agent.contextFrom("example/select_product").paramList("product_id", Arrays.asList(0, 1, 2, 3));
+		SqlContext ctx = agent.contextFrom("example/select_product").param("product_id", Arrays.asList(0, 1, 2, 3));
 
 		ResultSet rs = agent.query(ctx);
 		assertNotNull("ResultSetが取得できませんでした。", rs);
@@ -298,12 +285,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentArray() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		ResultSet rs = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3).resultSet();
+		ResultSet rs = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3).resultSet();
 		assertNotNull("ResultSetが取得できませんでした。", rs);
 		assertTrue("結果が0件です。", rs.next());
 		assertEquals("0", rs.getString("PRODUCT_ID"));
@@ -316,12 +304,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentCollect() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.collect();
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -335,12 +324,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentCollectCaseFormat() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.collect(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -354,12 +344,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentCollectEntity() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Product> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		List<Product> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.collect(Product.class);
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Product product = ans.get(0);
@@ -373,6 +364,7 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentCollectSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -385,7 +377,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.collect();
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -399,12 +391,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFirst() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.first();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
@@ -416,18 +409,19 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentOne() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 		try {
-			agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3).one();
+			agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3).one();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.one();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
@@ -439,6 +433,7 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFirstSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -451,7 +446,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.first();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -463,6 +458,7 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentOneSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -476,14 +472,14 @@ public class SqlAgentTest {
 		agent = config.agent();
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.one();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.one();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -495,13 +491,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindFirst() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1, 2, 3).findFirst();
+				.paramList("product_id", 0, 1, 2, 3).findFirst();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -511,13 +508,14 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JAN_CODE"));
 		assertEquals("0番目の商品", map.get("PRODUCT_DESCRIPTION"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindOne() throws Exception {
 		// 事前条件
@@ -525,13 +523,13 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3).findOne();
+					.paramList("product_id", 0, 1, 2, 3).findOne();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0).findOne();
+				.paramList("product_id", 0).findOne();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -541,13 +539,14 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JAN_CODE"));
 		assertEquals("0番目の商品", map.get("PRODUCT_DESCRIPTION"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindFirstSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -561,7 +560,7 @@ public class SqlAgentTest {
 		agent = config.agent();
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1, 2, 3).findFirst();
+				.paramList("product_id", 0, 1, 2, 3).findFirst();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -571,13 +570,14 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("jan_code"));
 		assertEquals("0番目の商品", map.get("product_description"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindOneSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -591,14 +591,14 @@ public class SqlAgentTest {
 		agent = config.agent();
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.findOne();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.findOne();
 		assertTrue(optional.isPresent());
 
@@ -609,19 +609,20 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("jan_code"));
 		assertEquals("0番目の商品", map.get("product_description"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFirstCaseFormat() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
 				.first(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -633,6 +634,7 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentOneCaseFormat() throws Exception {
 		// 事前条件
@@ -640,14 +642,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.one(CaseFormat.LOWER_SNAKE_CASE);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.one(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -659,13 +661,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindFirstCaseFormat() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1, 2, 3).findFirst(CaseFormat.PASCAL_CASE);
+				.paramList("product_id", 0, 1, 2, 3).findFirst(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -675,13 +678,14 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JanCode"));
 		assertEquals("0番目の商品", map.get("ProductDescription"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindOneCaseFormat() throws Exception {
 		// 事前条件
@@ -689,14 +693,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.findOne(CaseFormat.PASCAL_CASE);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.findOne(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
@@ -707,20 +711,21 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JanCode"));
 		assertEquals("0番目の商品", map.get("ProductDescription"));
 
-		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFirstByClass() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Product product = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1, 2, 3)
+				.paramList("product_id", 0, 1, 2, 3)
 				.first(Product.class);
 
 		assertEquals(0, product.getProductId());
@@ -733,13 +738,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindFirstByClass() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Product> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1, 2, 3)
+				.paramList("product_id", 0, 1, 2, 3)
 				.findFirst(Product.class);
 
 		assertTrue(optional.isPresent());
@@ -753,7 +759,7 @@ public class SqlAgentTest {
 		assertEquals("0番目の商品", product.getProductDescription());
 
 		optional = agent.query("example/select_product")
-				.paramArray("product_id", 4)
+				.paramList("product_id", 4)
 				.findFirst(Product.class);
 
 		assertFalse(optional.isPresent());
@@ -762,20 +768,21 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentOneByClass() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.one(Product.class);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Product product = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.one(Product.class);
 
 		assertEquals(0, product.getProductId());
@@ -788,6 +795,7 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理(1件取得:Optional)のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentFindOneByClass() throws Exception {
 		// 事前条件
@@ -795,14 +803,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramArray("product_id", 0, 1, 2, 3)
+					.paramList("product_id", 0, 1, 2, 3)
 					.findOne(Product.class);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Product> optional = agent.query("example/select_product")
-				.paramArray("product_id", 0)
+				.paramList("product_id", 0)
 				.findOne(Product.class);
 		assertTrue(optional.isPresent());
 
@@ -815,7 +823,7 @@ public class SqlAgentTest {
 		assertEquals("0番目の商品", product.getProductDescription());
 
 		optional = agent.query("example/select_product")
-				.paramArray("product_id", 4)
+				.paramList("product_id", 4)
 				.findOne(Product.class);
 
 		assertFalse(optional.isPresent());
@@ -824,13 +832,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryLambda() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product");
-		ctx.paramArray("product_id", 0, 1);
+		ctx.paramList("product_id", 0, 1);
 
 		agent.query(ctx, (rs) -> {
 			ResultSetMetaData rsmd = rs.getMetaData();
@@ -858,12 +867,13 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentLambda() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramArray("product_id", 0, 1)
+		agent.query("example/select_product").paramList("product_id", 0, 1)
 				.stream().forEach((m) -> {
 					assertTrue(m.containsKey("PRODUCT_ID"));
 					assertTrue(m.containsKey("PRODUCT_NAME"));
@@ -874,19 +884,20 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("UPD_DATETIME"));
 					assertTrue(m.containsKey("VERSION_NO"));
 				});
-		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
 
 	}
 
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentLambdaCaseFormat() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramArray("product_id", 0, 1)
+		agent.query("example/select_product").paramList("product_id", 0, 1)
 				.stream(CaseFormat.LOWER_SNAKE_CASE).forEach((m) -> {
 					assertTrue(m.containsKey("product_id"));
 					assertTrue(m.containsKey("product_name"));
@@ -897,12 +908,13 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("upd_datetime"));
 					assertTrue(m.containsKey("version_no"));
 				});
-		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentLambdaSetDefaultCaseFormat() throws Exception {
 		// 事前条件
@@ -915,7 +927,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		agent.query("example/select_product").paramArray("product_id", 0, 1)
+		agent.query("example/select_product").paramList("product_id", 0, 1)
 				.stream().forEach((m) -> {
 					assertTrue(m.containsKey("product_id"));
 					assertTrue(m.containsKey("product_name"));
@@ -926,7 +938,7 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("upd_datetime"));
 					assertTrue(m.containsKey("version_no"));
 				});
-		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
@@ -961,13 +973,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentStreamEntity() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		agent.query("example/select_product")
-				.paramArray("product_id", 0, 1)
+				.paramList("product_id", 0, 1)
 				.stream(Product.class)
 				.forEach(p -> {
 					assertNotNull(p.getProductId());
@@ -979,19 +992,20 @@ public class SqlAgentTest {
 					assertNotNull(p.getUpdDatetime());
 					assertNotNull(p.getVersionNo());
 				});
-		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
 	 * クエリ実行処理のテストケース。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryMapResuletSetConverter() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product");
-		ctx.paramArray("product_id", 0, 1);
+		ctx.paramList("product_id", 0, 1);
 
 		List<Map<String, Object>> ans = agent.query(ctx, CaseFormat.CAMEL_CASE);
 		assertThat(ans.size(), is(2));
@@ -1008,7 +1022,7 @@ public class SqlAgentTest {
 		});
 
 		SqlContext ctx2 = agent.contextFrom("example/select_product");
-		ctx2.paramArray("product_id", 0, 1);
+		ctx2.paramList("product_id", 0, 1);
 
 		List<Map<String, Object>> ans2 = agent.query(ctx2, CaseFormat.UPPER_SNAKE_CASE);
 		assertThat(ans2.size(), is(2));
@@ -1027,13 +1041,14 @@ public class SqlAgentTest {
 	/**
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testQueryFluentLambdaAndUpdate() throws Exception {
 		// 事前条件
 		truncateTable("product_regist_work");
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramArray("product_id", 0, 1)
+		agent.query("example/select_product").paramList("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.forEach((m) -> {
 					try {
@@ -1050,6 +1065,7 @@ public class SqlAgentTest {
 	/**
 	 * DB更新処理のテストケース。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testExecuteUpdate() throws Exception {
 		// 事前条件
@@ -1066,7 +1082,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1)
+				.paramList("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1076,6 +1092,7 @@ public class SqlAgentTest {
 	/**
 	 * DB更新処理のテストケース。(Fluent API)
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testUpdateFluent() throws Exception {
 		// 事前条件
@@ -1090,7 +1107,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramArray("product_id", 0, 1)
+				.paramList("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1100,6 +1117,7 @@ public class SqlAgentTest {
 	/**
 	 * バッチ処理のテストケース。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testExecuteBatch() throws Exception {
 		// 事前条件
@@ -1127,7 +1145,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramArray("product_id", 1, 2)
+				.paramList("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1137,6 +1155,7 @@ public class SqlAgentTest {
 	/**
 	 * バッチ処理のテストケース。(複数回)
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testExecuteBatchRepeat() throws Exception {
 		// 事前条件
@@ -1168,7 +1187,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramArray("product_id", 1, 2)
+				.paramList("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1178,6 +1197,7 @@ public class SqlAgentTest {
 	/**
 	 * バッチ処理(Null挿入）のテストケース。
 	 */
+	@SuppressWarnings({ "deprecation" })
 	@Test
 	public void testExecuteBatchNull() throws Exception {
 		// 事前条件
@@ -1202,7 +1222,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchNull.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramArray("product_id", 1, 2)
+				.paramList("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentTest.java
@@ -145,12 +145,35 @@ public class SqlAgentTest {
 	 * クエリ実行処理のテストケース。
 	 */
 	@Test
+	public void testQueryParamArray() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		SqlContext ctx = agent.contextFrom("example/select_product")
+				.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
+				.setSqlId("test_sql_id");
+
+		ResultSet rs = agent.query(ctx);
+		assertNotNull("ResultSetが取得できませんでした。", rs);
+		assertTrue("結果が0件です。", rs.next());
+		assertEquals("0", rs.getString("PRODUCT_ID"));
+		assertEquals("商品名0", rs.getString("PRODUCT_NAME"));
+		assertEquals("ショウヒンメイゼロ", rs.getString("PRODUCT_KANA_NAME"));
+		assertEquals("1234567890123", rs.getString("JAN_CODE"));
+		assertEquals("0番目の商品", rs.getString("PRODUCT_DESCRIPTION"));
+		assertFalse("結果が複数件です。", rs.next());
+	}
+
+	/**
+	 * クエリ実行処理のテストケース。
+	 */
+	@Test
 	public void testQueryParamList() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramList("product_id", new BigDecimal("0"), new BigDecimal("2"))
+				.paramList("product_id", Arrays.asList(new BigDecimal("0"), new BigDecimal("2")))
 				.setSqlId("test_sql_id");
 
 		ResultSet rs = agent.query(ctx);
@@ -179,7 +202,7 @@ public class SqlAgentTest {
 		manager.addSqlFilter(filter);
 
 		SqlContext ctx = agent.contextFrom("example/select_product")
-				.paramList("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
+				.paramArray("product_id", new BigDecimal("0"), new BigDecimal("1")).param("startRowIndex", 0)
 				.param("maxRowCount", 1);
 
 		ResultSet rs = agent.query(ctx);
@@ -240,7 +263,27 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		SqlContext ctx = agent.contextFrom("example/select_product").paramList("product_id", 0, 1, 2, 3);
+		SqlContext ctx = agent.contextFrom("example/select_product").paramArray("product_id", 0, 1, 2, 3);
+
+		ResultSet rs = agent.query(ctx);
+		assertNotNull("ResultSetが取得できませんでした。", rs);
+		assertTrue("結果が0件です。", rs.next());
+		assertEquals("0", rs.getString("PRODUCT_ID"));
+		assertEquals("商品名0", rs.getString("PRODUCT_NAME"));
+		assertEquals("ショウヒンメイゼロ", rs.getString("PRODUCT_KANA_NAME"));
+		assertEquals("1234567890123", rs.getString("JAN_CODE"));
+		assertEquals("0番目の商品", rs.getString("PRODUCT_DESCRIPTION"));
+	}
+
+	/**
+	 * クエリ実行処理のテストケース。
+	 */
+	@Test
+	public void testQueryList() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		SqlContext ctx = agent.contextFrom("example/select_product").paramList("product_id", Arrays.asList(0, 1, 2, 3));
 
 		ResultSet rs = agent.query(ctx);
 		assertNotNull("ResultSetが取得できませんでした。", rs);
@@ -260,7 +303,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		ResultSet rs = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3).resultSet();
+		ResultSet rs = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3).resultSet();
 		assertNotNull("ResultSetが取得できませんでした。", rs);
 		assertTrue("結果が0件です。", rs.next());
 		assertEquals("0", rs.getString("PRODUCT_ID"));
@@ -278,7 +321,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.collect();
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -297,7 +340,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.collect(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -316,7 +359,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		List<Product> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		List<Product> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.collect(Product.class);
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Product product = ans.get(0);
@@ -342,7 +385,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		List<Map<String, Object>> ans = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		List<Map<String, Object>> ans = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.collect();
 		assertEquals("結果の件数が一致しません。", 2, ans.size());
 		Map<String, Object> map = ans.get(0);
@@ -361,7 +404,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.first();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
@@ -378,13 +421,13 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 		try {
-			agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3).one();
+			agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3).one();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.one();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
@@ -408,7 +451,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.first();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -433,14 +476,14 @@ public class SqlAgentTest {
 		agent = config.agent();
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.one();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.one();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -458,7 +501,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0, 1, 2, 3).findFirst();
+				.paramArray("product_id", 0, 1, 2, 3).findFirst();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -468,7 +511,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JAN_CODE"));
 		assertEquals("0番目の商品", map.get("PRODUCT_DESCRIPTION"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
@@ -482,13 +525,13 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3).findOne();
+					.paramArray("product_id", 0, 1, 2, 3).findOne();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0).findOne();
+				.paramArray("product_id", 0).findOne();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -498,7 +541,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JAN_CODE"));
 		assertEquals("0番目の商品", map.get("PRODUCT_DESCRIPTION"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
@@ -518,7 +561,7 @@ public class SqlAgentTest {
 		agent = config.agent();
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0, 1, 2, 3).findFirst();
+				.paramArray("product_id", 0, 1, 2, 3).findFirst();
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -528,7 +571,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("jan_code"));
 		assertEquals("0番目の商品", map.get("product_description"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
@@ -548,14 +591,14 @@ public class SqlAgentTest {
 		agent = config.agent();
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.findOne();
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.findOne();
 		assertTrue(optional.isPresent());
 
@@ -566,7 +609,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("jan_code"));
 		assertEquals("0番目の商品", map.get("product_description"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
@@ -578,7 +621,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		Map<String, Object> map = agent.query("example/select_product").paramList("product_id", 0, 1, 2, 3)
+		Map<String, Object> map = agent.query("example/select_product").paramArray("product_id", 0, 1, 2, 3)
 				.first(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -597,14 +640,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.one(CaseFormat.LOWER_SNAKE_CASE);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Map<String, Object> map = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.one(CaseFormat.LOWER_SNAKE_CASE);
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
@@ -622,7 +665,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0, 1, 2, 3).findFirst(CaseFormat.PASCAL_CASE);
+				.paramArray("product_id", 0, 1, 2, 3).findFirst(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
 		Map<String, Object> map = optional.get();
@@ -632,7 +675,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JanCode"));
 		assertEquals("0番目の商品", map.get("ProductDescription"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findFirst();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findFirst();
 		assertFalse(optional.isPresent());
 	}
 
@@ -646,14 +689,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.findOne(CaseFormat.PASCAL_CASE);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Map<String, Object>> optional = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.findOne(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
@@ -664,7 +707,7 @@ public class SqlAgentTest {
 		assertEquals("1234567890123", map.get("JanCode"));
 		assertEquals("0番目の商品", map.get("ProductDescription"));
 
-		optional = agent.query("example/select_product").paramList("product_id", 4).findOne();
+		optional = agent.query("example/select_product").paramArray("product_id", 4).findOne();
 		assertFalse(optional.isPresent());
 	}
 
@@ -677,7 +720,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Product product = agent.query("example/select_product")
-				.paramList("product_id", 0, 1, 2, 3)
+				.paramArray("product_id", 0, 1, 2, 3)
 				.first(Product.class);
 
 		assertEquals(0, product.getProductId());
@@ -696,7 +739,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		Optional<Product> optional = agent.query("example/select_product")
-				.paramList("product_id", 0, 1, 2, 3)
+				.paramArray("product_id", 0, 1, 2, 3)
 				.findFirst(Product.class);
 
 		assertTrue(optional.isPresent());
@@ -710,7 +753,7 @@ public class SqlAgentTest {
 		assertEquals("0番目の商品", product.getProductDescription());
 
 		optional = agent.query("example/select_product")
-				.paramList("product_id", 4)
+				.paramArray("product_id", 4)
 				.findFirst(Product.class);
 
 		assertFalse(optional.isPresent());
@@ -725,14 +768,14 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.one(Product.class);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Product product = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.one(Product.class);
 
 		assertEquals(0, product.getProductId());
@@ -752,14 +795,14 @@ public class SqlAgentTest {
 
 		try {
 			agent.query("example/select_product")
-					.paramList("product_id", 0, 1, 2, 3)
+					.paramArray("product_id", 0, 1, 2, 3)
 					.findOne(Product.class);
 			assertTrue(false);
 		} catch (DataNonUniqueException e) {
 			// OK
 		}
 		Optional<Product> optional = agent.query("example/select_product")
-				.paramList("product_id", 0)
+				.paramArray("product_id", 0)
 				.findOne(Product.class);
 		assertTrue(optional.isPresent());
 
@@ -772,7 +815,7 @@ public class SqlAgentTest {
 		assertEquals("0番目の商品", product.getProductDescription());
 
 		optional = agent.query("example/select_product")
-				.paramList("product_id", 4)
+				.paramArray("product_id", 4)
 				.findOne(Product.class);
 
 		assertFalse(optional.isPresent());
@@ -787,7 +830,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product");
-		ctx.paramList("product_id", 0, 1);
+		ctx.paramArray("product_id", 0, 1);
 
 		agent.query(ctx, (rs) -> {
 			ResultSetMetaData rsmd = rs.getMetaData();
@@ -820,7 +863,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramList("product_id", 0, 1)
+		agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.stream().forEach((m) -> {
 					assertTrue(m.containsKey("PRODUCT_ID"));
 					assertTrue(m.containsKey("PRODUCT_NAME"));
@@ -831,7 +874,7 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("UPD_DATETIME"));
 					assertTrue(m.containsKey("VERSION_NO"));
 				});
-		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
 
 	}
 
@@ -843,7 +886,7 @@ public class SqlAgentTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramList("product_id", 0, 1)
+		agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.stream(CaseFormat.LOWER_SNAKE_CASE).forEach((m) -> {
 					assertTrue(m.containsKey("product_id"));
 					assertTrue(m.containsKey("product_name"));
@@ -854,7 +897,7 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("upd_datetime"));
 					assertTrue(m.containsKey("version_no"));
 				});
-		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
@@ -872,7 +915,7 @@ public class SqlAgentTest {
 		config.getSqlAgentFactory().setDefaultMapKeyCaseFormat(CaseFormat.LOWER_SNAKE_CASE);
 		agent = config.agent();
 
-		agent.query("example/select_product").paramList("product_id", 0, 1)
+		agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.stream().forEach((m) -> {
 					assertTrue(m.containsKey("product_id"));
 					assertTrue(m.containsKey("product_name"));
@@ -883,7 +926,7 @@ public class SqlAgentTest {
 					assertTrue(m.containsKey("upd_datetime"));
 					assertTrue(m.containsKey("version_no"));
 				});
-		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
@@ -924,7 +967,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		agent.query("example/select_product")
-				.paramList("product_id", 0, 1)
+				.paramArray("product_id", 0, 1)
 				.stream(Product.class)
 				.forEach(p -> {
 					assertNotNull(p.getProductId());
@@ -936,7 +979,7 @@ public class SqlAgentTest {
 					assertNotNull(p.getUpdDatetime());
 					assertNotNull(p.getVersionNo());
 				});
-		assertThat(agent.query("example/select_product").paramList("product_id", 0, 1).stream().count(), is(2L));
+		assertThat(agent.query("example/select_product").paramArray("product_id", 0, 1).stream().count(), is(2L));
 	}
 
 	/**
@@ -948,7 +991,7 @@ public class SqlAgentTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		SqlContext ctx = agent.contextFrom("example/select_product");
-		ctx.paramList("product_id", 0, 1);
+		ctx.paramArray("product_id", 0, 1);
 
 		List<Map<String, Object>> ans = agent.query(ctx, CaseFormat.CAMEL_CASE);
 		assertThat(ans.size(), is(2));
@@ -965,7 +1008,7 @@ public class SqlAgentTest {
 		});
 
 		SqlContext ctx2 = agent.contextFrom("example/select_product");
-		ctx2.paramList("product_id", 0, 1);
+		ctx2.paramArray("product_id", 0, 1);
 
 		List<Map<String, Object>> ans2 = agent.query(ctx2, CaseFormat.UPPER_SNAKE_CASE);
 		assertThat(ans2.size(), is(2));
@@ -990,7 +1033,7 @@ public class SqlAgentTest {
 		truncateTable("product_regist_work");
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-		agent.query("example/select_product").paramList("product_id", 0, 1)
+		agent.query("example/select_product").paramArray("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.forEach((m) -> {
 					try {
@@ -1023,7 +1066,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 0, 1)
+				.paramArray("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1047,7 +1090,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 0, 1)
+				.paramArray("product_id", 0, 1)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1084,7 +1127,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2)
+				.paramArray("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1125,7 +1168,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2)
+				.paramArray("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
@@ -1159,7 +1202,7 @@ public class SqlAgentTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchNull.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.paramList("product_id", 1, 2)
+				.paramArray("product_id", 1, 2)
 				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 

--- a/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
+++ b/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
@@ -14,15 +14,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Test;
+
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.connection.DefaultConnectionSupplierImpl;
 import jp.co.future.uroborosql.dialect.H2Dialect;
 import jp.co.future.uroborosql.store.SqlManagerImpl;
 import jp.co.future.uroborosql.utils.CaseFormat;
-
-import org.apache.commons.lang3.StringUtils;
-import org.h2.jdbcx.JdbcDataSource;
-import org.junit.Test;
 
 public class UroboroSQLTest {
 	private List<Map<String, Object>> getDataFromFile(final Path path) {
@@ -180,7 +180,7 @@ public class UroboroSQLTest {
 
 			insert(agent, Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-			agent.query("example/select_product").paramList("product_id", 0, 1)
+			agent.query("example/select_product").paramArray("product_id", 0, 1)
 					.stream().forEach((m) -> {
 						assertTrue(m.containsKey("productId"));
 						assertTrue(m.containsKey("productName"));

--- a/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
+++ b/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.DriverManager;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,7 +181,7 @@ public class UroboroSQLTest {
 
 			insert(agent, Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
-			agent.query("example/select_product").paramArray("product_id", 0, 1)
+			agent.query("example/select_product").param("product_id", Arrays.asList(0, 1))
 					.stream().forEach((m) -> {
 						assertTrue(m.containsKey("productId"));
 						assertTrue(m.containsKey("productName"));

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
@@ -308,7 +308,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 		SqlContextFactory factory = config.getSqlContextFactory();
 
 		final int productId = 2;
-		Consumer<SqlContext> binder1 = (ctx) -> ctx.paramArrayIfAbsent("product_id", productId);
+		Consumer<SqlContext> binder1 = (ctx) -> ctx.paramIfAbsent("product_id", productId);
 		factory.addQueryAutoParameterBinder(binder1);
 
 		try (SqlAgent agent = config.agent()) {

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
@@ -17,16 +17,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.exception.UroborosqlSQLException;
 import jp.co.future.uroborosql.utils.CaseFormat;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class SqlContextFactoryAutoParameterBinderTest {
 	private static SqlConfig config;
@@ -140,7 +140,8 @@ public class SqlContextFactoryAutoParameterBinderTest {
 			assertThat(
 					agent.queryWith(
 							"select * from PRODUCT where 1 = 1/*IF upd_datetime != null */ AND UPD_DATETIME = /*upd_datetime*/ /*END*/")
-							.collect().size(), is(2));
+							.collect().size(),
+					is(2));
 		}
 
 		config.getSqlContextFactory().removeUpdateAutoParameterBinder(binder);
@@ -307,7 +308,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 		SqlContextFactory factory = config.getSqlContextFactory();
 
 		final int productId = 2;
-		Consumer<SqlContext> binder1 = (ctx) -> ctx.paramListIfAbsent("product_id", productId);
+		Consumer<SqlContext> binder1 = (ctx) -> ctx.paramArrayIfAbsent("product_id", productId);
 		factory.addQueryAutoParameterBinder(binder1);
 
 		try (SqlAgent agent = config.agent()) {
@@ -359,10 +360,9 @@ public class SqlContextFactoryAutoParameterBinderTest {
 			// insert
 			assertThat(agent.batch("example/insert_product").paramStream(input.stream()).count(), is(count));
 
-			long dateCount =
-					agent.query("example/select_product").stream(CaseFormat.LOWER_SNAKE_CASE)
-							.map(r -> r.get("ins_datetime"))
-							.distinct().count();
+			long dateCount = agent.query("example/select_product").stream(CaseFormat.LOWER_SNAKE_CASE)
+					.map(r -> r.get("ins_datetime"))
+					.distinct().count();
 			// ins_datetimeが同じ時間になっていないことを確認
 			assertNotEquals(1, dateCount);
 		}

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
@@ -197,37 +197,17 @@ public class SqlContextImplTest {
 		assertFalse(ctx.hasParam("key2"));
 	}
 
-	@Test
-	public void testParamArray() throws Exception {
-		SqlContext ctx = null;
-
-		ctx = getSqlContext("select * from dummy");
-		ctx.paramArray("key1", "value1");
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1")));
-
-		ctx = getSqlContext("select * from dummy");
-		ctx.paramArray("key1", "value1", "value2");
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-
-		String[] values = { "value1", "value2" };
-		ctx = getSqlContext("select * from dummy");
-		ctx.paramArray("key1", () -> {
-			return values;
-		});
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-
-	}
-
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testParamList() throws Exception {
 		SqlContext ctx = null;
 
 		ctx = getSqlContext("select * from dummy");
-		ctx.paramList("key1", Arrays.asList("value1"));
+		ctx.paramList("key1", "value1");
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1")));
 
 		ctx = getSqlContext("select * from dummy");
-		ctx.paramList("key1", Arrays.asList("value1", "value2"));
+		ctx.paramList("key1", "value1", "value2");
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 		Set<String> values = new HashSet<>();
@@ -235,7 +215,7 @@ public class SqlContextImplTest {
 		values.add("value2");
 
 		ctx = getSqlContext("select * from dummy");
-		ctx.paramList("key1", values);
+		ctx.param("key1", values);
 		assertThat(ctx.getParam("key1").getValue(), is(values));
 
 		ctx = getSqlContext("select * from dummy");
@@ -269,21 +249,9 @@ public class SqlContextImplTest {
 		assertThat(ctx.getParam("key1").getValue(), is("value1"));
 
 		ctx = getSqlContext("select * from dummy");
-		ctx.paramArrayIfAbsent("key1", "value1", "value2");
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-		ctx.paramArrayIfAbsent("key1", "value11", "value22");
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-
-		ctx = getSqlContext("select * from dummy");
 		ctx.paramListIfAbsent("key1", "value1", "value2");
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 		ctx.paramListIfAbsent("key1", "value11", "value22");
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-
-		ctx = getSqlContext("select * from dummy");
-		ctx.paramListIfAbsent("key1", Arrays.asList("value1", "value2"));
-		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
-		ctx.paramListIfAbsent("key1", Arrays.asList("value11", "value22"));
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 		ctx = getSqlContext("select * from dummy");

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
@@ -10,8 +10,13 @@ import java.io.StringReader;
 import java.sql.JDBCType;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
@@ -20,9 +25,6 @@ import jp.co.future.uroborosql.parameter.StreamParameter;
 import jp.co.future.uroborosql.parser.ContextTransformer;
 import jp.co.future.uroborosql.parser.SqlParser;
 import jp.co.future.uroborosql.parser.SqlParserImpl;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class SqlContextImplTest {
 	private static SqlConfig config = null;
@@ -55,7 +57,8 @@ public class SqlContextImplTest {
 		assertEquals(replaceLineSep("select * from test where /* comment */ aaa = 1"), ctx3.getExecutableSql());
 
 		SqlContext ctx4 = getSqlContext("select * from test where -- /* comment */  [LF] and aaa = 1");
-		assertEquals(replaceLineSep("select * from test where -- /* comment */  [LF] aaa = 1"), ctx4.getExecutableSql());
+		assertEquals(replaceLineSep("select * from test where -- /* comment */  [LF] aaa = 1"),
+				ctx4.getExecutableSql());
 
 		SqlContext ctx5 = getSqlContext("select * from test where -- /* comment */  [LF] order = 1");
 		assertEquals(replaceLineSep("select * from test where -- /* comment */  [LF] order = 1"),
@@ -141,19 +144,24 @@ public class SqlContextImplTest {
 		SqlContext ctx2 = getSqlContext("insert into (, aaa, bbb, ccc) values (,111 ,222 ,333)");
 		assertEquals(replaceLineSep("insert into ( aaa, bbb, ccc) values (111 ,222 ,333)"), ctx2.getExecutableSql());
 
-		SqlContext ctx3 = getSqlContext("insert into ([LF], aaa[LF], bbb[LF], ccc[LF]) values (,[LF]111,[LF]222,[LF]333[LF])");
+		SqlContext ctx3 = getSqlContext(
+				"insert into ([LF], aaa[LF], bbb[LF], ccc[LF]) values (,[LF]111,[LF]222,[LF]333[LF])");
 		assertEquals(
 				replaceLineSep("insert into ([LF] aaa[LF], bbb[LF], ccc[LF]) values ([LF]111,[LF]222,[LF]333[LF])"),
 				ctx3.getExecutableSql());
 
-		SqlContext ctx4 = getSqlContext("insert into ([LF]/* comment */, aaa[LF], bbb[LF], ccc[LF]) values (/* comment */,[LF]111,[LF]222,[LF]333[LF])");
+		SqlContext ctx4 = getSqlContext(
+				"insert into ([LF]/* comment */, aaa[LF], bbb[LF], ccc[LF]) values (/* comment */,[LF]111,[LF]222,[LF]333[LF])");
 		assertEquals(
-				replaceLineSep("insert into ([LF]/* comment */ aaa[LF], bbb[LF], ccc[LF]) values (/* comment */[LF]111,[LF]222,[LF]333[LF])"),
+				replaceLineSep(
+						"insert into ([LF]/* comment */ aaa[LF], bbb[LF], ccc[LF]) values (/* comment */[LF]111,[LF]222,[LF]333[LF])"),
 				ctx4.getExecutableSql());
 
-		SqlContext ctx5 = getSqlContext("insert into (--comment[LF], aaa[LF], bbb[LF], ccc[LF]) values (,/*comment*/[LF]111,[LF]222,[LF]333[LF])");
+		SqlContext ctx5 = getSqlContext(
+				"insert into (--comment[LF], aaa[LF], bbb[LF], ccc[LF]) values (,/*comment*/[LF]111,[LF]222,[LF]333[LF])");
 		assertEquals(
-				replaceLineSep("insert into (--comment[LF] aaa[LF], bbb[LF], ccc[LF]) values (/*comment*/[LF]111,[LF]222,[LF]333[LF])"),
+				replaceLineSep(
+						"insert into (--comment[LF] aaa[LF], bbb[LF], ccc[LF]) values (/*comment*/[LF]111,[LF]222,[LF]333[LF])"),
 				ctx5.getExecutableSql());
 	}
 
@@ -171,7 +179,8 @@ public class SqlContextImplTest {
 		assertEquals(replaceLineSep("update test set[LF]aaa = 111, bbb = 222, ccc = 333 where 1 = 1"),
 				ctx3.getExecutableSql());
 
-		SqlContext ctx4 = getSqlContext("update test set /* comment */[LF],aaa = 111, bbb = 222, ccc = 333 where 1 = 1");
+		SqlContext ctx4 = getSqlContext(
+				"update test set /* comment */[LF],aaa = 111, bbb = 222, ccc = 333 where 1 = 1");
 		assertEquals(replaceLineSep("update test set /* comment */[LF]aaa = 111, bbb = 222, ccc = 333 where 1 = 1"),
 				ctx4.getExecutableSql());
 
@@ -188,6 +197,55 @@ public class SqlContextImplTest {
 		assertFalse(ctx.hasParam("key2"));
 	}
 
+	@Test
+	public void testParamArray() throws Exception {
+		SqlContext ctx = null;
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramArray("key1", "value1");
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1")));
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramArray("key1", "value1", "value2");
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+
+		String[] values = { "value1", "value2" };
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramArray("key1", () -> {
+			return values;
+		});
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+
+	}
+
+	@Test
+	public void testParamList() throws Exception {
+		SqlContext ctx = null;
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramList("key1", Arrays.asList("value1"));
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1")));
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramList("key1", Arrays.asList("value1", "value2"));
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+
+		Set<String> values = new HashSet<>();
+		values.add("value1");
+		values.add("value2");
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramList("key1", values);
+		assertThat(ctx.getParam("key1").getValue(), is(values));
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramList("key1", () -> {
+			return values;
+		});
+		assertThat(ctx.getParam("key1").getValue(), is(values));
+	}
+
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testIfAbsent() throws Exception {
 		SqlContext ctx = null;
@@ -211,9 +269,21 @@ public class SqlContextImplTest {
 		assertThat(ctx.getParam("key1").getValue(), is("value1"));
 
 		ctx = getSqlContext("select * from dummy");
+		ctx.paramArrayIfAbsent("key1", "value1", "value2");
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+		ctx.paramArrayIfAbsent("key1", "value11", "value22");
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+
+		ctx = getSqlContext("select * from dummy");
 		ctx.paramListIfAbsent("key1", "value1", "value2");
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 		ctx.paramListIfAbsent("key1", "value11", "value22");
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+
+		ctx = getSqlContext("select * from dummy");
+		ctx.paramListIfAbsent("key1", Arrays.asList("value1", "value2"));
+		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
+		ctx.paramListIfAbsent("key1", Arrays.asList("value11", "value22"));
 		assertThat(ctx.getParam("key1").getValue(), is(Arrays.asList("value1", "value2")));
 
 		ctx = getSqlContext("select * from dummy");

--- a/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterTest.java
@@ -21,16 +21,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.testlog.TestAppender;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class AuditLogSqlFilterTest {
 	private SqlConfig config;
@@ -122,7 +122,7 @@ public class AuditLogSqlFilterTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = agent.contextFrom("example/select_product")
-					.paramList("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterTest.java
@@ -122,7 +122,7 @@ public class AuditLogSqlFilterTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = agent.contextFrom("example/select_product")
-					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.param("product_id", Arrays.asList(new BigDecimal("0"), new BigDecimal("2")))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterWithToStringStyleTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterWithToStringStyleTest.java
@@ -129,7 +129,7 @@ public class AuditLogSqlFilterWithToStringStyleTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = this.agent.contextFrom("example/select_product")
-					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.param("product_id", Arrays.asList(new BigDecimal("0"), new BigDecimal("2")))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterWithToStringStyleTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/AuditLogSqlFilterWithToStringStyleTest.java
@@ -129,7 +129,7 @@ public class AuditLogSqlFilterWithToStringStyleTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = this.agent.contextFrom("example/select_product")
-					.paramList("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/filter/DumpResultSqlFilterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/DumpResultSqlFilterTest.java
@@ -18,16 +18,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.testlog.TestAppender;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class DumpResultSqlFilterTest {
 
@@ -120,7 +120,7 @@ public class DumpResultSqlFilterTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = agent.contextFrom("example/select_product")
-					.paramList("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/filter/DumpResultSqlFilterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/filter/DumpResultSqlFilterTest.java
@@ -120,7 +120,7 @@ public class DumpResultSqlFilterTest {
 
 		List<String> log = TestAppender.getLogbackLogs(() -> {
 			SqlContext ctx = agent.contextFrom("example/select_product")
-					.paramArray("product_id", new BigDecimal("0"), new BigDecimal("2"))
+					.param("product_id", Arrays.asList(new BigDecimal("0"), new BigDecimal("2")))
 					.param("_userName", "testUserName").param("_funcId", "testFunction").setSqlId("111");
 			ctx.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE);
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/ParameterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/ParameterTest.java
@@ -127,7 +127,7 @@ public class ParameterTest {
 	public void testSetInParameter_array() throws SQLException {
 
 		try (SqlAgent agent = config.agent()) {
-			SqlContext ctx = agent.contextFrom("test/PARAM_MAPPING3").paramList("targetStrs", "1", "2", "3");
+			SqlContext ctx = agent.contextFrom("test/PARAM_MAPPING3").paramArray("targetStrs", "1", "2", "3");
 
 			try (ResultSet rs = agent.query(ctx)) {
 				assertThat("結果が0件です。", rs.next(), is(true));
@@ -155,7 +155,7 @@ public class ParameterTest {
 
 			assertThat("更新件数が一致しません",
 					agent.updateWith("INSERT INTO BYTE_ARRAY_TEST VALUES (/*id*/, /*data*/)").param("id", 1)
-					.param("data", "test".getBytes()).count(),
+							.param("data", "test".getBytes()).count(),
 					is(1));
 		}
 	}

--- a/src/test/java/jp/co/future/uroborosql/parameter/ParameterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/ParameterTest.java
@@ -123,11 +123,12 @@ public class ParameterTest {
 	 *
 	 * @throws SQLException SQL例外
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSetInParameter_array() throws SQLException {
 
 		try (SqlAgent agent = config.agent()) {
-			SqlContext ctx = agent.contextFrom("test/PARAM_MAPPING3").paramArray("targetStrs", "1", "2", "3");
+			SqlContext ctx = agent.contextFrom("test/PARAM_MAPPING3").paramList("targetStrs", "1", "2", "3");
 
 			try (ResultSet rs = agent.query(ctx)) {
 				assertThat("結果が0件です。", rs.next(), is(true));


### PR DESCRIPTION
fixed #196 

add paramArray methods.
 - <V> SqlFluent#paramArray(String paramName, V... value);
 - <V> SqlFluent#paramArray(String paramName, Supplire<V[]> supplier);
 - <V> SqlFluent#paramArrayIfAbsent(String paramName, V... value);

add paramList methods.
 - <V> SqlFluent#paramList(String paramName, Iterable<V> value);
 - <V> SqlFluent#paramList(String paramName, Supplire<Iterable<V>> supplier);
 - <V> SqlFluent#paramListIfAbsent(String paramName, Iterable<V> value);

deprecated
 - <V> SqlFluent#paramList(String paramName, V... value);
 - <V> SqlFluent#paramListIfAbsent(String paramName, V... value);


and SqlFluent#paramXXX methods change from `Object value` to `type parameter (V) value`
