### PR TITLE
bugfix #218 and enhancement #224

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgent.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.config.SqlConfigAware;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.ResultSetConverter;
 import jp.co.future.uroborosql.coverage.CoverageHandler;
@@ -34,7 +34,7 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  * @author H.Sugimoto
  */
 
-public interface SqlAgent extends AutoCloseable, TransactionManager {
+public interface SqlAgent extends AutoCloseable, TransactionManager, SqlConfigAware {
 	/**
 	 * {@link SqlAgent#inserts(Stream, InsertsCondition)}の一括更新用のフレームの判定条件.<br>
 	 *
@@ -144,14 +144,6 @@ public interface SqlAgent extends AutoCloseable, TransactionManager {
 	Map<String, Object> procedure(SqlContext sqlContext) throws SQLException;
 
 	/**
-	 * クローズ処理
-	 *
-	 * @see java.lang.AutoCloseable#close()
-	 */
-	@Override
-	void close();
-
-	/**
 	 * フェッチサイズ取得。
 	 *
 	 * @return フェッチサイズ
@@ -208,40 +200,6 @@ public interface SqlAgent extends AutoCloseable, TransactionManager {
 	 * @see jp.co.future.uroborosql.enums.InsertsType
 	 */
 	void setDefaultInsertsType(InsertsType defaultInsertsType);
-
-	/**
-	 * トランザクションのコミット用API<br>
-	 * <br>
-	 * 実装はオプション。APIを提供しない場合は{@link UnsupportedOperationException}をスローすること
-	 *
-	 * @throws UnsupportedOperationException この操作を提供しない場合
-	 */
-	@Override
-	void commit();
-
-	/**
-	 * トランザクションのロールバック用API<br>
-	 * <br>
-	 * 実装はオプション。APIを提供しない場合は{@link UnsupportedOperationException}をスローすること
-	 *
-	 * @throws UnsupportedOperationException この操作を提供しない場合
-	 */
-	@Override
-	void rollback();
-
-	/**
-	 * SQL設定管理クラスの取得
-	 *
-	 * @return SQL設定管理クラスインスタンス
-	 */
-	SqlConfig getSqlConfig();
-
-	/**
-	 * SQL設定管理クラスの設定
-	 *
-	 * @param config SQL設定管理クラスインスタンス
-	 */
-	void setSqlConfig(SqlConfig config);
 
 	/**
 	 * 空のSqlContextの生成

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -8,7 +8,7 @@ package jp.co.future.uroborosql;
 
 import java.util.List;
 
-import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.config.SqlConfigAware;
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.exception.UroborosqlTransactionException;
@@ -22,7 +22,7 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  *
  * @author H.Sugimoto
  */
-public interface SqlAgentFactory {
+public interface SqlAgentFactory extends SqlConfigAware {
 	/** ファクトリBean名 */
 	String FACTORY_BEAN_NAME = "sqlAagentFactory";
 
@@ -120,13 +120,6 @@ public interface SqlAgentFactory {
 	 * @return ORM処理クラス
 	 */
 	EntityHandler<?> getEntityHandler();
-
-	/**
-	 * SqlConfigの設定[
-	 *
-	 * @param sqlConfig SqlConfig
-	 */
-	void setSqlConfig(final SqlConfig sqlConfig);
 
 	/**
 	 * 例外発生時のログ出力を行うかどうかを取得します。

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -109,7 +109,17 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.SqlAgentFactory#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#getSqlConfig()
+	 */
+	@Override
+	public SqlConfig getSqlConfig() {
+		return this.sqlConfig;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
 	 */
 	@Override
 	public void setSqlConfig(final SqlConfig sqlConfig) {

--- a/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
+++ b/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
@@ -267,6 +267,7 @@ public final class UroboroSQL {
 			this.sqlContextFactory.setSqlFilterManager(this.sqlFilterManager);
 			this.sqlContextFactory.initialize();
 			this.sqlAgentFactory.setSqlConfig(this);
+			this.entityHandler.setSqlConfig(this);
 		}
 
 		/**

--- a/src/main/java/jp/co/future/uroborosql/config/SqlConfigAware.java
+++ b/src/main/java/jp/co/future/uroborosql/config/SqlConfigAware.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.config;
 
 /**

--- a/src/main/java/jp/co/future/uroborosql/config/SqlConfigAware.java
+++ b/src/main/java/jp/co/future/uroborosql/config/SqlConfigAware.java
@@ -1,0 +1,23 @@
+package jp.co.future.uroborosql.config;
+
+/**
+ * SqlConfigに対するアクセスインタフェース
+ *
+ * @author H.Sugimoto
+ */
+public interface SqlConfigAware {
+
+	/**
+	 * SqlConfigの設定.
+	 *
+	 * @param sqlConfig SqlConfig
+	 */
+	void setSqlConfig(SqlConfig sqlConfig);
+
+	/**
+	 * SqlConfigの取得.
+	 *
+	 * @return SqlConfig
+	 */
+	SqlConfig getSqlConfig();
+}

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -183,4 +183,14 @@ public interface Dialect {
 	 * @return FOR UPDATE句を追加したSQL文
 	 */
 	StringBuilder addForUpdateClause(StringBuilder sql, ForUpdateType forUpdateType, int waitSeconds);
+
+	/**
+	 * 乗除を行うためのSQL文字列を取得する
+	 * @param dividend 除算される値
+	 * @param divisor 除算する値
+	 * @return 乗除を行うためのSQL文字列
+	 */
+	default String getModLiteral(final String dividend, final String divisor) {
+		return dividend + " % " + divisor;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
@@ -99,4 +99,13 @@ public abstract class OracleDialect extends AbstractDialect {
 	 */
 	protected abstract boolean isTargetVersion(int majorVersion);
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getModLiteral(java.lang.String, java.lang.String)
+	 */
+	@Override
+	public String getModLiteral(final String dividend, final String divisor) {
+		return "MOD(" + dividend + ", " + divisor + ")";
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/CyclicLockVersionOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/CyclicLockVersionOptimisticLockSupplier.java
@@ -1,0 +1,24 @@
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+
+/**
+ * 循環式ロックバージョンによる楽観ロックサプライヤクラス
+ *
+ * @author H.Sugimoto
+ */
+public class CyclicLockVersionOptimisticLockSupplier extends OptimisticLockSupplier {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.OptimisticLockSupplier#getPart(jp.co.future.uroborosql.mapping.TableMetadata.Column, jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
+		String modPart = sqlConfig.getDialect().getModLiteral(versionColumn.getColumnIdentifier(),
+				"1" + new String(new char[versionColumn.getColumnSize() - 1]).replace("\0", "0"));
+		return versionColumn.getColumnIdentifier() + " = (" + modPart + ") + 1";
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/CyclicLockVersionOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/CyclicLockVersionOptimisticLockSupplier.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.mapping;
 
 import jp.co.future.uroborosql.config.SqlConfig;

--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -592,7 +592,7 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 
 		StringBuilder sql = new StringBuilder("INSERT ").append("/* ")
 				.append(sqlConfig.getSqlAgentFactory().getSqlIdKeyName()).append(" */")
-				.append(" INTO ").append(metadata.getTableIdentifier()).append("(").append(System.lineSeparator());
+				.append(" INTO ").append(metadata.getTableIdentifier()).append(" (").append(System.lineSeparator());
 
 		boolean firstFlag = true;
 		for (TableMetadata.Column col : metadata.getColumns()) {

--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -40,6 +40,7 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 	private static Map<Class<?>, TableMetadata> CONTEXTS = new ConcurrentHashMap<>();
 	private final PropertyMapperManager propertyMapperManager = new PropertyMapperManager();
 	private boolean emptyStringEqualsNull = true;
+	private SqlConfig sqlConfig = null;
 
 	/**
 	 * {@inheritDoc}
@@ -752,4 +753,25 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 	private String buildBulkParamName(final String base, final int entityIndex) {
 		return base + "$" + entityIndex;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public void setSqlConfig(final SqlConfig sqlConfig) {
+		this.sqlConfig = sqlConfig;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#getSqlConfig()
+	 */
+	@Override
+	public SqlConfig getSqlConfig() {
+		return this.sqlConfig;
+	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.util.stream.Stream;
 
 import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.config.SqlConfigAware;
 import jp.co.future.uroborosql.connection.ConnectionManager;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.mapping.mapper.PropertyMapper;
@@ -20,7 +21,7 @@ import jp.co.future.uroborosql.mapping.mapper.PropertyMapper;
  * @param <ENTITY> エンティティクラス
  * @author ota
  */
-public interface EntityHandler<ENTITY> {
+public interface EntityHandler<ENTITY> extends SqlConfigAware {
 	/**
 	 * エンティティ型を返す
 	 *

--- a/src/main/java/jp/co/future/uroborosql/mapping/FieldIncrementOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/FieldIncrementOptimisticLockSupplier.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.mapping;
 
 import jp.co.future.uroborosql.config.SqlConfig;

--- a/src/main/java/jp/co/future/uroborosql/mapping/FieldIncrementOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/FieldIncrementOptimisticLockSupplier.java
@@ -1,0 +1,23 @@
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+
+/**
+ * フィールド値のインクリメントによる楽観ロックサプライヤクラス
+ *
+ * @author H.Sugimoto
+ */
+public class FieldIncrementOptimisticLockSupplier extends OptimisticLockSupplier {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.OptimisticLockSupplier#getPart(jp.co.future.uroborosql.mapping.TableMetadata.Column, jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
+		return versionColumn.getColumnIdentifier() + " = /*(" + versionColumn.getCamelColumnName()
+				+ " + @java.lang.Short@valueOf(1))*/";
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/LockVersionOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/LockVersionOptimisticLockSupplier.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.mapping;
 
 import jp.co.future.uroborosql.config.SqlConfig;

--- a/src/main/java/jp/co/future/uroborosql/mapping/LockVersionOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/LockVersionOptimisticLockSupplier.java
@@ -1,0 +1,22 @@
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+
+/**
+ * ロックバージョンによる楽観ロックサプライヤクラス
+ *
+ * @author H.Sugimoto
+ */
+public class LockVersionOptimisticLockSupplier extends OptimisticLockSupplier {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.OptimisticLockSupplier#getPart(jp.co.future.uroborosql.mapping.TableMetadata.Column, jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
+		return versionColumn.getColumnIdentifier() + " = " + versionColumn.getColumnIdentifier() + " + 1";
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/MappingColumn.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MappingColumn.java
@@ -10,6 +10,7 @@ import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.mapping.annotations.GeneratedValue;
 import jp.co.future.uroborosql.mapping.annotations.SequenceGenerator;
 import jp.co.future.uroborosql.mapping.annotations.Transient;
+import jp.co.future.uroborosql.mapping.annotations.Version;
 
 /**
  * カラムマッピングインターフェース
@@ -118,4 +119,11 @@ public interface MappingColumn {
 	 * @return バージョンカラムの場合は<code>true</code>
 	 */
 	boolean isVersion();
+
+	/**
+	 * {@link Version} の取得
+	 *
+	 * @return {@link Version}
+	 */
+	Version getVersion();
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
@@ -63,7 +63,7 @@ public final class MappingUtils {
 		private final GeneratedValue generatedValue;
 		private final SequenceGenerator sequenceGenerator;
 		private final Transient transientAnno;
-		private final boolean isVersion;
+		private final Version versionAnno;
 
 		MappingColumnImpl(final Field field, final JavaType javaType) {
 			this.field = field;
@@ -83,7 +83,7 @@ public final class MappingUtils {
 			this.generatedValue = field.getAnnotation(GeneratedValue.class);
 			this.sequenceGenerator = field.getAnnotation(SequenceGenerator.class);
 			this.transientAnno = field.getAnnotation(Transient.class);
-			this.isVersion = field.getAnnotation(Version.class) != null;
+			this.versionAnno = field.getAnnotation(Version.class);
 
 			if (this.isId && this.generatedValue == null) {
 				throw new UroborosqlRuntimeException("@Id annotation is set in the field [" + field.getName()
@@ -217,7 +217,17 @@ public final class MappingUtils {
 		 */
 		@Override
 		public boolean isVersion() {
-			return isVersion;
+			return this.versionAnno != null;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.MappingColumn#getVersion()
+		 */
+		@Override
+		public Version getVersion() {
+			return this.versionAnno;
 		}
 	}
 

--- a/src/main/java/jp/co/future/uroborosql/mapping/OptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/OptimisticLockSupplier.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.mapping;
 
 import java.util.Map;
@@ -24,6 +30,7 @@ public abstract class OptimisticLockSupplier {
 	/**
 	 * 楽観ロックサプライヤの取得
 	 *
+	 * @param supplier 楽観ロックサプライヤクラス
 	 * @return 楽観ロックサプライヤ
 	 * @throws UroborosqlRuntimeException 指定した楽観ロックサプライヤがServiceLoaderに登録されていない場合
 	 */

--- a/src/main/java/jp/co/future/uroborosql/mapping/OptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/OptimisticLockSupplier.java
@@ -1,0 +1,48 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+
+/**
+ * 楽観ロックサプライヤ
+ *
+ * @author H.Sugimoto
+ */
+public abstract class OptimisticLockSupplier {
+	private static final Map<Class<? extends OptimisticLockSupplier>, OptimisticLockSupplier> suppliers = new ConcurrentHashMap<>();
+
+	static {
+		for (OptimisticLockSupplier supplier : ServiceLoader.load(OptimisticLockSupplier.class)) {
+			suppliers.put(supplier.getClass(), supplier);
+		}
+	}
+
+	/**
+	 * 楽観ロックサプライヤの取得
+	 *
+	 * @return 楽観ロックサプライヤ
+	 * @throws UroborosqlRuntimeException 指定した楽観ロックサプライヤがServiceLoaderに登録されていない場合
+	 */
+	public static OptimisticLockSupplier getSupplier(final Class<? extends OptimisticLockSupplier> supplier) {
+		if (suppliers.containsKey(supplier)) {
+			return suppliers.get(supplier);
+		} else {
+			throw new UroborosqlRuntimeException(
+					"OptimisticLockSupplier not found in ServiceLoader. class=" + supplier.toString());
+		}
+	}
+
+	/**
+	 * バージョンカラムの設定を行うためのSQLパーツを取得する.
+	 *
+	 * @param versionColumn バージョンカラム
+	 * @param sqlConfig SqlConfig
+	 * @return バージョンカラムの設定を行うためのSQLパーツ
+	 */
+	public abstract String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig);
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -28,6 +29,9 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  * @author ota
  */
 public interface TableMetadata {
+	/** QuoteStringで囲む必要があるテーブルのパターン(大文字小文字混在、もしくは英数字以外を含む) */
+	Pattern TABLE_NAME_PATTERN = Pattern.compile("(?=.*[a-z])(?=.*[A-Z]).*|.*[^A-Za-z0-9_].*");
+
 	/**
 	 * カラム情報
 	 */
@@ -247,7 +251,11 @@ public interface TableMetadata {
 		}
 		entityMetadata.setSchema(schema);
 		entityMetadata.setTableName(tableName);
-		entityMetadata.setIdentifierQuoteString(identifierQuoteString);
+		if (TABLE_NAME_PATTERN.matcher(tableName).matches()) {
+			entityMetadata.setIdentifierQuoteString(identifierQuoteString);
+		} else {
+			entityMetadata.setIdentifierQuoteString("");
+		}
 		try (ResultSet rs = metaData.getPrimaryKeys(null, StringUtils.isEmpty(schema) ? "%" : schema, tableName)) {
 			while (rs.next()) {
 				String columnName = rs.getString(4);

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
@@ -69,6 +69,13 @@ public interface TableMetadata {
 		int getDataType();
 
 		/**
+		 * カラムサイズ取得
+		 *
+		 * @return カラムサイズ
+		 */
+		int getColumnSize();
+
+		/**
 		 * 主キー内の連番取得 (値1は主キーの最初の列、値2は主キーの2番目の列を表す)。
 		 *
 		 * @return 主キー内の連番
@@ -242,8 +249,10 @@ public interface TableMetadata {
 					String isNullable = rs.getString("IS_NULLABLE");
 					int ordinalPosition = rs.getInt("ORDINAL_POSITION");
 
-					TableMetadataImpl.Column column = new TableMetadataImpl.Column(columnName, sqlType, remarks,
-							isNullable, ordinalPosition, identifierQuoteString);
+					int columnSize = rs.getInt("COLUMN_SIZE");
+
+					TableMetadataImpl.Column column = new TableMetadataImpl.Column(columnName, sqlType, columnSize,
+							remarks, isNullable, ordinalPosition, identifierQuoteString);
 					entityMetadata.addColumn(column);
 					columns.put(column.getColumnName(), column);
 				}

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
@@ -29,6 +29,7 @@ public class TableMetadataImpl implements TableMetadata {
 		private String camelName;
 		private String identifier;
 		private int dataType;
+		private final int columnSize;
 		private Integer keySeq = null;
 		private final String identifierQuoteString;
 		private final String remarks;
@@ -40,14 +41,16 @@ public class TableMetadataImpl implements TableMetadata {
 		 *
 		 * @param columnName カラム名
 		 * @param dataType データタイプ
+		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
 		 * @param nullable NULL可かどうか
 		 * @param ordinalPosition 列インデックス
 		 * @param identifierQuoteString SQL識別子を引用するのに使用する文字列
 		 */
-		public Column(final String columnName, final SQLType dataType, final String remarks, final String nullable,
-				final int ordinalPosition, final String identifierQuoteString) {
-			this(columnName, dataType.getVendorTypeNumber(), remarks, nullable, ordinalPosition, identifierQuoteString);
+		public Column(final String columnName, final SQLType dataType, final int columnSize, final String remarks,
+				final String nullable, final int ordinalPosition, final String identifierQuoteString) {
+			this(columnName, dataType.getVendorTypeNumber(), columnSize, remarks, nullable, ordinalPosition,
+					identifierQuoteString);
 		}
 
 		/**
@@ -55,15 +58,17 @@ public class TableMetadataImpl implements TableMetadata {
 		 *
 		 * @param columnName カラム名
 		 * @param dataType データタイプ
+		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
 		 * @param nullable NULL可かどうか
 		 * @param ordinalPosition 列インデックス
 		 * @param identifierQuoteString SQL識別子を引用するのに使用する文字列
 		 */
-		public Column(final String columnName, final int dataType, final String remarks, final String nullable,
-				final int ordinalPosition, final String identifierQuoteString) {
+		public Column(final String columnName, final int dataType, final int columnSize, final String remarks,
+				final String nullable, final int ordinalPosition, final String identifierQuoteString) {
 			this.columnName = columnName;
 			this.dataType = dataType;
+			this.columnSize = columnSize;
 			this.remarks = remarks;
 			this.nullable = "YES".equalsIgnoreCase(nullable);
 			this.ordinalPosition = ordinalPosition;
@@ -76,40 +81,20 @@ public class TableMetadataImpl implements TableMetadata {
 		}
 
 		/**
-		 * コンストラクタ
+		 * {@inheritDoc}
 		 *
-		 * @param columnName カラム名
-		 * @param dataType データタイプ
-		 * @param remarks コメント文字列
-		 * @param nullable NULL可かどうか
-		 * @param ordinalPosition 列インデックス
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getColumnName()
 		 */
-		@Deprecated
-		public Column(final String columnName, final SQLType dataType, final String remarks, final String nullable,
-				final int ordinalPosition) {
-			this(columnName, dataType, remarks, nullable, ordinalPosition, null);
-		}
-
-		/**
-		 * コンストラクタ
-		 *
-		 * @param columnName カラム名
-		 * @param dataType データタイプ
-		 * @param remarks コメント文字列
-		 * @param nullable NULL可かどうか
-		 * @param ordinalPosition 列インデックス
-		 */
-		@Deprecated
-		public Column(final String columnName, final int dataType, final String remarks, final String nullable,
-				final int ordinalPosition) {
-			this(columnName, dataType, remarks, nullable, ordinalPosition, null);
-		}
-
 		@Override
 		public String getColumnName() {
 			return this.columnName;
 		}
 
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getCamelColumnName()
+		 */
 		@Override
 		public String getCamelColumnName() {
 			return this.camelName != null ? this.camelName
@@ -145,6 +130,16 @@ public class TableMetadataImpl implements TableMetadata {
 		 */
 		public void setDataType(final int dataType) {
 			this.dataType = dataType;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getColumnSize()
+		 */
+		@Override
+		public int getColumnSize() {
+			return columnSize;
 		}
 
 		/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 package jp.co.future.uroborosql.mapping;
 
 import jp.co.future.uroborosql.config.SqlConfig;

--- a/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
@@ -1,0 +1,22 @@
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+
+/**
+ * タイムスタンプによる楽観ロックサプライヤクラス
+ *
+ * @author H.Sugimoto
+ */
+public class TimestampOptimisticLockSupplier extends OptimisticLockSupplier {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.OptimisticLockSupplier#getPart(jp.co.future.uroborosql.mapping.TableMetadata.Column, jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
+		return versionColumn.getColumnIdentifier() + " = " + System.currentTimeMillis();
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/annotations/Version.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/annotations/Version.java
@@ -6,7 +6,13 @@
  */
 package jp.co.future.uroborosql.mapping.annotations;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jp.co.future.uroborosql.mapping.LockVersionOptimisticLockSupplier;
+import jp.co.future.uroborosql.mapping.OptimisticLockSupplier;
 
 /**
  * エンティティ バージョン情報アノテーション
@@ -16,4 +22,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Version {
+	/** @return 楽観ロックのサプライヤクラス */
+	Class<? extends OptimisticLockSupplier> supplier() default LockVersionOptimisticLockSupplier.class;
 }

--- a/src/main/resources/META-INF/services/jp.co.future.uroborosql.mapping.OptimisticLockSupplier
+++ b/src/main/resources/META-INF/services/jp.co.future.uroborosql.mapping.OptimisticLockSupplier
@@ -1,0 +1,3 @@
+jp.co.future.uroborosql.mapping.LockVersionOptimisticLockSupplier
+jp.co.future.uroborosql.mapping.CyclicLockVersionOptimisticLockSupplier
+jp.co.future.uroborosql.mapping.TimestampOptimisticLockSupplier

--- a/src/main/resources/META-INF/services/jp.co.future.uroborosql.mapping.OptimisticLockSupplier
+++ b/src/main/resources/META-INF/services/jp.co.future.uroborosql.mapping.OptimisticLockSupplier
@@ -1,3 +1,4 @@
 jp.co.future.uroborosql.mapping.LockVersionOptimisticLockSupplier
 jp.co.future.uroborosql.mapping.CyclicLockVersionOptimisticLockSupplier
 jp.co.future.uroborosql.mapping.TimestampOptimisticLockSupplier
+jp.co.future.uroborosql.mapping.FieldIncrementOptimisticLockSupplier

--- a/src/test/java/jp/co/future/uroborosql/mapping/CustomOptimisticLockSupplier.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/CustomOptimisticLockSupplier.java
@@ -1,0 +1,23 @@
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.mapping.TableMetadata.Column;
+
+/**
+ * 例外検証のカスタム楽観ロックサプライヤ
+ *
+ * @author H.Sugimoto
+ */
+public class CustomOptimisticLockSupplier extends OptimisticLockSupplier {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.OptimisticLockSupplier#getPart(jp.co.future.uroborosql.mapping.TableMetadata.Column, jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public String getPart(final Column versionColumn, final SqlConfig sqlConfig) {
+		return null;
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierMultiByteTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierMultiByteTest.java
@@ -1,0 +1,235 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+import jp.co.future.uroborosql.mapping.annotations.Table;
+
+public class DefaultEntityHandlerIdentifierMultiByteTest {
+
+	private static SqlConfig config;
+
+	@Table(name = "日本語table")
+	public static class TestEntity {
+		private long id;
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(final long id, final String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public long getId() {
+			return this.id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setId(final long id) {
+			this.id = id;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this, true);
+		}
+
+		@Override
+		public boolean equals(final Object obj) {
+			return EqualsBuilder.reflectionEquals(this, obj, true);
+		}
+
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
+	}
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:DefaultEntityHandlerBuildSqlTest;DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists \"日本語table\"");
+				stmt.execute(
+						"create table if not exists \"日本語table\"( \"Id\" NUMERIC(4),\"Name\" VARCHAR(10), primary key(\"Id\"))");
+			}
+		}
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from \"日本語table\"").count();
+			agent.commit();
+		}
+	}
+
+	@Test
+	public void testInsert() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test1 = new TestEntity(1, "name1");
+				agent.insert(test1);
+				TestEntity test2 = new TestEntity(2, "name2");
+				agent.insert(test2);
+				TestEntity test3 = new TestEntity(3, "name3");
+				agent.insert(test3);
+				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntity.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntity.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testQuery1() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test1 = new TestEntity(1, "name1");
+				agent.insert(test1);
+				TestEntity test2 = new TestEntity(2, "name2");
+				agent.insert(test2);
+				TestEntity test3 = new TestEntity(3, "name3");
+				agent.insert(test3);
+
+				List<TestEntity> list = agent.query(TestEntity.class).collect();
+				assertThat(list.get(0), is(test1));
+				assertThat(list.get(1), is(test2));
+				assertThat(list.get(2), is(test3));
+
+				list = agent.query(TestEntity.class)
+						.equal("name", "name2")
+						.collect();
+				assertThat(list.get(0), is(test2));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdate1() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test = new TestEntity(1, "name1");
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(test));
+				assertThat(data.getName(), is("updatename"));
+			});
+		}
+	}
+
+	@Test
+	public void testDelete1() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test = new TestEntity(1, "name1");
+				agent.insert(test);
+
+				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(test));
+
+				agent.delete(test);
+
+				data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsert() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test3 = new TestEntity(3, "name3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntity.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntity.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsert() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test3 = new TestEntity(3, "name3");
+
+				int count = agent.inserts(Stream.of(test1, test2, test3));
+				assertThat(count, is(3));
+
+				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntity.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntity.class, 3).orElse(null);
+				assertThat(data, is(test3));
+
+			});
+		}
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -54,7 +54,7 @@ public class DefaultEntityHandlerTest {
 			try (Statement stmt = conn.createStatement()) {
 				stmt.execute("drop table if exists test");
 				stmt.execute(
-						"create table if not exists test( \"ID\" NUMERIC(4),name VARCHAR(10),\"Age\" NUMERIC(5),birthday DATE,memo VARCHAR(500),lock_version NUMERIC(4), primary key(id))");
+						"create table if not exists test( \"ID\" NUMERIC(4),name VARCHAR(10),\"Age\" NUMERIC(5),birthday DATE,memo VARCHAR(500),lock_version INTEGER, primary key(id))");
 				stmt.execute("comment on table test is 'test'");
 				stmt.execute("comment on column test.\"ID\" is 'id'");
 				stmt.execute("comment on column test.name is 'name'");
@@ -73,6 +73,14 @@ public class DefaultEntityHandlerTest {
 				stmt.execute("drop table if exists test_data_lock_version");
 				stmt.execute(
 						"create table if not exists test_data_lock_version( id NUMERIC(4), name VARCHAR(10), lock_version NUMERIC(10))");
+
+				stmt.execute("drop table if exists test_data_cyclic_lock_version");
+				stmt.execute(
+						"create table if not exists test_data_cyclic_lock_version( id NUMERIC(4), name VARCHAR(10), lock_version NUMERIC(10))");
+
+				stmt.execute("drop table if exists test_data_timestamp_lock_version");
+				stmt.execute(
+						"create table if not exists test_data_timestamp_lock_version( id NUMERIC(4), name VARCHAR(10), lock_version BIGINT)");
 			}
 		}
 
@@ -792,7 +800,6 @@ public class DefaultEntityHandlerTest {
 
 	@Test
 	public void testUpdateLockVersionOnly() throws Exception {
-
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
 				TestEntityLockVersion test = new TestEntityLockVersion(1L, "name1");
@@ -804,6 +811,82 @@ public class DefaultEntityHandlerTest {
 				TestEntityLockVersion data = agent.find(TestEntityLockVersion.class).orElse(null);
 				assertThat(data, is(test));
 				assertThat(data.getName(), is("updatename"));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateCyclicLockVersionMin() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityCyclicLockVersion test = new TestEntityCyclicLockVersion(1L, "name1");
+				assertThat(test.getLockVersion(), is(0));
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityCyclicLockVersion data = agent.find(TestEntityCyclicLockVersion.class).orElse(null);
+				assertThat(data, is(test));
+				assertThat(data.getName(), is("updatename"));
+				assertThat(data.getLockVersion(), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateCyclicLockVersionMax() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityCyclicLockVersion test = new TestEntityCyclicLockVersion(1L, "name1");
+				test.setLockVersion(1000000000);
+				assertThat(test.getLockVersion(), is(1000000000));
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityCyclicLockVersion data = agent.find(TestEntityCyclicLockVersion.class).orElse(null);
+				assertThat(data, is(test));
+				assertThat(data.getName(), is("updatename"));
+				assertThat(data.getLockVersion(), is(1));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateTimestampLockVersion() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityTimestampLockVersion test = new TestEntityTimestampLockVersion(1L, "name1");
+				assertThat(test.getLockVersion(), is(0L));
+				agent.insert(test);
+
+				TestEntityTimestampLockVersion insertedData = agent.find(TestEntityTimestampLockVersion.class)
+						.orElse(null);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityTimestampLockVersion updatedData = agent.find(TestEntityTimestampLockVersion.class)
+						.orElse(null);
+				assertThat(updatedData, is(test));
+				assertThat(updatedData.getName(), is("updatename"));
+				assertThat(updatedData.getLockVersion(), not(is(insertedData.getLockVersion())));
+			});
+		}
+	}
+
+	@Test(expected = UroborosqlRuntimeException.class)
+	public void testUpdateCustomLockVersionWithNoEntry() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityCustomLockVersion test = new TestEntityCustomLockVersion(1L, "name1");
+				assertThat(test.getLockVersion(), is(0L));
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
 			});
 		}
 	}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCustomLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCustomLockVersion.java
@@ -1,0 +1,74 @@
+package jp.co.future.uroborosql.mapping;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_DATA_TIMESTAMP_LOCK_VERSION")
+public class TestEntityCustomLockVersion {
+	private Long id;
+	private String name;
+	@Version(supplier = CustomOptimisticLockSupplier.class)
+	private long lockVersion = 0;
+
+	public TestEntityCustomLockVersion() {
+	}
+
+	public TestEntityCustomLockVersion(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public long getLockVersion() {
+		return lockVersion;
+	}
+
+	public void setLockVersion(final long lockVersion) {
+		this.lockVersion = lockVersion;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this, true);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj, true);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCyclicLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCyclicLockVersion.java
@@ -1,0 +1,74 @@
+package jp.co.future.uroborosql.mapping;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_DATA_LOCK_VERSION")
+public class TestEntityCyclicLockVersion {
+	private Long id;
+	private String name;
+	@Version(supplier = CyclicLockVersionOptimisticLockSupplier.class)
+	private int lockVersion = 0;
+
+	public TestEntityCyclicLockVersion() {
+	}
+
+	public TestEntityCyclicLockVersion(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public int getLockVersion() {
+		return lockVersion;
+	}
+
+	public void setLockVersion(final int lockVersion) {
+		this.lockVersion = lockVersion;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this, true);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj, true);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityFieldIncrementLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityFieldIncrementLockVersion.java
@@ -1,0 +1,74 @@
+package jp.co.future.uroborosql.mapping;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_DATA_FIELD_INCREMENT_LOCK_VERSION")
+public class TestEntityFieldIncrementLockVersion {
+	private Long id;
+	private String name;
+	@Version(supplier = FieldIncrementOptimisticLockSupplier.class)
+	private short lockVersion = 0;
+
+	public TestEntityFieldIncrementLockVersion() {
+	}
+
+	public TestEntityFieldIncrementLockVersion(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public short getLockVersion() {
+		return lockVersion;
+	}
+
+	public void setLockVersion(final short lockVersion) {
+		this.lockVersion = lockVersion;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this, true);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj, true);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestampLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestampLockVersion.java
@@ -1,0 +1,74 @@
+package jp.co.future.uroborosql.mapping;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_DATA_TIMESTAMP_LOCK_VERSION")
+public class TestEntityTimestampLockVersion {
+	private Long id;
+	private String name;
+	@Version(supplier = TimestampOptimisticLockSupplier.class)
+	private long lockVersion = 0;
+
+	public TestEntityTimestampLockVersion() {
+	}
+
+	public TestEntityTimestampLockVersion(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public long getLockVersion() {
+		return lockVersion;
+	}
+
+	public void setLockVersion(final long lockVersion) {
+		this.lockVersion = lockVersion;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this, true);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj, true);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+}


### PR DESCRIPTION
#218 
- Modified the schema name to be enclosed in `" `if it contains mixed case or non-alphanumeric characters.

#224 
- Modified so that OptimisticLockSupplier can be specified in @Version annotation.
The optimistic lock check method can be changed by implementing OptimisticLockSupplier.

Other
- add SqlConfigAware interface.
- Remove SqlAgent#close(). (Apply AutoCloseable#close())
- EntityHandler now holds SqlConfig.