### PR TITLE
add CaseFormat.NONE (Do not Convert) and fix CaseFormat conversion logic.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/converter/EntityResultSetConverter.java
+++ b/src/main/java/jp/co/future/uroborosql/converter/EntityResultSetConverter.java
@@ -12,13 +12,14 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.mapping.MappingColumn;
 import jp.co.future.uroborosql.mapping.MappingUtils;
 import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jp.co.future.uroborosql.utils.CaseFormat;
 
 /**
  * 検索結果の1行を任意型に変換する変換器
@@ -90,7 +91,7 @@ public class EntityResultSetConverter<E> implements ResultSetConverter<E> {
 
 	private void bindValue(final E rec, final ResultSet rs, final MappingColumn column) throws SQLException {
 		for (int i = 1; i <= columnCount; i++) {
-			if (columnLabels[i].equalsIgnoreCase(column.getName())) {
+			if (CaseFormat.UPPER_SNAKE_CASE.convert(columnLabels[i]).equalsIgnoreCase(column.getName())) {
 				column.setValue(rec, mapperManager.getValue(column.getJavaType(), rs, i));
 				return;
 			}

--- a/src/main/java/jp/co/future/uroborosql/utils/CaseFormat.java
+++ b/src/main/java/jp/co/future/uroborosql/utils/CaseFormat.java
@@ -38,15 +38,18 @@ public enum CaseFormat {
 				return str;
 			}
 			StringBuilder builder = new StringBuilder();
-			str = str.toLowerCase();
 			int len = str.length();
 
 			if (!str.contains("_")) {
+				if (isUpperCase(str)) {
+					str = str.toLowerCase();
+				}
 				builder.append(Character.toUpperCase(str.charAt(0)));
 				if (len > 1) {
 					builder.append(str.substring(1));
 				}
 			} else {
+				str = str.toLowerCase();
 				int i = 0;
 				while (i < len) {
 					char ch = str.charAt(i);
@@ -93,17 +96,24 @@ public enum CaseFormat {
 			if (str.isEmpty()) {
 				return str;
 			}
+			int len = str.length();
 			if (!str.contains("_")) {
 				char ch = str.charAt(0);
 				if ('a' <= ch && ch <= 'z' || '0' <= ch && ch <= '9') {
 					// 先頭小文字で"_"を含まない場合（つまりすでにCamelCaseの場合）、文字列変換せずにそのまま返す
 					return str;
+				} else if (!isUpperCase(str)) {
+					StringBuilder builder = new StringBuilder();
+					builder.append(Character.toLowerCase(str.charAt(0)));
+					if (len > 1) {
+						builder.append(str.substring(1));
+					}
+					return builder.toString();
 				}
 			}
 			StringBuilder builder = new StringBuilder();
 			str = str.toLowerCase();
 			int i = 0;
-			int len = str.length();
 			while (i < len) {
 				char ch = str.charAt(i);
 				if (ch == '_') {
@@ -217,7 +227,7 @@ public enum CaseFormat {
 	UPPER_CASE {
 
 		@Override
-		public String convert(String original) {
+		public String convert(final String original) {
 			if (original == null || "".equals(original)) {
 				return "";
 			}
@@ -229,12 +239,24 @@ public enum CaseFormat {
 	LOWER_CASE {
 
 		@Override
-		public String convert(String original) {
+		public String convert(final String original) {
 			if (original == null || "".equals(original)) {
 				return "";
 			}
 			return original.trim().toLowerCase();
 		}
+	},
+
+	/** 変換なし */
+	NONE {
+		@Override
+		public String convert(final String original) {
+			if (original == null || "".equals(original)) {
+				return "";
+			}
+			return original.trim();
+		}
+
 	};
 
 	/**
@@ -244,4 +266,18 @@ public enum CaseFormat {
 	 * @return 変換後文字列
 	 */
 	public abstract String convert(String original);
