### PR TITLE
REPL generate command supports update statement optimistic locking and autoincrement.

### DIFF
--- a/REPL/repl.properties
+++ b/REPL/repl.properties
@@ -4,6 +4,8 @@ db.password=
 
 sql.additionalClassPath=src/test/resources;target/test-classes;${user.home}/.m2/repository/com/h2database/h2/1.4.199/h2-1.4.199.jar
 sql.encoding=UTF-8
+sql.versionColumnName=lock_no
+sql.optimisticLockSupplier=jp.co.future.uroborosql.mapping.FieldIncrementOptimisticLockSupplier
 #sql.loadPath=sql
 #sql.fileExtension=.sql
 #sql.detectChanges=true

--- a/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
@@ -47,6 +47,9 @@ public final class SqlParamUtils {
 	/** 数字かどうかを判定するための正規表現 */
 	private static final Pattern NUMBER_PAT = Pattern.compile("^[\\-\\+]?[1-9][0-9]*([Ll]|\\.\\d+[FfDd])?$");
 
+	/** 入力内容の中で[]で囲まれた値を置換するための正規表現 */
+	private static final Pattern PARAM_PAT = Pattern.compile("\\[(.+?)\\]");
+
 	/**
 	 * コンストラクタ
 	 */
@@ -61,24 +64,21 @@ public final class SqlParamUtils {
 	 * @return 入力内容をパラメータに分割した配列
 	 */
 	public static String[] parseLine(final String line) {
-		Pattern pat = Pattern.compile("\\[(.+?)\\]");
-		Matcher matcher = pat.matcher(line);
-
-		StringBuffer buffer = new StringBuffer();
-
+		StringBuffer sb = new StringBuffer();
+		Matcher matcher = PARAM_PAT.matcher(line);
 		while (matcher.find()) {
 			String arrayPart = matcher.group();
-			matcher.appendReplacement(buffer, arrayPart.replaceAll("\\s*,\\s*", ","));
+			matcher.appendReplacement(sb, arrayPart.replaceAll("\\s*,\\s*", ","));
 		}
-		matcher.appendTail(buffer);
+		matcher.appendTail(sb);
 
 		int idx = 0;
 		List<String> parts = new ArrayList<>();
 		boolean bracketFlag = false;
 		boolean singleQuoteFlag = false;
 		StringBuilder part = new StringBuilder();
-		while (buffer.length() > idx) {
-			char c = buffer.charAt(idx++);
+		while (sb.length() > idx) {
+			char c = sb.charAt(idx++);
 			if (Character.isWhitespace(c)) {
 				if (bracketFlag || singleQuoteFlag) {
 					// 囲み文字の中なのでそのまま追加する

--- a/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
@@ -328,7 +328,7 @@ public class SqlREPL {
 			return true;
 		}
 
-		String[] parts = line.split("\\s+");
+		String[] parts = SqlParamUtils.parseLine(line);
 		Optional<ReplCommand> command = commands.stream().filter(c -> c.is(parts[0])).findFirst();
 		if (command.isPresent()) {
 			return command.get().execute(reader, parts, sqlConfig, props);

--- a/src/main/java/jp/co/future/uroborosql/client/command/GenerateCommand.java
+++ b/src/main/java/jp/co/future/uroborosql/client/command/GenerateCommand.java
@@ -20,6 +20,7 @@ import jp.co.future.uroborosql.client.completer.SqlKeywordCompleter.SqlKeyword;
 import jp.co.future.uroborosql.client.completer.TableNameCompleter;
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.mapping.MetaTable;
 import jp.co.future.uroborosql.mapping.Table;
 import jp.co.future.uroborosql.mapping.TableMetadata;
 
@@ -53,22 +54,15 @@ public class GenerateCommand extends ReplCommand {
 			return true;
 		}
 
-		Optional<SqlKeyword> sqlKeyword = SqlKeyword.of(parts[1]);
-		String tableName = parts[2];
-
 		try (SqlAgent agent = sqlConfig.agent()) {
-			Table table = new Table() {
+			Optional<SqlKeyword> sqlKeyword = SqlKeyword.of(parts[1]);
+			final String tableName = parts[2];
+			final String versionColumnName = props.getProperty("sql.versionColumnName");
+			final String optimisticLockSupplier = props
+					.getProperty("sql.optimisticLockSupplier",
+							"jp.co.future.uroborosql.mapping.LockVersionOptimisticLockSupplier");
 
-				@Override
-				public String getSchema() {
-					return null;
-				}
-
-				@Override
-				public String getName() {
-					return tableName;
-				}
-			};
+			Table table = new MetaTable(tableName, null, versionColumnName, optimisticLockSupplier);
 			TableMetadata metadata = TableMetadata.createTableEntityMetadata(agent, table);
 			metadata.setSchema(null);
 

--- a/src/main/java/jp/co/future/uroborosql/mapping/MetaTable.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MetaTable.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.mapping;
+
+import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+
+/**
+ * 動的に生成するテーブルの情報を保持したクラス
+ *
+ * @author H.Sugimoto
+ */
+public class MetaTable implements Table {
+	/** テーブル名 */
+	private final String name;
+	/** スキーマ名 */
+	private final String schema;
+	/** バージョンカラム名 */
+	private final String versionColumnName;
+	/** 楽観ロックを提供するクラス名 */
+	private final String optimisticLockSupplierClassName;
+
+	/**
+	 * コンストラクタ
+	 *
+	 * @param name テーブル名
+	 * @param schema スキーマ名
+	 * @param versionColumnName バージョンカラム名
+	 * @param optimisticLockSupplierClassName 楽観ロックを提供するクラス名
+	 */
+	public MetaTable(final String name, final String schema, final String versionColumnName,
+			final String optimisticLockSupplierClassName) {
+		super();
+		this.name = name;
+		this.schema = schema;
+		this.versionColumnName = versionColumnName;
+		this.optimisticLockSupplierClassName = optimisticLockSupplierClassName;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.Table#getName()
+	 */
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.Table#getSchema()
+	 */
+	@Override
+	public String getSchema() {
+		return this.schema;
+	}
+
+	/**
+	 * バージョンカラムの取得.
+	 *
+	 * @return バージョンカラム
+	 */
+	public String getVersionColumnName() {
+		return this.versionColumnName;
+	}
+
+	/**
+	 * 楽観ロックを提供するクラスの取得
+	 *
+	 * @return 楽観ロックを提供するクラス
+	 */
+	@SuppressWarnings("unchecked")
+	public Class<? extends OptimisticLockSupplier> getOptimisticLockType() {
+		try {
+			return (Class<? extends OptimisticLockSupplier>) Class.forName(this.optimisticLockSupplierClassName);
+		} catch (ClassNotFoundException e) {
+			throw new UroborosqlRuntimeException(
+					"OptimisticLockSupplier class : " + this.optimisticLockSupplierClassName + " not found.", e);
+		}
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
@@ -33,6 +33,9 @@ public class TableMetadataImpl implements TableMetadata {
 		private final String identifierQuoteString;
 		private final String remarks;
 		private final boolean nullable;
+		private final boolean autoincrement;
+		private final boolean version;
+		private final Class<? extends OptimisticLockSupplier> optimisticLockType;
 		private final int ordinalPosition;
 
 		/**
@@ -43,13 +46,24 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
 		 * @param nullable NULL可かどうか
+		 * @param autoincrement 自動インクリメントされるかどうか
+		 * @param version バージョンカラムかどうか
+		 * @param optimisticLockType 楽観ロックタイプ
 		 * @param ordinalPosition 列インデックス
 		 * @param identifierQuoteString SQL識別子を引用するのに使用する文字列
 		 */
-		public Column(final String columnName, final SQLType dataType, final int columnSize, final String remarks,
-				final String nullable, final int ordinalPosition, final String identifierQuoteString) {
-			this(columnName, dataType.getVendorTypeNumber(), columnSize, remarks, nullable, ordinalPosition,
-					identifierQuoteString);
+		public Column(final String columnName,
+				final SQLType dataType,
+				final int columnSize,
+				final String remarks,
+				final String nullable,
+				final String autoincrement,
+				final boolean version,
+				final Class<? extends OptimisticLockSupplier> optimisticLockType,
+				final int ordinalPosition,
+				final String identifierQuoteString) {
+			this(columnName, dataType.getVendorTypeNumber(), columnSize, remarks, nullable, autoincrement, version,
+					optimisticLockType, ordinalPosition, identifierQuoteString);
 		}
 
 		/**
@@ -60,16 +74,30 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
 		 * @param nullable NULL可かどうか
+		 * @param autoincrement 自動インクリメントされるかどうか
+		 * @param version バージョンカラムかどうか
+		 * @param optimisticLockType 楽観ロックタイプ
 		 * @param ordinalPosition 列インデックス
 		 * @param identifierQuoteString SQL識別子を引用するのに使用する文字列
 		 */
-		public Column(final String columnName, final int dataType, final int columnSize, final String remarks,
-				final String nullable, final int ordinalPosition, final String identifierQuoteString) {
+		public Column(final String columnName,
+				final int dataType,
+				final int columnSize,
+				final String remarks,
+				final String nullable,
+				final String autoincrement,
+				final boolean version,
+				final Class<? extends OptimisticLockSupplier> optimisticLockType,
+				final int ordinalPosition,
+				final String identifierQuoteString) {
 			this.columnName = columnName;
 			this.dataType = dataType;
 			this.columnSize = columnSize;
 			this.remarks = remarks;
 			this.nullable = "YES".equalsIgnoreCase(nullable);
+			this.autoincrement = "YES".equalsIgnoreCase(autoincrement);
+			this.version = version;
+			this.optimisticLockType = optimisticLockType;
 			this.ordinalPosition = ordinalPosition;
 
 			if (StringUtils.isEmpty(identifierQuoteString)) {
@@ -195,6 +223,36 @@ public class TableMetadataImpl implements TableMetadata {
 		/**
 		 * {@inheritDoc}
 		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#isAutoincrement()
+		 */
+		@Override
+		public boolean isAutoincrement() {
+			return this.autoincrement;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#isVersion()
+		 */
+		@Override
+		public boolean isVersion() {
+			return this.version;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getOptimisticLockType()
+		 */
+		@Override
+		public Class<? extends OptimisticLockSupplier> getOptimisticLockType() {
+			return this.optimisticLockType;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
 		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getOrdinalPosition()
 		 */
 		@Override
@@ -210,7 +268,6 @@ public class TableMetadataImpl implements TableMetadata {
 		public void setKeySeq(final int keySeq) {
 			this.keySeq = keySeq;
 		}
-
 	}
 
 	private String tableName;

--- a/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
@@ -215,4 +215,16 @@ public class SqlParamUtilsTest {
 		assertThat(params, not(contains("CLS_AGE_DEFAULT")));
 	}
 
+	@Test
+	public void testParseLine() {
+		String[] parts = SqlParamUtils.parseLine("update /sss/bbb param1=[1, 2, 3] param2=3 param3=[1, 2]");
+		assertThat(parts, arrayContaining("update", "/sss/bbb", "param1=[1,2,3]", "param2=3", "param3=[1,2]"));
+
+		parts = SqlParamUtils.parseLine("update /sss/bbb param1=[NULL] param2=[EMPTY]");
+		assertThat(parts, arrayContaining("update", "/sss/bbb", "param1=[NULL]", "param2=[EMPTY]"));
+
+		parts = SqlParamUtils.parseLine("update /sss/bbb param1=['o n e', 't w o'] param2='s p a c e'");
+		assertThat(parts, arrayContaining("update", "/sss/bbb", "param1=['o n e','t w o']", "param2='s p a c e'"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/client/command/GenerateCommandTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/command/GenerateCommandTest.java
@@ -82,7 +82,7 @@ public class GenerateCommandTest extends ReaderTestSupport {
 	}
 
 	private String trimWhitespace(final String str) {
-		return str.trim().replaceAll("\r\n|\t+|\\s+", " ");
+		return str.trim().replaceAll("\r\n|\r|\n|\t+|\\s+", " ");
 	}
 
 	@Test

--- a/src/test/resources/sql/ddl/create_tables.sql
+++ b/src/test/resources/sql/ddl/create_tables.sql
@@ -47,3 +47,11 @@ create table if not exists COLUMN_TYPE_ARRAY (
 	COL_ARRAY			ARRAY
 )
 ;
+
+create table if not exists GEN_TEST (
+	ID			NUMERIC(10, 0) NOT NULL AUTO_INCREMENT,
+	NAME		VARCHAR(100),
+	LOCK_NO		NUMERIC(10, 0),
+	constraint PK_GEN_TEST primary key (ID)
+)
+;


### PR DESCRIPTION
fixed #91

- Generate SQL corresponding to autoincrement column and optimistic lock when update statement is generated by REPL generate command.
- Added support to generate SQL corresponding to autoincrement when generating INSERT statement.
- Bug fixes found in REPL（Invalid command argument parsing method）