### PR TITLE
The forUpdate clause output in the SQL generated by query combining SqlEntityQuery#notExists() and SqlEntityQuery#forUpdate()

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -87,56 +87,62 @@ public interface SqlAgentFactory {
 	String PROPS_KEY_DEFAULT_FOR_UPDATE_WAIT_SECONDS = "defaultForUpdateWaitSeconds";
 
 	/**
-	 * SQL実行クラス生成。
+	 * プロパティ:ForUpdateTypeの指定を厳格に扱うかどうか<br>
+	 * デフォルトは<code>false</code>
+	 */
+	String PROPS_KEY_STRICT_FOR_UPDATE_TYPE = "strictForUpdateType";
+
+	/**
+	 * SQL実行クラス生成.
 	 *
 	 * @return SqlAgent
 	 */
 	SqlAgent createSqlAgent();
 
 	/**
-	 * SQL管理クラスを取得します。
+	 * SQL管理クラスを取得する.
 	 *
-	 * @return SQL管理クラス。
+	 * @return SQL管理クラス
 	 */
 	SqlManager getSqlManager();
 
 	/**
-	 * SqlFilter管理クラスを取得します。
+	 * SqlFilter管理クラスを取得する.
 	 *
 	 * @return SqlFilter管理クラス
 	 */
 	SqlFilterManager getSqlFilterManager();
 
 	/**
-	 * コネクション供給クラスを取得します。
+	 * コネクション供給クラスを取得する.
 	 *
 	 * @return コネクション供給クラス
 	 */
 	ConnectionSupplier getConnectionSupplier();
 
 	/**
-	 * ORM処理クラスを取得します。
+	 * ORM処理クラスを取得する.
 	 *
 	 * @return ORM処理クラス
 	 */
 	EntityHandler<?> getEntityHandler();
 
 	/**
-	 * SqlConfigの設定[
+	 * SqlConfigを設定する.
 	 *
 	 * @param sqlConfig SqlConfig
 	 */
 	void setSqlConfig(final SqlConfig sqlConfig);
 
 	/**
-	 * 例外発生時のログ出力を行うかどうかを取得します。
+	 * 例外発生時のログ出力を行うかどうかを取得する.
 	 *
 	 * @return 例外発生時のログ出力を行うかどうか。ログ出力する場合は<code>true</code>
 	 */
 	boolean isOutputExceptionLog();
 
 	/**
-	 * 例外発生時のログ出力を行うかどうかを設定します。
+	 * 例外発生時のログ出力を行うかどうかを設定する.
 	 *
 	 * @param outputExceptionLog 例外発生時のログ出力を行うかどうか。ログ出力する場合は<code>true</code>
 	 * @return SqlAgentFactory
@@ -144,14 +150,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setOutputExceptionLog(final boolean outputExceptionLog);
 
 	/**
-	 * フェッチサイズを取得します
+	 * フェッチサイズを取得する.
 	 *
 	 * @return フェッチサイズ
 	 */
 	int getFetchSize();
 
 	/**
-	 * フェッチサイズを設定する
+	 * フェッチサイズを設定する.
 	 *
 	 * @param fetchSize フェッチサイズ
 	 * @return SqlAgentFactory
@@ -159,14 +165,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setFetchSize(final int fetchSize);
 
 	/**
-	 * フェッチサイズを取得します
+	 * フェッチサイズを取得する.
 	 *
 	 * @return フェッチサイズ
 	 */
 	int getQueryTimeout();
 
 	/**
-	 * クエリタイムアウトを設定する
+	 * クエリタイムアウトを設定する.
 	 *
 	 * @param queryTimeout クエリタイムアウト
 	 * @return SqlAgentFactory
@@ -174,14 +180,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setQueryTimeout(final int queryTimeout);
 
 	/**
-	 * SQLをリトライ実行するSQLエラーコードのリスト を取得します
+	 * SQLをリトライ実行するSQLエラーコードのリスト を取得する.
 	 *
 	 * @return SQLをリトライ実行するSQLエラーコードのリスト
 	 */
 	List<String> getSqlRetryCodeList();
 
 	/**
-	 * SQLをリトライ実行するSQLエラーコードのリスト を設定します
+	 * SQLをリトライ実行するSQLエラーコードのリスト を設定する.
 	 *
 	 * @param sqlRetryCodeList SQLをリトライ実行するSQLエラーコードのリスト
 	 * @return SqlAgentFactory
@@ -189,14 +195,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setSqlRetryCodeList(final List<String> sqlRetryCodeList);
 
 	/**
-	 * 最大リトライカウントの初期値を取得します
+	 * 最大リトライカウントの初期値を取得する.
 	 *
 	 * @return 最大リトライカウントの初期値
 	 */
 	int getDefaultMaxRetryCount();
 
 	/**
-	 * 最大リトライカウントの初期値を設定する
+	 * 最大リトライカウントの初期値を設定する.
 	 *
 	 * @param defaultMaxRetryCount 最大リトライカウントの初期値
 	 * @return SqlAgentFactory
@@ -204,14 +210,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setDefaultMaxRetryCount(final int defaultMaxRetryCount);
 
 	/**
-	 * SQLリトライ時の待機時間（ms）の初期値を取得します
+	 * SQLリトライ時の待機時間（ms）の初期値を取得する.
 	 *
 	 * @return SQLリトライ時の待機時間（ms）の初期値
 	 */
 	int getDefaultSqlRetryWaitTime();
 
 	/**
-	 * SQLリトライ時の待機時間（ms）の初期値を設定する
+	 * SQLリトライ時の待機時間（ms）の初期値を設定する.
 	 *
 	 * @param defaultSqlRetryWaitTime SQLリトライ時の待機時間（ms）の初期値
 	 * @return SqlAgentFactory
@@ -219,14 +225,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setDefaultSqlRetryWaitTime(final int defaultSqlRetryWaitTime);
 
 	/**
-	 * SQL_IDを置換するためのKEY文字列を取得します
+	 * SQL_IDを置換するためのKEY文字列を取得する.
 	 *
 	 * @return SQL_IDを置換するためのKEY文字列
 	 */
 	String getSqlIdKeyName();
 
 	/**
-	 * SQL_IDを置換するためのKEY文字列を設定する
+	 * SQL_IDを置換するためのKEY文字列を設定する.
 	 *
 	 * @param sqlIdKeyName SQL_IDを置換するためのKEY文字列
 	 * @return SqlAgentFactory
@@ -234,14 +240,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setSqlIdKeyName(final String sqlIdKeyName);
 
 	/**
-	 * Queryの結果を格納するMapのキーを生成する際に使用するCaseFormatを取得する
+	 * Queryの結果を格納するMapのキーを生成する際に使用するCaseFormatを取得する.
 	 *
 	 * @return Queryの結果を格納するMapのキーを生成する際に使用するCaseFormat
 	 */
 	CaseFormat getDefaultMapKeyCaseFormat();
 
 	/**
-	 * Queryの結果を格納するMapのキーを生成する際に使用するCaseFormatを設定する
+	 * Queryの結果を格納するMapのキーを生成する際に使用するCaseFormatを設定する.
 	 *
 	 * @param defaultMapKeyCaseFormat Queryの結果を格納するMapのキーを生成する際に使用するCaseFormat
 	 * @return SqlAgentFactory
@@ -249,7 +255,7 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setDefaultMapKeyCaseFormat(CaseFormat defaultMapKeyCaseFormat);
 
 	/**
-	 * デフォルトの{@link InsertsType}を取得する
+	 * デフォルトの{@link InsertsType}を取得する.
 	 *
 	 * @return insertsType
 	 * @see jp.co.future.uroborosql.enums.InsertsType
@@ -257,7 +263,7 @@ public interface SqlAgentFactory {
 	InsertsType getDefaultInsertsType();
 
 	/**
-	 * デフォルトの{@link InsertsType}を設定する
+	 * デフォルトの{@link InsertsType}を設定する.
 	 *
 	 * @param defaultInsertsType デフォルトの{@link InsertsType}
 	 * @return SqlAgentFactory
@@ -266,13 +272,14 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setDefaultInsertsType(InsertsType defaultInsertsType);
 
 	/**
-	 * トランザクション内での更新を強制するかどうかを取得する
+	 * トランザクション内での更新を強制するかどうかを取得する.
+	 *
 	 * @return トランザクション内でのみ更新可能とする場合<code>true</code>
 	 */
 	boolean isForceUpdateWithinTransaction();
 
 	/**
-	 * トランザクション内での更新を強制するかどうかを設定する<br>
+	 * トランザクション内での更新を強制するかどうかを設定する.<br>
 	 * <code>true</code>を指定するとトランザクションを開始していない状態で SELECT文以外のSQLを発行すると {@link UroborosqlTransactionException}をスローする
 	 *
 	 * @param forceUpdateWithinTransaction トランザクション内でのみ更新可能とするかどうか。
@@ -281,18 +288,33 @@ public interface SqlAgentFactory {
 	SqlAgentFactory setForceUpdateWithinTransaction(boolean forceUpdateWithinTransaction);
 
 	/**
-	 * 明示的な行ロック時の待機時間(s)デフォルト値を取得します
+	 * 明示的な行ロック時の待機時間(s)デフォルト値を取得する.
 	 *
 	 * @return 明示的な行ロック時の待機時間(s)デフォルト値
 	 */
 	int getDefaultForUpdateWaitSeconds();
 
 	/**
-	 * 明示的な行ロック時の待機時間(s)デフォルト値を設定する
+	 * 明示的な行ロック時の待機時間(s)デフォルト値を設定する.
 	 *
 	 * @param defaultForUpdateWaitSeconds 明示的な行ロック時の待機時間(s)デフォルト値
 	 * @return SqlAgentFactory
 	 */
 	SqlAgentFactory setDefaultForUpdateWaitSeconds(final int defaultForUpdateWaitSeconds);
+
+	/**
+	 * ForUpdateTypeの指定を厳格に扱うかどうかを取得する.
+	 *
+	 * @return ForUpdateTypeの指定を厳格に扱うかどうか
+	 */
+	boolean isStrictForUpdateType();
+
+	/**
+	 * ForUpdateTypeの指定を厳格に扱うかどうかを設定する.
+	 *
+	 * @param strictForUpdateType ForUpdateTypeの指定を厳格に扱うかどうか
+	 * @return SqlAgentFactory
+	 */
+	SqlAgentFactory setStrictForUpdateType(boolean strictForUpdateType);
 
 }

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -322,7 +322,8 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	@Override
 	public boolean isForceUpdateWithinTransaction() {
 		return Boolean
-				.parseBoolean(getDefaultProps().getOrDefault(PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION, "FALSE"));
+				.parseBoolean(getDefaultProps().getOrDefault(PROPS_KEY_FORCE_UPDATE_WITHIN_TRANSACTION,
+						Boolean.FALSE.toString()));
 	}
 
 	/**
@@ -364,6 +365,28 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	@Override
 	public SqlAgentFactory setDefaultForUpdateWaitSeconds(final int defaultForUpdateWaitSeconds) {
 		getDefaultProps().put(PROPS_KEY_DEFAULT_FOR_UPDATE_WAIT_SECONDS, String.valueOf(defaultForUpdateWaitSeconds));
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#isStrictForUpdateType()
+	 */
+	@Override
+	public boolean isStrictForUpdateType() {
+		return Boolean.parseBoolean(
+				getDefaultProps().getOrDefault(PROPS_KEY_STRICT_FOR_UPDATE_TYPE, Boolean.FALSE.toString()));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.SqlAgentFactory#setStrictForUpdateType(boolean)
+	 */
+	@Override
+	public SqlAgentFactory setStrictForUpdateType(final boolean strictForUpdateType) {
+		getDefaultProps().put(PROPS_KEY_STRICT_FOR_UPDATE_TYPE, Boolean.toString(strictForUpdateType));
 		return this;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -659,6 +659,10 @@ public class DefaultEntityHandlerTest {
 				config.getSqlAgentFactory().setDefaultForUpdateWaitSeconds(30);
 				assertThat(config.getSqlAgentFactory().getDefaultForUpdateWaitSeconds(), is(30));
 
+				assertThat(config.getSqlAgentFactory().isStrictForUpdateType(), is(false));
+				config.getSqlAgentFactory().setStrictForUpdateType(true);
+				assertThat(config.getSqlAgentFactory().isStrictForUpdateType(), is(true));
+
 				agent.required(() -> {
 					List<TestEntity3> list = agent.query(TestEntity3.class).forUpdate().collect();
 					assertThat(list.size(), is(4));
@@ -696,6 +700,36 @@ public class DefaultEntityHandlerTest {
 				} catch (Throwable th) {
 					fail();
 				}
+
+				config.getSqlAgentFactory().setStrictForUpdateType(false);
+				try {
+					assertThat(agent.query(TestEntity3.class).forUpdateNoWait().first().isPresent(), is(true));
+				} catch (Throwable th) {
+					fail();
+				}
+
+				try {
+					assertThat(agent.query(TestEntity3.class).forUpdateWait().first().isPresent(), is(true));
+				} catch (Throwable th) {
+					fail();
+				}
+
+				try {
+					assertThat(agent.query(TestEntity3.class).forUpdateWait(10).first().isPresent(), is(true));
+				} catch (Throwable th) {
+					fail();
+				}
+
+				try {
+					agent.query(TestEntity3.class)
+							.equal("id", 3).forUpdate()
+							.notExists(() -> {
+								throw new IllegalStateException();
+							});
+				} catch (Throwable th) {
+					fail();
+				}
+
 			});
 		}
 	}


### PR DESCRIPTION
fixed #222

- forUpdate clause output in the SQL generated by query combining `SqlEntityQuery#notExists()` and  `SqlEntityQuery#forUpdate()`.
- Add SqlAgentFactory#isStrictForUpdateType() and SqlAgentFactory#setStrictForUpdateType(boolean)
- fix javadoc comment.