+
+	/**
+	 * 渡された文字列が大文字のみで構成されるかどうかを判定する.
+	 *
+	 * @param str 判定対象文字列
+	 * @return 大文字で構成される場合は<code>true</code>
+	 */
+	private static boolean isUpperCase(final String str) {
+		if (str == null || "".equals(str)) {
+			return false;
+		} else {
+			return str.equals(str.toUpperCase());
+		}
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierPascalCaseTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierPascalCaseTest.java
@@ -1,0 +1,266 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.SqlAgentFactoryImpl;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.utils.CaseFormat;
+
+public class DefaultEntityHandlerIdentifierPascalCaseTest {
+
+	private static SqlConfig config;
+
+	@Table(name = "PascalTable")
+	public static class TestEntity {
+		private long id;
+		private String lastName;
+		private String firstName;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(final long id, final String lastName, final String firstName) {
+			this.id = id;
+			this.lastName = lastName;
+			this.firstName = firstName;
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public void setId(final long id) {
+			this.id = id;
+		}
+
+		public String getLastName() {
+			return lastName;
+		}
+
+		public void setLastName(final String lastName) {
+			this.lastName = lastName;
+		}
+
+		public String getFirstName() {
+			return firstName;
+		}
+
+		public void setFirstName(final String firstName) {
+			this.firstName = firstName;
+		}
+
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this, true);
+		}
+
+		@Override
+		public boolean equals(final Object obj) {
+			return EqualsBuilder.reflectionEquals(this, obj, true);
+		}
+
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
+	}
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:" + DefaultEntityHandlerIdentifierPascalCaseTest.class.getSimpleName()
+				+ ";DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists \"PascalTable\"");
+				stmt.execute(
+						"create table if not exists \"PascalTable\"( \"Id\" NUMERIC(4), \"LastName\" VARCHAR(10), \"FirstName\" VARCHAR(10), primary key(\"Id\"))");
+			}
+		}
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlAgentFactory(new SqlAgentFactoryImpl().setDefaultMapKeyCaseFormat(CaseFormat.CAMEL_CASE))
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from \"PascalTable\"").count();
+			agent.commit();
+		}
+	}
+
+	//TODO SNAKE_CASE以外のカラム名に対するEntityマッピングについてはMappingルールの全体見直しと合わせて実施する
+	//	@Test
+	//	public void testInsert() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				agent.insert(test1);
+	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				agent.insert(test2);
+	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				agent.insert(test3);
+	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(test1));
+	//				data = agent.find(TestEntity.class, 2).orElse(null);
+	//				assertThat(data, is(test2));
+	//				data = agent.find(TestEntity.class, 3).orElse(null);
+	//				assertThat(data, is(test3));
+	//
+	//			});
+	//		}
+	//	}
+
+	@Test
+	public void testSqlQuery() throws Exception {
+
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith(
+					"insert into \"PascalTable\" (\"Id\", \"LastName\", \"FirstName\") values (/*id*/1, /*lastName*/'', /*firstName*/'')")
+					.param("id", 1)
+					.param("lastName", "lastName1")
+					.param("firstName", "firstName1")
+					.count();
+
+			TestEntity entity = agent.queryWith("select * from \"PascalTable\"").first(TestEntity.class);
+			assertThat(entity.getId(), is(1L));
+			assertThat(entity.getLastName(), is("lastName1"));
+			assertThat(entity.getFirstName(), is("firstName1"));
+		}
+	}
+
+	//TODO SNAKE_CASE以外のカラム名に対するEntityマッピングについてはMappingルールの全体見直しと合わせて実施する
+	//	@Test
+	//	public void testQuery1() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				agent.insert(test1);
+	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				agent.insert(test2);
+	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				agent.insert(test3);
+	//
+	//				List<TestEntity> list = agent.query(TestEntity.class).collect();
+	//				assertThat(list.get(0), is(test1));
+	//				assertThat(list.get(1), is(test2));
+	//				assertThat(list.get(2), is(test3));
+	//
+	//				list = agent.query(TestEntity.class)
+	//						.equal("name", "name2")
+	//						.collect();
+	//				assertThat(list.get(0), is(test2));
+	//			});
+	//		}
+	//	}
+	//
+	//	@Test
+	//	public void testUpdate1() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test = new TestEntity(1, "lastName1", "firstName1");
+	//				agent.insert(test);
+	//
+	//				test.setLastName("updatename");
+	//				agent.update(test);
+	//
+	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(test));
+	//				assertThat(data.getLastName(), is("updatename"));
+	//			});
+	//		}
+	//	}
+	//
+	//	@Test
+	//	public void testDelete1() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test = new TestEntity(1, "lastName1", "firstName1");
+	//				agent.insert(test);
+	//
+	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(test));
+	//
+	//				agent.delete(test);
+	//
+	//				data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(nullValue()));
+	//			});
+	//		}
+	//	}
+	//
+	//	@Test
+	//	public void testBatchInsert() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//
+	//				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+	//				assertThat(count, is(3));
+	//
+	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(test1));
+	//				data = agent.find(TestEntity.class, 2).orElse(null);
+	//				assertThat(data, is(test2));
+	//				data = agent.find(TestEntity.class, 3).orElse(null);
+	//				assertThat(data, is(test3));
+	//
+	//			});
+	//		}
+	//	}
+	//
+	//	@Test
+	//	public void testBulkInsert() throws Exception {
+	//
+	//		try (SqlAgent agent = config.agent()) {
+	//			agent.required(() -> {
+	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//
+	//				int count = agent.inserts(Stream.of(test1, test2, test3));
+	//				assertThat(count, is(3));
+	//
+	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
+	//				assertThat(data, is(test1));
+	//				data = agent.find(TestEntity.class, 2).orElse(null);
+	//				assertThat(data, is(test2));
+	//				data = agent.find(TestEntity.class, 3).orElse(null);
+	//				assertThat(data, is(test3));
+	//
+	//			});
+	//		}
+	//	}
+	//
+}

