### PR TITLE
Modified to use CamelCase#convert() for col in SqlEntityUpdate#set().

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
@@ -16,6 +16,7 @@ import jp.co.future.uroborosql.exception.EntitySqlRuntimeException;
 import jp.co.future.uroborosql.fluent.SqlEntityUpdate;
 import jp.co.future.uroborosql.mapping.EntityHandler;
 import jp.co.future.uroborosql.mapping.TableMetadata;
+import jp.co.future.uroborosql.utils.CaseFormat;
 
 /**
  * SqlEntityQuery実装
@@ -64,7 +65,7 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 	 */
 	@Override
 	public <V> SqlEntityUpdate<E> set(final String col, final V value) {
-		param(col, value);
+		param(CaseFormat.CAMEL_CASE.convert(col), value);
 		return this;
 	}
 
@@ -75,7 +76,7 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 	 */
 	@Override
 	public <V> SqlEntityUpdate<E> set(final String col, final Supplier<V> supplier) {
-		param(col, supplier);
+		param(CaseFormat.CAMEL_CASE.convert(col), supplier);
 		return this;
 	}
 
@@ -86,7 +87,7 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 	 */
 	@Override
 	public <V> SqlEntityUpdate<E> set(final String col, final V value, final int sqlType) {
-		param(col, value, sqlType);
+		param(CaseFormat.CAMEL_CASE.convert(col), value, sqlType);
 		return this;
 	}
 
@@ -97,7 +98,7 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 	 */
 	@Override
 	public <V> SqlEntityUpdate<E> set(final String col, final V value, final SQLType sqlType) {
-		param(col, value, sqlType);
+		param(CaseFormat.CAMEL_CASE.convert(col), value, sqlType);
 		return this;
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -33,6 +33,18 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 	}
 
 	@Test
+	public void testCountByEntitySingleSnakeCase() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		agent.required(() -> {
+			assertThat(agent.update(Product.class).set("product_name", "商品名_new").equal("product_id", 1).count(),
+					is(1));
+			assertThat(agent.query(Product.class).equal("product_id", 1).one().get().getProductName(), is("商品名_new"));
+		});
+	}
+
+	@Test
 	public void testCountByEntityMulti() {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
@@ -70,6 +82,21 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 	}
 
 	@Test
+	public void testCountByEntitySetSupplierSnakeCase() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		agent.required(() -> {
+			assertThat(
+					agent.update(Product.class).set("product_name", () -> "商品名_new").greaterEqual("product_id", 0)
+							.count(),
+					is(2));
+			assertThat(agent.query(Product.class).equal("product_id", 0).one().get().getProductName(), is("商品名_new"));
+			assertThat(agent.query(Product.class).equal("product_id", 1).one().get().getProductName(), is("商品名_new"));
+		});
+	}
+
+	@Test
 	public void testCountByEntitySetIntType() {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
@@ -86,6 +113,22 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 	}
 
 	@Test
+	public void testCountByEntitySetIntTypeSnakeCase() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		agent.required(() -> {
+			assertThat(
+					agent.update(Product.class).set("product_name", "商品名_new", JDBCType.VARCHAR.getVendorTypeNumber())
+							.greaterEqual("product_id", 0)
+							.count(),
+					is(2));
+			assertThat(agent.query(Product.class).equal("product_id", 0).one().get().getProductName(), is("商品名_new"));
+			assertThat(agent.query(Product.class).equal("product_id", 1).one().get().getProductName(), is("商品名_new"));
+		});
+	}
+
+	@Test
 	public void testCountByEntitySetType() {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
@@ -98,6 +141,22 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 					is(2));
 			assertThat(agent.query(Product.class).equal("productId", 0).one().get().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("productId", 1).one().get().getProductName(), is("商品名_new"));
+		});
+	}
+
+	@Test
+	public void testCountByEntitySetTypeSnakeCase() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		agent.required(() -> {
+			assertThat(
+					agent.update(Product.class).set("product_name", "商品名_new", JDBCType.VARCHAR)
+							.greaterEqual("product_id", 0)
+							.count(),
+					is(2));
+			assertThat(agent.query(Product.class).equal("product_id", 0).one().get().getProductName(), is("商品名_new"));
+			assertThat(agent.query(Product.class).equal("product_id", 1).one().get().getProductName(), is("商品名_new"));
 		});
 	}
 


### PR DESCRIPTION
fix #220
SqlEntityUpdate modified to perform the CamelCase#convert() for the arguments col of set().