### PR TITLE
Api change ExtractionCondition#where() methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.co.future</groupId>
 	<artifactId>uroborosql</artifactId>
-	<version>0.16.0-SNAPSHOT</version>
+	<version>0.15.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>uroboroSQL</name>
 	<description>Developer-oriented and SQL centric database access library</description>

--- a/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractSqlFluent.java
@@ -91,7 +91,7 @@ abstract class AbstractSqlFluent<T extends SqlFluent<T>> implements SqlFluent<T>
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T paramMap(final Map<String, ?> paramMap) {
+	public T paramMap(final Map<String, Object> paramMap) {
 		if (paramMap != null) {
 			paramMap.forEach((k, v) -> param(k, v));
 		}

--- a/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
@@ -25,6 +25,7 @@ import jp.co.future.uroborosql.mapping.TableMetadata;
  */
 final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntityUpdate<E>>
 		implements SqlEntityUpdate<E> {
+	/** エンティティハンドラー */
 	private final EntityHandler<?> entityHandler;
 
 	/**
@@ -41,6 +42,11 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 		this.entityHandler = entityHandler;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#count()
+	 */
 	@Override
 	public int count() {
 		try {
@@ -51,27 +57,47 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#set(java.lang.String, java.lang.Object)
+	 */
 	@Override
-	public <V> SqlEntityUpdate<E> set(final String paramName, final V value) {
-		param(paramName, value);
+	public <V> SqlEntityUpdate<E> set(final String col, final V value) {
+		param(col, value);
 		return this;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#set(java.lang.String, java.util.function.Supplier)
+	 */
 	@Override
-	public <V> SqlEntityUpdate<E> set(final String paramName, final Supplier<V> supplier) {
-		param(paramName, supplier);
+	public <V> SqlEntityUpdate<E> set(final String col, final Supplier<V> supplier) {
+		param(col, supplier);
 		return this;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#set(java.lang.String, java.lang.Object, int)
+	 */
 	@Override
-	public <V> SqlEntityUpdate<E> set(final String paramName, final V value, final int sqlType) {
-		param(paramName, value, sqlType);
+	public <V> SqlEntityUpdate<E> set(final String col, final V value, final int sqlType) {
+		param(col, value, sqlType);
 		return this;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#set(java.lang.String, java.lang.Object, java.sql.SQLType)
+	 */
 	@Override
-	public <V> SqlEntityUpdate<E> set(final String paramName, final V value, final SQLType sqlType) {
-		param(paramName, value, sqlType);
+	public <V> SqlEntityUpdate<E> set(final String col, final V value, final SQLType sqlType) {
+		param(col, value, sqlType);
 		return this;
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -511,7 +511,7 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramMap(java.util.Map)
 	 */
 	@Override
-	public SqlContext paramMap(final Map<String, ?> paramMap) {
+	public SqlContext paramMap(final Map<String, Object> paramMap) {
 		if (paramMap != null) {
 			paramMap.forEach((k, v) -> param(k, v));
 		}

--- a/src/main/java/jp/co/future/uroborosql/fluent/ExtractionCondition.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/ExtractionCondition.java
@@ -6,6 +6,12 @@
  */
 package jp.co.future.uroborosql.fluent;
 
+import java.io.InputStream;
+import java.io.Reader;
+import java.sql.SQLType;
+import java.util.Map;
+import java.util.function.Supplier;
+
 /**
  * 抽出条件インタフェース
  * @author H.Sugimoto
@@ -15,87 +21,98 @@ package jp.co.future.uroborosql.fluent;
 public interface ExtractionCondition<T> extends SqlFluent<T> {
 
 	/**
-	 * Where句に equal 条件を追加する
+	 * Where句に equal 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T equal(String col, Object value);
+	<V> T equal(String col, V value);
 
 	/**
-	 * Where句に not equal 条件を追加する
+	 * Where句に not equal 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T notEqual(String col, Object value);
+	<V> T notEqual(String col, V value);
 
 	/**
-	 * Where句に greater than 条件を追加する
+	 * Where句に greater than 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T greaterThan(String col, Object value);
+	<V> T greaterThan(String col, V value);
 
 	/**
-	 * Where句に less than 条件を追加する
+	 * Where句に less than 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T lessThan(String col, Object value);
+	<V> T lessThan(String col, V value);
 
 	/**
-	 * Where句に greater equal 条件を追加する
+	 * Where句に greater equal 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T greaterEqual(String col, Object value);
+	<V> T greaterEqual(String col, V value);
 
 	/**
-	 * Where句に less equal 条件を追加する
+	 * Where句に less equal 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param value 値
 	 * @return T
 	 */
-	T lessEqual(String col, Object value);
+	<V> T lessEqual(String col, V value);
 
 	/**
-	 * Where句に in 条件を追加する
+	 * Where句に in 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param values 値の配列
 	 * @return T
 	 */
-	T in(String col, Object... values);
+	<V> T in(String col, @SuppressWarnings("unchecked") V... values);
 
 	/**
-	 * Where句に in 条件を追加する
+	 * Where句に in 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param valueList 値の集合
 	 * @return T
 	 */
-	T in(String col, Iterable<?> valueList);
+	<V> T in(String col, Iterable<V> valueList);
 
 	/**
-	 * Where句に not in 条件を追加する
+	 * Where句に not in 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param values 値の配列
 	 * @return T
 	 */
-	T notIn(String col, Object... values);
+	<V> T notIn(String col, @SuppressWarnings("unchecked") V... values);
 
 	/**
-	 * Where句に not in 条件を追加する
+	 * Where句に not in 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param valueList 値の集合
 	 * @return T
 	 */
-	T notIn(String col, Iterable<?> valueList);
+	<V> T notIn(String col, Iterable<V> valueList);
 
 	/**
-	 * Where句に like 条件を追加する。検索文字列はエスケープしない
+	 * Where句に like 条件を追加する. 検索文字列はエスケープしない.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -103,7 +120,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T like(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に前方一致条件を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に前方一致条件を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -111,7 +129,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T startsWith(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に後方一致条件を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に後方一致条件を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -119,7 +138,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T endsWith(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に 部分一致条件を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に 部分一致条件を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -127,7 +147,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T contains(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に not like 条件を追加する
+	 * Where句に not like 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -135,7 +156,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T notLike(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に前方一致条件の否定を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に前方一致条件の否定を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -143,7 +165,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T notStartsWith(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に後方一致条件の否定を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に後方一致条件の否定を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -151,7 +174,8 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T notEndsWith(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に 部分一致条件の否定を追加する。検索文字列は内部でエスケープされる。
+	 * Where句に 部分一致条件の否定を追加する. 検索文字列は内部でエスケープされる.
+	 *
 	 * @param col bind column name
 	 * @param searchValue 検索文字列
 	 * @return T
@@ -159,33 +183,258 @@ public interface ExtractionCondition<T> extends SqlFluent<T> {
 	T notContains(String col, CharSequence searchValue);
 
 	/**
-	 * Where句に between 条件を追加する
+	 * Where句に between 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @param fromValue 開始値
 	 * @param toValue 終了値
 	 * @return T
 	 */
-	T between(String col, Object fromValue, Object toValue);
+	<V> T between(String col, V fromValue, V toValue);
 
 	/**
-	 * Where句に is null 条件を追加する
+	 * Where句に is null 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @return T
 	 */
 	T isNull(String col);
 
 	/**
-	 * Where句に is not null 条件を追加する
+	 * Where句に is not null 条件を追加する.
+	 *
 	 * @param col bind column name
 	 * @return T
 	 */
 	T isNotNull(String col);
 
 	/**
-	 * Where句に 素の文字列指定で 条件を追加する。複数回呼び出した場合はそれぞれの条件をANDで結合する。
+	 * Where句に 素の文字列指定で 条件を追加する. 複数回呼び出した場合はそれぞれの条件をANDで結合する.
+	 *
 	 * @param rawString Where句に出力する条件式
 	 * @return T
 	 */
 	T where(CharSequence rawString);
+
+	/**
+	 * Where句に 素の文字列指定で 条件を追加する. 複数回呼び出した場合はそれぞれの条件をANDで結合する.
+	 *
+	 * @param rawString Where句に出力する条件式
+	 * @param paramName 条件式にバインドするパラメータ名
+	 * @param value 条件式にバインドする値
+	 * @return T
+	 */
+	<V> T where(CharSequence rawString, String paramName, V value);
+
+	/**
+	 * Where句に 素の文字列指定で 条件を追加する. 複数回呼び出した場合はそれぞれの条件をANDで結合する.
+	 *
+	 * @param rawString Where句に出力する条件式
+	 * @param paramMap 条件式にバインドするパラメータ群
+	 * @return T
+	 */
+	T where(CharSequence rawString, Map<String, Object> paramMap);
+
+	// deprecated methods
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.lang.Object)
+	 */
+	@Override
+	@Deprecated
+	<V> T param(final String paramName, final V value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.util.function.Supplier)
+	 */
+	@Override
+	@Deprecated
+	<V> T param(final String paramName, final Supplier<V> supplier);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object)
+	 */
+	@Override
+	@Deprecated
+	<V> T paramIfAbsent(final String paramName, final V value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.lang.Object[])
+	 */
+	@Override
+	@Deprecated
+	<V> T paramList(final String paramName, @SuppressWarnings("unchecked") final V... value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramList(java.lang.String, java.util.function.Supplier)
+	 */
+	@Override
+	@Deprecated
+	<V> T paramList(final String paramName, final Supplier<Iterable<V>> supplier);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramListIfAbsent(java.lang.String, java.lang.Object[])
+	 */
+	@Override
+	@Deprecated
+	<V> T paramListIfAbsent(final String paramName, @SuppressWarnings("unchecked") final V... value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramMap(java.util.Map)
+	 */
+	@Override
+	@Deprecated
+	T paramMap(final Map<String, Object> paramMap);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramBean(java.lang.Object)
+	 */
+	@Override
+	@Deprecated
+	<V> T paramBean(final V bean);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.lang.Object, java.sql.SQLType)
+	 */
+	@Override
+	@Deprecated
+	<V> T param(final String paramName, final V value, final SQLType sqlType);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object, java.sql.SQLType)
+	 */
+	@Override
+	@Deprecated
+	<V> T paramIfAbsent(final String paramName, final V value, final SQLType sqlType);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#param(java.lang.String, java.lang.Object, int)
+	 */
+	@Override
+	@Deprecated
+	<V> T param(final String paramName, final V value, final int sqlType);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#paramIfAbsent(java.lang.String, java.lang.Object, int)
+	 */
+	@Override
+	@Deprecated
+	<V> T paramIfAbsent(final String paramName, final V value, final int sqlType);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりに {@link ExtractionCondition#equal(String, Object)} を使用してください.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#blobParam(java.lang.String, java.io.InputStream)
+	 */
+	@Override
+	@Deprecated
+	T blobParam(final String paramName, final InputStream value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#blobParamIfAbsent(java.lang.String, java.io.InputStream)
+	 */
+	@Override
+	@Deprecated
+	T blobParamIfAbsent(final String paramName, final InputStream value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#blobParam(java.lang.String, java.io.InputStream, int)
+	 */
+	@Override
+	@Deprecated
+	T blobParam(final String paramName, final InputStream value, final int len);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#blobParamIfAbsent(java.lang.String, java.io.InputStream, int)
+	 */
+	@Override
+	@Deprecated
+	T blobParamIfAbsent(final String paramName, final InputStream value, final int len);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#clobParam(java.lang.String, java.io.Reader)
+	 */
+	@Override
+	@Deprecated
+	T clobParam(final String paramName, final Reader value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#clobParamIfAbsent(java.lang.String, java.io.Reader)
+	 */
+	@Override
+	@Deprecated
+	T clobParamIfAbsent(final String paramName, final Reader value);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#clobParam(java.lang.String, java.io.Reader, int)
+	 */
+	@Override
+	@Deprecated
+	T clobParam(final String paramName, final Reader value, final int len);
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated 代わりはありません.
+	 * @see jp.co.future.uroborosql.fluent.SqlFluent#clobParamIfAbsent(java.lang.String, java.io.Reader, int)
+	 */
+	@Override
+	@Deprecated
+	T clobParamIfAbsent(final String paramName, final Reader value, final int len);
 
 }

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityUpdate.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityUpdate.java
@@ -23,12 +23,42 @@ public interface SqlEntityUpdate<E> extends ExtractionCondition<SqlEntityUpdate<
 	 */
 	int count();
 
-	<V> SqlEntityUpdate<E> set(final String paramName, final V value);
+	/**
+	 * 更新する値の設定.
+	 *
+	 * @param col 更新するカラム名（キャメルケース）
+	 * @param value 更新する値
+	 * @return SqlEntityUpdate
+	 */
+	<V> SqlEntityUpdate<E> set(final String col, final V value);
 
-	<V> SqlEntityUpdate<E> set(final String paramName, final Supplier<V> supplier);
+	/**
+	 * 更新する値の設定.
+	 *
+	 * @param col 更新するカラム名（キャメルケース）
+	 * @param supplier 更新する値を提供するサプライヤ
+	 * @return SqlEntityUpdate
+	 */
+	<V> SqlEntityUpdate<E> set(final String col, final Supplier<V> supplier);
 
-	<V> SqlEntityUpdate<E> set(final String paramName, final V value, final int sqlType);
+	/**
+	 * 更新する値の設定.
+	 *
+	 * @param col 更新するカラム名（キャメルケース）
+	 * @param value 更新する値
+	 * @param sqlType SQLタイプ
+	 * @return SqlEntityUpdate
+	 */
+	<V> SqlEntityUpdate<E> set(final String col, final V value, final int sqlType);
 
-	<V> SqlEntityUpdate<E> set(final String paramName, final V value, final SQLType sqlType);
+	/**
+	 * 更新する値の設定.
+	 *
+	 * @param col 更新するカラム名（キャメルケース）
+	 * @param value 更新する値
+	 * @param sqlType SQLタイプ
+	 * @return SqlEntityUpdate
+	 */
+	<V> SqlEntityUpdate<E> set(final String col, final V value, final SQLType sqlType);
 
 }

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlFluent.java
@@ -118,7 +118,7 @@ public interface SqlFluent<T> {
 	 * @param paramMap パラメータのKey-Valueセット
 	 * @return T
 	 */
-	T paramMap(Map<String, ?> paramMap);
+	T paramMap(Map<String, Object> paramMap);
 
 	/**
 	 * 引数として渡されたObjectのフィールド名と値のセットをパラメータに追加<br>

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
@@ -120,4 +120,27 @@ public class SqlEntityQueryTest extends AbstractDbTest {
 		assertThat(empty.isPresent(), is(false));
 	}
 
+	@Test
+	public void testCollectParam() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		@SuppressWarnings("deprecation")
+		List<Product> products = agent.query(Product.class)
+				.param("productId", 0)
+				.collect();
+
+		products.forEach(p -> {
+			assertNotNull(p.getProductId());
+			assertNotNull(p.getProductName());
+			assertNotNull(p.getProductKanaName());
+			assertNotNull(p.getJanCode());
+			assertNotNull(p.getProductDescription());
+			assertNotNull(p.getInsDatetime());
+			assertNotNull(p.getUpdDatetime());
+			assertNotNull(p.getVersionNo());
+		});
+		assertThat(products.size(), is(1));
+	}
+
 }


### PR DESCRIPTION
- Api change ExtractionCondition#where() methods.
- And add deprecated to param() (and similar methods).
- ExtractionCondition use Type Parameter.
- SqlEntityUpdate add Javadoc

fixed #214