--- a/src/test/java/jp/co/future/uroborosql/utils/CaseFormatTest.java
+++ b/src/test/java/jp/co/future/uroborosql/utils/CaseFormatTest.java
@@ -48,8 +48,10 @@ public class CaseFormatTest {
 		assertEquals("Pascal", CaseFormat.PASCAL_CASE.convert("PASCAL"));
 		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("CONVERT_TO_PASCAL"));
 		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("convert_to_pascal"));
-		assertEquals("Converttopascal", CaseFormat.PASCAL_CASE.convert("convertToPascal"));
+		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("convertToPascal"));
 		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("convert_to_pascal_"));
+		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("ConvertToPascal"));
+		assertEquals("ConvertToPascal", CaseFormat.PASCAL_CASE.convert("convertToPascal"));
 		assertEquals("ToPascal", CaseFormat.PASCAL_CASE.convert("_TO_PASCAL"));
 		assertEquals("ToPascal", CaseFormat.PASCAL_CASE.convert("_TO_PASCAL_"));
 		assertEquals("", CaseFormat.PASCAL_CASE.convert(null));
@@ -63,6 +65,7 @@ public class CaseFormatTest {
 		assertEquals("convertToCamel", CaseFormat.CAMEL_CASE.convert("CONVERT_TO_CAMEL"));
 		assertEquals("convertToCamel", CaseFormat.CAMEL_CASE.convert("convert_to_camel"));
 		assertEquals("convertToCamel", CaseFormat.CAMEL_CASE.convert("convertToCamel"));
+		assertEquals("convertToCamel", CaseFormat.CAMEL_CASE.convert("ConvertToCamel"));
 		assertEquals("convertToCamel", CaseFormat.CAMEL_CASE.convert("convert_to_camel_"));
 		assertEquals("ToCamel", CaseFormat.CAMEL_CASE.convert("_TO_CAMEL"));
 		assertEquals("ToCamel", CaseFormat.CAMEL_CASE.convert("_TO_CAMEL_"));
@@ -97,6 +100,20 @@ public class CaseFormatTest {
 		assertEquals("", CaseFormat.LOWER_CASE.convert(null));
 		assertEquals("", CaseFormat.LOWER_CASE.convert(""));
 		assertEquals("", CaseFormat.LOWER_CASE.convert(" "));
+	}
+
+	@Test
+	public void testNone() {
+		assertEquals("snake", CaseFormat.NONE.convert("snake"));
+		assertEquals("convertToSnake", CaseFormat.NONE.convert("convertToSnake"));
+		assertEquals("ConvertToSnake", CaseFormat.NONE.convert("ConvertToSnake"));
+		assertEquals("convert_to_snake", CaseFormat.NONE.convert("convert_to_snake"));
+		assertEquals("CONVERT_TO_SNAKE", CaseFormat.NONE.convert("CONVERT_TO_SNAKE"));
+		assertEquals("SNAKE", CaseFormat.NONE.convert("SNAKE"));
+		assertEquals("toSnake", CaseFormat.NONE.convert("toSnake"));
+		assertEquals("", CaseFormat.NONE.convert(null));
+		assertEquals("", CaseFormat.NONE.convert(""));
+		assertEquals("", CaseFormat.NONE.convert(" "));
 	}
 
 }


### PR DESCRIPTION
fix #226

- Add CaseFormat.NONE (Do not convert anything)

- Fix CaseFormat.CamelCase and PascalCase Conversion logic.
  - CamelCase
    - convertToCamel -> convertToCamel (Do not convert the second and subsequent characters to lowercase)
    - ConvertToCamel -> convertToCamel (Do not convert the second and subsequent characters to lowercase)
  - PascalCase
    - convertToCamel -> ConvertToCamel (Do not convert the second and subsequent characters to lowercase)
    - ConvertToCamel -> ConvertToCamel (Do not convert)

- Fix EntityResultSetConverter#bindValue() field matching logic.