### PR TITLE
Added clock to SqlConfig so that it can be used with ParameterMapper and PropertyMapper

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -465,7 +465,7 @@ public abstract class AbstractAgent implements SqlAgent {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.SqlAgent#getSqlConfig()
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#getSqlConfig()
 	 */
 	@Override
 	public SqlConfig getSqlConfig() {
@@ -475,7 +475,7 @@ public abstract class AbstractAgent implements SqlAgent {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.SqlAgent#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
 	 */
 	@Override
 	public void setSqlConfig(final SqlConfig config) {

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -243,7 +243,7 @@ public class SqlAgentImpl extends AbstractAgent {
 	public List<Map<String, Object>> query(final SqlContext sqlContext, final CaseFormat caseFormat)
 			throws SQLException {
 		try (Stream<Map<String, Object>> stream = query(sqlContext,
-				new MapResultSetConverter(getSqlConfig().getDialect(), caseFormat))) {
+				new MapResultSetConverter(getSqlConfig(), caseFormat))) {
 			return stream.collect(Collectors.toList());
 		}
 	}

--- a/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlQueryImpl.java
@@ -248,7 +248,7 @@ final class SqlQueryImpl extends AbstractSqlFluent<SqlQuery> implements SqlQuery
 	 */
 	@Override
 	public Stream<Map<String, Object>> stream(final CaseFormat caseFormat) {
-		return stream(new MapResultSetConverter(this.agent.getSqlConfig().getDialect(), caseFormat));
+		return stream(new MapResultSetConverter(this.agent.getSqlConfig(), caseFormat));
 	}
 
 	/**
@@ -258,7 +258,8 @@ final class SqlQueryImpl extends AbstractSqlFluent<SqlQuery> implements SqlQuery
 	 */
 	@Override
 	public <T> Stream<T> stream(final Class<T> type) {
-		return stream(new EntityResultSetConverter<>(type, new PropertyMapperManager()));
+		return stream(
+				new EntityResultSetConverter<>(type, new PropertyMapperManager(this.agent.getSqlConfig().getClock())));
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
+++ b/src/main/java/jp/co/future/uroborosql/config/SqlConfig.java
@@ -9,6 +9,8 @@
  */
 package jp.co.future.uroborosql.config;
 
+import java.time.Clock;
+
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.SqlAgentFactory;
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
@@ -21,21 +23,21 @@ import jp.co.future.uroborosql.mapping.EntityHandler;
 import jp.co.future.uroborosql.store.SqlManager;
 
 /**
- * SQLを発行するための設定を管理するクラスのインタフェース
+ * SQLを発行するための設定を管理するクラスのインタフェース.
  *
  * @author H.Sugimoto
  */
 public interface SqlConfig {
 
 	/**
-	 * SqlContextの生成
+	 * SqlContextの生成.
 	 *
 	 * @return 生成したSqlContext
 	 */
 	SqlContext context();
 
 	/**
-	 * ファイル指定のSqlContextの生成
+	 * ファイル指定のSqlContextの生成.
 	 *
 	 * @param sqlName SQLファイルのルートからの相対パス（ファイル拡張子なし）を指定
 	 * @return 生成したSqlContext
@@ -43,7 +45,7 @@ public interface SqlConfig {
 	SqlContext contextFrom(String sqlName);
 
 	/**
-	 * SQL文を指定したSqlContextの生成
+	 * SQL文を指定したSqlContextの生成.
 	 *
 	 * @param sql SQL文の文字列
 	 * @return 生成したSqlContext
@@ -51,7 +53,7 @@ public interface SqlConfig {
 	SqlContext contextWith(String sql);
 
 	/**
-	 * SqlAgentの生成
+	 * SqlAgentの生成.
 	 *
 	 * @deprecated Instead, use the agent() method.
 	 *
@@ -61,9 +63,9 @@ public interface SqlConfig {
 	SqlAgent createAgent();
 
 	/**
-	 * SqlAgentの生成
+	 * SqlAgentの生成.
 	 *
-	 * @return 生成したSqlAgent
+	 * @return 生成したSqlAgent.
 	 */
 	SqlAgent agent();
 
@@ -101,6 +103,13 @@ public interface SqlConfig {
 	 * @return sqlAgentFactory
 	 */
 	SqlAgentFactory getSqlAgentFactory();
+
+	/**
+	 * clock を取得.
+	 *
+	 * @return clock
+	 */
+	Clock getClock();
 
 	/**
 	 * dialect を取得.

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactory.java
@@ -40,6 +40,8 @@ public interface SqlContextFactory extends SqlConfigAware {
 	/**
 	 * 定数パラメータプレフィックスを取得.
 	 *
+	 * @deprecated Use getSqlConfig().getSqlFilterManager() instead.
+	 *
 	 * @return SQLフィルタ管理クラス
 	 */
 	@Deprecated
@@ -47,6 +49,8 @@ public interface SqlContextFactory extends SqlConfigAware {
 
 	/**
 	 * SQLフィルタ管理クラスを設定する
+	 *
+	 * @deprecated Please do not use this method and set SqlFilterManager instance when generating SqlConfig.
 	 *
 	 * @param sqlFilterManager SQLフィルタ管理クラス
 	 */

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactory.java
@@ -10,37 +10,39 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import jp.co.future.uroborosql.config.SqlConfigAware;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.parameter.Parameter;
 import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
 
 /**
- * SQLコンテキストファクトリインタフェース
+ * SQLコンテキストファクトリインタフェース.
  *
  * @author H.Sugimoto
  *
  */
-public interface SqlContextFactory {
+public interface SqlContextFactory extends SqlConfigAware {
 	/** BEAN名 */
 	String FACTORY_BEAN_NAME = "sqlContextFactory";
 
 	/**
-	 * 初期化処理
+	 * 初期化処理.
 	 */
 	void initialize();
 
 	/**
-	 * SQLコンテキスト生成メソッド
+	 * SQLコンテキスト生成メソッド.
 	 *
 	 * @return SQLコンテキスト
 	 */
 	SqlContext createSqlContext();
 
 	/**
-	 * SQLフィルタ管理クラスを取得する
+	 * 定数パラメータプレフィックスを取得.
 	 *
 	 * @return SQLフィルタ管理クラス
 	 */
+	@Deprecated
 	SqlFilterManager getSqlFilterManager();
 
 	/**
@@ -48,6 +50,7 @@ public interface SqlContextFactory {
 	 *
 	 * @param sqlFilterManager SQLフィルタ管理クラス
 	 */
+	@Deprecated
 	void setSqlFilterManager(SqlFilterManager sqlFilterManager);
 
 	/**
@@ -58,7 +61,7 @@ public interface SqlContextFactory {
 	String getConstParamPrefix();
 
 	/**
-	 * 定数パラメータプレフィックスを設定します。
+	 * 定数パラメータプレフィックスを設定.
 	 *
 	 * @param constParamPrefix
 	 *            定数パラメータプレフィックス
@@ -67,14 +70,14 @@ public interface SqlContextFactory {
 	SqlContextFactory setConstParamPrefix(String constParamPrefix);
 
 	/**
-	 * 定数クラス名（FQDN）を取得します。
+	 * 定数クラス名（FQDN）を取得.
 	 *
 	 * @return 定数クラス名（FQDN）
 	 */
 	List<String> getConstantClassNames();
 
 	/**
-	 * 定数クラス名（FQDN）を設定します。
+	 * 定数クラス名（FQDN）を設定.
 	 *
 	 * @param constantClassNames
 	 *            定数クラス名（FQDN）
@@ -83,14 +86,14 @@ public interface SqlContextFactory {
 	SqlContextFactory setConstantClassNames(List<String> constantClassNames);
 
 	/**
-	 * Enum定数パッケージ名を取得します。
+	 * Enum定数パッケージ名を取得.
 	 *
 	 * @return Enum定数パッケージ名
 	 */
 	List<String> getEnumConstantPackageNames();
 
 	/**
-	 * Enum定数パッケージ名（FQDN）を設定します。
+	 * Enum定数パッケージ名（FQDN）を設定.
 	 *
 	 * @param enumConstantPackageNames Enum定数パッケージ名
 	 * @return SqlContextFactory
@@ -98,14 +101,14 @@ public interface SqlContextFactory {
 	SqlContextFactory setEnumConstantPackageNames(List<String> enumConstantPackageNames);
 
 	/**
-	 * 定数クラスパラメータマップを取得します。
+	 * 定数クラスパラメータマップを取得.
 	 *
 	 * @return 定数クラスパラメータマップ
 	 */
 	Map<String, Parameter> getConstParameterMap();
 
 	/**
-	 * 自動バインド用パラメータ生成クラスのリストを取得します。
+	 * 自動バインド用パラメータ生成クラスのリストを取得.
 	 *
 	 * @return 自動バインド用パラメータ生成クラスのリスト
 	 */
@@ -113,7 +116,7 @@ public interface SqlContextFactory {
 	List<AutoBindParameterCreator> getAutoBindParameterCreators();
 
 	/**
-	 * 自動バインド用パラメータ生成クラスのリストを設定します。
+	 * 自動バインド用パラメータ生成クラスのリストを設定.
 	 *
 	 * use {@link #addQueryAutoParameterBinder(Consumer)} , {@link #addUpdateAutoParameterBinder(Consumer)}
 	 *
@@ -125,35 +128,39 @@ public interface SqlContextFactory {
 	SqlContextFactory setAutoBindParameterCreators(List<AutoBindParameterCreator> autoBindParameterCreators);
 
 	/**
-	 * 自動パラメータバインド関数(query用)の追加
+	 * 自動パラメータバインド関数(query用)の追加.
+	 *
 	 * @param binder 自動パラメータバインド関数
 	 * @return SqlContextFactory
 	 */
 	SqlContextFactory addQueryAutoParameterBinder(Consumer<SqlContext> binder);
 
 	/**
-	 * 自動パラメータバインド関数(query用)の削除
+	 * 自動パラメータバインド関数(query用)の削除.
+	 *
 	 * @param binder 自動パラメータバインド関数
 	 * @return SqlContextFactory
 	 */
 	SqlContextFactory removeQueryAutoParameterBinder(Consumer<SqlContext> binder);
 
 	/**
-	 * 自動パラメータバインド関数(update/batch/proc用)の追加
+	 * 自動パラメータバインド関数(update/batch/proc用)の追加.
+	 *
 	 * @param binder 自動パラメータバインド関数
 	 * @return SqlContextFactory
 	 */
 	SqlContextFactory addUpdateAutoParameterBinder(Consumer<SqlContext> binder);
 
 	/**
-	 * 自動パラメータバインド関数(update/batch/proc用)の削除
+	 * 自動パラメータバインド関数(update/batch/proc用)の削除.
+	 *
 	 * @param binder 自動パラメータバインド関数
 	 * @return SqlContextFactory
 	 */
 	SqlContextFactory removeUpdateAutoParameterBinder(Consumer<SqlContext> binder);
 
 	/**
-	 * パラメータ変換クラス{@link BindParameterMapper}を追加
+	 * パラメータ変換クラス{@link BindParameterMapper}を追加.
 	 *
 	 * @param parameterMapper {@link BindParameterMapper}
 	 * @return SqlContextFactory
@@ -161,7 +168,7 @@ public interface SqlContextFactory {
 	SqlContextFactory addBindParamMapper(BindParameterMapper<?> parameterMapper);
 
 	/**
-	 * パラメータ変換クラス{@link BindParameterMapper}をremove
+	 * パラメータ変換クラス{@link BindParameterMapper}をremove.
 	 *
 	 * @param parameterMapper {@link BindParameterMapper}
 	 * @return SqlContextFactory
@@ -169,7 +176,7 @@ public interface SqlContextFactory {
 	SqlContextFactory removeBindParamMapper(BindParameterMapper<?> parameterMapper);
 
 	/**
-	 * SqlContextに設定するResultSetTypeの初期値を指定する
+	 * SqlContextに設定するResultSetTypeの初期値を指定.
 	 *
 	 * @param resultSetType ResultSetTypeの初期値
 	 * @return SqlContextFactory
@@ -177,7 +184,7 @@ public interface SqlContextFactory {
 	SqlContextFactory setDefaultResultSetType(int resultSetType);
 
 	/**
-	 * SqlContextに設定するResultSetConcurrencyの初期値を指定する
+	 * SqlContextに設定するResultSetConcurrencyの初期値を指定.
 	 *
 	 * @param resultSetConcurrency ResultSetConcurrencyの初期値
 	 * @return SqlContextFactory

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
@@ -321,6 +321,8 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	@Override
 	public void setSqlFilterManager(final SqlFilterManager sqlFilterManager) {
 		// do nothing
+		LOG.warn(
+				"Do not use SqlContextFactory#setSqlFilterManager() method. Instead, set SqlFilterManager when generating SqlConfig.");
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.filter.SqlFilterManager;
 import jp.co.future.uroborosql.parameter.Parameter;
 import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
@@ -62,8 +63,9 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	/** 定数パラメータマップ */
 	private Map<String, Parameter> constParameterMap = null;
 
-	/** SqlFilter管理クラス */
-	private SqlFilterManager sqlFilterManager;
+	/** SQL設定クラス */
+	private SqlConfig sqlConfig = null;
+
 	/** 自動バインド用パラメータ生成クラスのリスト */
 	private List<AutoBindParameterCreator> autoBindParameterCreators = null;
 
@@ -86,7 +88,7 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	private int defaultResultSetConcurrency = ResultSet.CONCUR_READ_ONLY;
 
 	/** パラメータ変換マネージャ */
-	private final BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+	private BindParameterMapperManager parameterMapperManager;
 
 	/**
 	 * {@inheritDoc}
@@ -109,14 +111,35 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 		}
 
 		sqlContext.setConstParameterMap(paramMap);
-		sqlContext.setSqlFilterManager(getSqlFilterManager());
-		sqlContext.setParameterMapperManager(new BindParameterMapperManager(parameterMapperManager));
+		sqlContext.setSqlFilterManager(getSqlConfig().getSqlFilterManager());
+		sqlContext.setParameterMapperManager(
+				new BindParameterMapperManager(parameterMapperManager, getSqlConfig().getClock()));
 		sqlContext.setQueryAutoParameterBinder(queryAutoParameterBinder);
 		sqlContext.setUpdateAutoParameterBinder(updateAutoParameterBinder);
 		sqlContext.setResultSetType(defaultResultSetType);
 		sqlContext.setResultSetConcurrency(defaultResultSetConcurrency);
 
 		return sqlContext;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#setSqlConfig(jp.co.future.uroborosql.config.SqlConfig)
+	 */
+	@Override
+	public void setSqlConfig(final SqlConfig sqlConfig) {
+		this.sqlConfig = sqlConfig;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.config.SqlConfigAware#getSqlConfig()
+	 */
+	@Override
+	public SqlConfig getSqlConfig() {
+		return sqlConfig;
 	}
 
 	/**
@@ -131,6 +154,7 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 		paramMap.putAll(buildEnumConstParamMap());
 
 		constParameterMap = Collections.unmodifiableMap(paramMap);
+		parameterMapperManager = new BindParameterMapperManager(getSqlConfig().getClock());
 	}
 
 	/**
@@ -282,9 +306,10 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	 *
 	 * @see SqlContextFactory#setSqlFilterManager(SqlFilterManager)
 	 */
+	@Deprecated
 	@Override
 	public SqlFilterManager getSqlFilterManager() {
-		return sqlFilterManager;
+		return getSqlConfig().getSqlFilterManager();
 	}
 
 	/**
@@ -292,9 +317,10 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	 *
 	 * @see SqlContextFactory#setSqlFilterManager(SqlFilterManager)
 	 */
+	@Deprecated
 	@Override
 	public void setSqlFilterManager(final SqlFilterManager sqlFilterManager) {
-		this.sqlFilterManager = sqlFilterManager;
+		// do nothing
 	}
 
 	/**
@@ -539,15 +565,26 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 		return Optional.empty();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.context.SqlContextFactory#setDefaultResultSetType(int)
+	 */
 	@Override
 	public SqlContextFactory setDefaultResultSetType(final int resultSetType) {
 		defaultResultSetType = resultSetType;
 		return this;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.context.SqlContextFactory#setDefaultResultSetConcurrency(int)
+	 */
 	@Override
 	public SqlContextFactory setDefaultResultSetConcurrency(final int resultSetConcurrency) {
 		defaultResultSetConcurrency = resultSetConcurrency;
 		return this;
 	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/converter/MapResultSetConverter.java
+++ b/src/main/java/jp/co/future/uroborosql/converter/MapResultSetConverter.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jp.co.future.uroborosql.dialect.Dialect;
+import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.mapping.JavaType;
 import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
 import jp.co.future.uroborosql.utils.CaseFormat;
@@ -25,42 +25,42 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  */
 public class MapResultSetConverter implements ResultSetConverter<Map<String, Object>> {
 	private final PropertyMapperManager mapperManager;
-	private final Dialect dialect;
+	private final SqlConfig sqlConfig;
 	private final CaseFormat caseFormat;
 
 	/**
 	 * コンストラクタ
 	 *
-	 * @param dialect データベースDialect
+	 * @param sqlConfig SQL設定クラス
 	 */
-	public MapResultSetConverter(final Dialect dialect) {
-		this(dialect, CaseFormat.UPPER_SNAKE_CASE);
+	public MapResultSetConverter(final SqlConfig sqlConfig) {
+		this(sqlConfig, CaseFormat.UPPER_SNAKE_CASE);
 	}
 
 	/**
 	 * コンストラクタ
 	 *
-	 * @param dialect データベースDialect
+	 * @param sqlConfig SQL設定クラス
 	 * @param caseFormat 変換するMapのキーの書式
 	 */
-	public MapResultSetConverter(final Dialect dialect, final CaseFormat caseFormat) {
-		this.dialect = dialect;
+	public MapResultSetConverter(final SqlConfig sqlConfig, final CaseFormat caseFormat) {
+		this.sqlConfig = sqlConfig;
 		this.caseFormat = caseFormat;
-		this.mapperManager = new PropertyMapperManager();
+		this.mapperManager = new PropertyMapperManager(sqlConfig.getClock());
 	}
 
 	/**
 	 * コンストラクタ
 	 *
-	 * @param dialect データベースDialect
+	 * @param sqlConfig SQL設定クラス
 	 * @param caseFormat 変換するMapのキーの書式
 	 * @param mapperManager コピー元のパラメータ変換クラス
 	 */
-	public MapResultSetConverter(final Dialect dialect, final CaseFormat caseFormat,
+	public MapResultSetConverter(final SqlConfig sqlConfig, final CaseFormat caseFormat,
 			final PropertyMapperManager mapperManager) {
-		this.dialect = dialect;
+		this.sqlConfig = sqlConfig;
 		this.caseFormat = caseFormat;
-		this.mapperManager = new PropertyMapperManager(mapperManager);
+		this.mapperManager = new PropertyMapperManager(mapperManager, sqlConfig.getClock());
 	}
 
 	/**
@@ -90,7 +90,7 @@ public class MapResultSetConverter implements ResultSetConverter<Map<String, Obj
 	 */
 	private Object getValue(final ResultSet rs, final ResultSetMetaData rsmd, final int columnIndex)
 			throws SQLException {
-		JavaType javaType = this.dialect.getJavaType(rsmd.getColumnType(columnIndex),
+		JavaType javaType = this.sqlConfig.getDialect().getJavaType(rsmd.getColumnType(columnIndex),
 				rsmd.getColumnTypeName(columnIndex));
 		return this.mapperManager.getValue(javaType, rs, columnIndex);
 	}

--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -37,9 +37,16 @@ import jp.co.future.uroborosql.utils.StringUtils;
 public class DefaultEntityHandler implements EntityHandler<Object> {
 
 	private static Map<Class<?>, TableMetadata> CONTEXTS = new ConcurrentHashMap<>();
-	private final PropertyMapperManager propertyMapperManager = new PropertyMapperManager();
+	private PropertyMapperManager propertyMapperManager;
 	private boolean emptyStringEqualsNull = true;
 	private SqlConfig sqlConfig = null;
+
+	/**
+	 * コンストラクタ
+	 */
+	public DefaultEntityHandler() {
+		super();
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -82,8 +89,7 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 	@Override
 	public <E> Stream<E> doSelect(final SqlAgent agent, final SqlContext context, final Class<? extends E> entityType)
 			throws SQLException {
-		return agent.query(context, new EntityResultSetConverter<>(entityType, new PropertyMapperManager(
-				propertyMapperManager)));
+		return agent.query(context, new EntityResultSetConverter<>(entityType, propertyMapperManager));
 	}
 
 	/**
@@ -771,6 +777,16 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 
 	private String buildBulkParamName(final String base, final int entityIndex) {
 		return base + "$" + entityIndex;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.EntityHandler#initialize()
+	 */
+	@Override
+	public void initialize() {
+		this.propertyMapperManager = new PropertyMapperManager(this.sqlConfig.getClock());
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/EntityHandler.java
@@ -23,6 +23,11 @@ import jp.co.future.uroborosql.mapping.mapper.PropertyMapper;
  */
 public interface EntityHandler<ENTITY> extends SqlConfigAware {
 	/**
+	 * 初期化処理
+	 */
+	void initialize();
+
+	/**
 	 * エンティティ型を返す
 	 *
 	 * @return エンティティ型

--- a/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
@@ -22,13 +22,13 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Year;
 import java.time.YearMonth;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoLocalDate;
 import java.time.chrono.Era;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Optional;
+import java.util.TimeZone;
 
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.mapping.JavaType;
@@ -39,7 +39,26 @@ import jp.co.future.uroborosql.mapping.JavaType;
  * @author ota
  */
 public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccessor> {
+	/**
+	 * 日時の変換に使用するClock
+	 */
+	private final Clock clock;
 
+	/**
+	 * コンストラクタ.
+	 *
+	 * @param clock 日時の変換に使用するClock
+	 */
+	public DateTimeApiPropertyMapper(final Clock clock) {
+		super();
+		this.clock = clock;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.mapper.PropertyMapper#canAccept(java.lang.Class)
+	 */
 	@Override
 	public boolean canAccept(final Class<?> type) {
 		return LocalDateTime.class.equals(type)
@@ -85,6 +104,11 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.mapping.mapper.PropertyMapper#getValue(jp.co.future.uroborosql.mapping.JavaType, java.sql.ResultSet, int, jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager)
+	 */
 	@Override
 	public TemporalAccessor getValue(final JavaType type, final ResultSet rs, final int columnIndex,
 			final PropertyMapperManager mapperManager) throws SQLException {
@@ -97,13 +121,13 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 		if (OffsetDateTime.class.equals(rawType)) {
 			return Optional.ofNullable(rs.getTimestamp(columnIndex))
 					.map(java.sql.Timestamp::toLocalDateTime)
-					.map(d -> OffsetDateTime.of(d, OffsetDateTime.now().getOffset()))
+					.map(d -> OffsetDateTime.of(d, OffsetDateTime.now(clock).getOffset()))
 					.orElse(null);
 		}
 		if (ZonedDateTime.class.equals(rawType)) {
 			return Optional.ofNullable(rs.getTimestamp(columnIndex))
 					.map(java.sql.Timestamp::toLocalDateTime)
-					.map(d -> ZonedDateTime.of(d, Clock.systemDefaultZone().getZone()))
+					.map(d -> ZonedDateTime.of(d, clock.getZone()))
 					.orElse(null);
 		}
 		if (LocalDate.class.equals(rawType)) {
@@ -113,12 +137,12 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 		}
 		if (LocalTime.class.equals(rawType)) {
 			return Optional.ofNullable(rs.getTime(columnIndex))
-					.map(DateTimeApiPropertyMapper::sqlTimeToLocalTime)
+					.map(this::sqlTimeToLocalTime)
 					.orElse(null);
 		}
 		if (OffsetTime.class.equals(rawType)) {
 			return Optional.ofNullable(rs.getTime(columnIndex))
-					.map(DateTimeApiPropertyMapper::sqlTimeToOffsetTime)
+					.map(this::sqlTimeToOffsetTime)
 					.orElse(null);
 		}
 
@@ -166,27 +190,41 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 			LocalDate localDate = date.toLocalDate();
 
 			try {
-				return (ChronoLocalDate) rawType.getMethod("of", int.class, int.class, int.class).invoke(null, localDate.getYear(),
+				return (ChronoLocalDate) rawType.getMethod("of", int.class, int.class, int.class).invoke(null,
+						localDate.getYear(),
 						localDate.getMonthValue(),
 						localDate.getDayOfMonth());
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+					| NoSuchMethodException | SecurityException e) {
 				throw new UroborosqlRuntimeException(e);
 			}
 		}
 		throw new UroborosqlRuntimeException();
 	}
 
-	private static OffsetTime sqlTimeToOffsetTime(final java.sql.Time time) {
+	/**
+	 * {@link java.sql.Time} から {@link OffsetTime} への変換を行う.
+	 *
+	 * @param time 変換する{@link java.sql.Time}
+	 * @return 変換後の{@link OffsetTime}
+	 */
+	private OffsetTime sqlTimeToOffsetTime(final java.sql.Time time) {
 		long milliseconds = time.getTime();
-		Calendar calendar = Calendar.getInstance();
+		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
 		calendar.setTimeInMillis(milliseconds);
-		return OffsetDateTime.ofInstant(calendar.toInstant(), ZoneId.systemDefault()).toOffsetTime();
+		return OffsetDateTime.ofInstant(calendar.toInstant(), clock.getZone()).toOffsetTime();
 	}
 
-	private static LocalTime sqlTimeToLocalTime(final java.sql.Time time) {
+	/**
+	 * {@link java.sql.Time} から {@link LocalTime} への変換を行う.
+	 *
+	 * @param time 変換する{@link java.sql.Time}
+	 * @return 変換後の{@link LocalTime}
+	 */
+	private LocalTime sqlTimeToLocalTime(final java.sql.Time time) {
 		long milliseconds = time.getTime();
-		Calendar calendar = Calendar.getInstance();
+		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
 		calendar.setTimeInMillis(milliseconds);
-		return LocalDateTime.ofInstant(calendar.toInstant(), ZoneId.systemDefault()).toLocalTime();
+		return LocalDateTime.ofInstant(calendar.toInstant(), clock.getZone()).toLocalTime();
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
@@ -8,6 +8,7 @@ package jp.co.future.uroborosql.parameter.mapper;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -24,12 +25,15 @@ public final class BindParameterMapperManager {
 	private final List<BindParameterMapper<?>> mappers;
 
 	/** デフォルトMapper */
-	private static final BindParameterMapper<?>[] DEFAULT_MAPPERS = { new DateParameterMapper(),
-			new DateTimeApiParameterMapper(), new BigIntegerParameterMapper(),
-			new OptionalParameterMapper(), new OptionalIntParameterMapper(), new OptionalLongParameterMapper(),
+	private static final BindParameterMapper<?>[] DEFAULT_MAPPERS = {
+			new DateParameterMapper(),
+			new BigIntegerParameterMapper(),
+			new OptionalParameterMapper(),
+			new OptionalIntParameterMapper(),
+			new OptionalLongParameterMapper(),
 			new OptionalDoubleParameterMapper(),
 			new DomainParameterMapper(),
-			new EnumParameterMapper(),// DomainParameterMapper・DateTimeApiParameterMapperより後に設定
+			new EnumParameterMapper(), // DomainParameterMapper・DateTimeApiParameterMapperより後に設定
 			new StringArrayParameterMapper(),
 			new IntArrayParameterMapper(),
 			new IntWrapperArrayParameterMapper(),
@@ -48,20 +52,27 @@ public final class BindParameterMapperManager {
 		return list;
 	}
 
+	private final DateTimeApiParameterMapper dateTimeApiParameterMapper;
+
 	/**
-	 * コンストラクタ
+	 * コンストラクタ.
+	 *
+	 * @param clock Clock
 	 */
-	public BindParameterMapperManager() {
+	public BindParameterMapperManager(final Clock clock) {
 		mappers = new CopyOnWriteArrayList<>(LOADED_MAPPERS);
+		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
 	}
 
 	/**
 	 * コピーコンストラクタ
 	 *
 	 * @param parameterMapperManager コピー元のパラメータ変換クラス
+	 * @param clock clock
 	 */
-	public BindParameterMapperManager(final BindParameterMapperManager parameterMapperManager) {
+	public BindParameterMapperManager(final BindParameterMapperManager parameterMapperManager, final Clock clock) {
 		mappers = new CopyOnWriteArrayList<>(parameterMapperManager.mappers);
+		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
 	}
 
 	/**
@@ -89,13 +100,12 @@ public final class BindParameterMapperManager {
 	 * @param connection パラメータ生成用にConnectionを渡す
 	 * @return PreparedStatementにセットするパラメータ
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Object toJdbc(final Object object, final Connection connection) {
 		if (object == null) {
 			return null;
 		}
-		for (@SuppressWarnings("rawtypes")
-		BindParameterMapper parameterMapper : mappers) {
+		for (BindParameterMapper parameterMapper : mappers) {
 			if (parameterMapper.canAccept(object)) {
 				return parameterMapper.toJdbc(object, connection, this);
 			}
@@ -116,8 +126,11 @@ public final class BindParameterMapperManager {
 			return object;
 		}
 
-		for (@SuppressWarnings("rawtypes")
-		BindParameterMapper parameterMapper : DEFAULT_MAPPERS) {
+		if (dateTimeApiParameterMapper.canAccept(object)) {
+			return ((BindParameterMapper) dateTimeApiParameterMapper).toJdbc(object, connection, this);
+		}
+
+		for (BindParameterMapper parameterMapper : DEFAULT_MAPPERS) {
 			if (parameterMapper.canAccept(object)) {
 				return parameterMapper.toJdbc(object, connection, this);
 			}
@@ -153,6 +166,10 @@ public final class BindParameterMapperManager {
 			if (parameterMapper.canAccept(object)) {
 				return true;
 			}
+		}
+
+		if (dateTimeApiParameterMapper.canAccept(object)) {
+			return true;
 		}
 
 		for (BindParameterMapper<?> parameterMapper : DEFAULT_MAPPERS) {

--- a/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
@@ -56,7 +56,7 @@ public class SqlBatchTest extends AbstractDbTest {
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
 				.param("product_id", Arrays.asList(1, 2))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -97,7 +97,7 @@ public class SqlBatchTest extends AbstractDbTest {
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatch.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
 				.param("product_id", Arrays.asList(1, 2))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -131,7 +131,7 @@ public class SqlBatchTest extends AbstractDbTest {
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchNull.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
 				.param("product_id", Arrays.asList(1, 2))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -167,7 +167,7 @@ public class SqlBatchTest extends AbstractDbTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchStream.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -199,7 +199,7 @@ public class SqlBatchTest extends AbstractDbTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchStream.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -229,7 +229,7 @@ public class SqlBatchTest extends AbstractDbTest {
 		List<Map<String, Object>> expectedDataList = getDataFromFile(Paths.get(
 				"src/test/resources/data/expected/SqlAgent", "testExecuteBatchStream.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -254,8 +254,7 @@ public class SqlBatchTest extends AbstractDbTest {
 
 		int workCount = agent.batch("example/insert_product_regist_work")
 				.paramStream(agent.query("example/select_product")
-						.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(),
-								CaseFormat.LOWER_SNAKE_CASE)))
+						.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE)))
 				.by((ctx, row) -> ctx.batchCount() == 7)
 				.count();
 
@@ -293,8 +292,7 @@ public class SqlBatchTest extends AbstractDbTest {
 		// 処理実行
 		int workCount = agent.batch("example/insert_product_regist_work")
 				.paramStream(agent.query("example/select_product")
-						.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(),
-								CaseFormat.LOWER_SNAKE_CASE)))
+						.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE)))
 				.paramStream(paramList.stream())
 				.by((ctx, row) -> ctx.batchCount() == 10)
 				.count();

--- a/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
@@ -1001,7 +1001,7 @@ public class SqlQueryTest extends AbstractDbTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 
 		agent.query("example/select_product").param("product_id", Arrays.asList(0, 1))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.forEach((m) -> {
 					try {
 						agent.update("example/insert_product_regist_work").paramMap(m).count();

--- a/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
@@ -39,7 +39,7 @@ public class SqlUpdateTest extends AbstractDbTest {
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
 				.param("product_id", Arrays.asList(0, 1))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());
@@ -63,7 +63,7 @@ public class SqlUpdateTest extends AbstractDbTest {
 				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
 		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
 				.param("product_id", Arrays.asList(0, 1))
-				.stream(new MapResultSetConverter(agent.getSqlConfig().getDialect(), CaseFormat.LOWER_SNAKE_CASE))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
 				.collect(Collectors.toList());
 
 		assertEquals(expectedDataList.toString(), actualDataList.toString());

--- a/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
@@ -31,7 +31,7 @@ public class SqlParamUtilsTest {
 	@Test
 	public void testSetSqlParams() {
 		String sql = "/*key1*/, /*key2*/, /*key3*/(), /*CLS_AGE_DEFALUT*/, /*$CLS_FLAG_OFF*/";
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=1", "key2", "key3=[true, false]");
@@ -43,7 +43,7 @@ public class SqlParamUtilsTest {
 		assertThat((List<Boolean>) ctx.getParam("key3").getValue(), hasItem(true));
 		assertThat((List<Boolean>) ctx.getParam("key3").getValue(), hasItem(false));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=[NULL]", "key2=[EMPTY]");
@@ -52,7 +52,7 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.hasParam("key2"), is(true));
 		assertThat(ctx.getParam("key2").getValue(), is(""));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key3=[10, 20, 30]", "key1='multi word'");
@@ -66,7 +66,7 @@ public class SqlParamUtilsTest {
 		assertThat(val3, hasItem(20));
 		assertThat(val3, hasItem(30));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=2019-01-01", "key2=10:15:20");
@@ -75,7 +75,7 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.hasParam("key2"), is(true));
 		assertThat(ctx.getParam("key2").getValue(), is(instanceOf(LocalTime.class)));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=2019-01-01T10:15:20");
@@ -83,21 +83,21 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(instanceOf(LocalDateTime.class)));
 
 		// int
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=1000");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=+1000");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=-1000");
@@ -105,7 +105,7 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(-1000));
 
 		// 桁あふれ
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=" + Integer.MAX_VALUE + "0");
@@ -113,21 +113,21 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(new BigDecimal(Integer.MAX_VALUE + "0")));
 
 		// long
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=1000L");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000L));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=+1000L");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000L));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=-1000L");
@@ -135,7 +135,7 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(-1000L));
 
 		// 桁あふれ
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=" + Long.MAX_VALUE + "0");
@@ -143,21 +143,21 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(new BigDecimal(Long.MAX_VALUE + "0")));
 
 		// float
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=1000.01F");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000.01F));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=+1000.01f");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000.01F));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=-1000.01F");
@@ -165,21 +165,21 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(-1000.01F));
 
 		// double
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=1000.01D");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000.01D));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=+1000.01d");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is(1000.01D));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=-1000.01D");
@@ -187,14 +187,14 @@ public class SqlParamUtilsTest {
 		assertThat(ctx.getParam("key1").getValue(), is(-1000.01D));
 
 		// 数字の集合
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=0000010");
 		assertThat(ctx.hasParam("key1"), is(true));
 		assertThat(ctx.getParam("key1").getValue(), is("0000010"));
 
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=  ");
@@ -205,7 +205,7 @@ public class SqlParamUtilsTest {
 	@Test
 	public void testSetSqlParamsIfNode() {
 		String sql = "/*IF check1 != null*/ /*key1*/ /*ELSE*/ /*key2*/ /*END*/";
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
 		SqlParamUtils.setSqlParams(sqlConfig, ctx, "key1=value1", "key2=value2");

--- a/src/test/java/jp/co/future/uroborosql/config/SqlConfigTest.java
+++ b/src/test/java/jp/co/future/uroborosql/config/SqlConfigTest.java
@@ -1,0 +1,100 @@
+/**
+ *
+ */
+package jp.co.future.uroborosql.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.utils.StringUtils;
+
+/**
+ * TestCase DefaultSqlConfig
+ *
+ * @author H.Sugimoto
+ *
+ */
+public class SqlConfigTest {
+	private static final String JDBC_URL = "jdbc:h2:mem:SqlConfigTest";
+	private static final String JDBC_USER = "sa";
+	private static final String JDBC_PASSWORD = "sa";
+
+	private JdbcDataSource ds;
+
+	private Connection conn;
+
+	@Before
+	public void setUp() throws Exception {
+		ds = new JdbcDataSource();
+		ds.setURL(JDBC_URL + System.currentTimeMillis() + ";DB_CLOSE_DELAY=-1");
+		ds.setUser(JDBC_USER);
+		ds.setPassword(JDBC_PASSWORD);
+
+		SqlConfig config = UroboroSQL.builder(ds).build();
+
+		try (SqlAgent agent = config.agent()) {
+			// create table
+			String[] sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/ddl/create_tables.sql")),
+					StandardCharsets.UTF_8).split(";");
+			for (String sql : sqls) {
+				if (StringUtils.isNotBlank(sql)) {
+					agent.updateWith(sql.trim()).count();
+				}
+			}
+			agent.commit();
+
+			// insert init data
+			sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/setup/insert_product.sql")),
+					StandardCharsets.UTF_8).split(";");
+			for (String sql : sqls) {
+				if (StringUtils.isNotBlank(sql)) {
+					agent.updateWith(sql.trim()).count();
+				}
+			}
+			agent.commit();
+		}
+
+		conn = ds.getConnection();
+
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		conn.close();
+	}
+
+	/**
+	 * Testcase of {@link jp.co.future.uroborosql.config.DefaultSqlConfig#getConfig(java.sql.Connection)}
+	 */
+	@Test
+	public void testGetConfigConnection() throws Exception {
+		validate(UroboroSQL.builder(conn).build());
+	}
+
+	/**
+	 * Testcase of {@link jp.co.future.uroborosql.config.DefaultSqlConfig#getConfig(javax.sql.DataSource)} のためのテスト・メソッド。
+	 */
+	@Test
+	public void testGetConfigDataSource() throws Exception {
+		validate(UroboroSQL.builder(ds).build());
+	}
+
+	private void validate(final SqlConfig config) throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			assertThat(agent.query("example/select_product").collect().size(), is(2));
+		}
+
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryTest.java
@@ -19,24 +19,23 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.event.Level;
 
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.test.TestConsts;
 import jp.co.future.uroborosql.context.test.TestEnum1;
-import jp.co.future.uroborosql.filter.SqlFilterManager;
-import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
 import jp.co.future.uroborosql.parameter.Parameter;
 
 public class SqlContextFactoryTest {
 
-	private SqlContextFactory sqlContextFactory;
+	private SqlConfig sqlConfig;
 
-	private SqlFilterManager sqlFilterManager;
+	private SqlContextFactory sqlContextFactory;
 
 	@Before
 	public void setUp() throws Exception {
-		sqlFilterManager = new SqlFilterManagerImpl();
-
-		sqlContextFactory = new SqlContextFactoryImpl();
-		sqlContextFactory.setSqlFilterManager(sqlFilterManager);
+		sqlConfig = UroboroSQL
+				.builder("jdbc:h2:mem:" + this.getClass().getSimpleName() + ";DB_CLOSE_DELAY=-1", "sa", "sa").build();
+		sqlContextFactory = sqlConfig.getSqlContextFactory();
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
@@ -11,15 +11,12 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import jp.co.future.uroborosql.utils.StringUtils;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,139 +28,108 @@ import jp.co.future.uroborosql.dialect.Oracle12Dialect;
 import jp.co.future.uroborosql.dialect.PostgresqlDialect;
 import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
 import jp.co.future.uroborosql.utils.CaseFormat;
+import jp.co.future.uroborosql.utils.StringUtils;
 
 public class MapResultSetConverterTest {
-
-	private SqlConfig config;
-
-	private SqlAgent agent;
+	private String url;
+	private static final String INSERT_SQL = "insert into COLUMN_TYPE_TEST2 (" +
+			"	COL_INT," +
+			"	COL_BOOLEAN," +
+			"	COL_TINYINT," +
+			"	COL_SMALLINT," +
+			"	COL_BIGINT," +
+			"	COL_DECIMAL," +
+			"	COL_DOUBLE," +
+			"	COL_REAL," +
+			"	COL_TIME," +
+			"	COL_DATE," +
+			"	COL_TIMESTAMP," +
+			//				"	COL_TIMESTAMPWTZ," +
+			"	COL_BINARY," +
+			"	COL_CHAR," +
+			"	COL_NCHAR," +
+			"	COL_VARCHAR," +
+			"	COL_NVARCHAR," +
+			"	COL_LONGVARCHAR," +
+			"	COL_CLOB," +
+			"	COL_NCLOB," +
+			"	COL_BLOB," +
+			"	COL_ARRAY" +
+			") VALUES (" +
+			"	/*int*/, " +
+			"	/*boolean*/, " +
+			"	/*tinyint*/, " +
+			"	/*smallint*/, " +
+			"	/*bigint*/, " +
+			"	/*decimal*/, " +
+			"	/*double*/, " +
+			"	/*real*/, " +
+			"	/*time*/, " +
+			"	/*date*/, " +
+			"	/*timestamp*/, " +
+			//				"	/*timestampwtz*/, " +
+			"	/*binary*/, " +
+			"	/*char*/, " +
+			"	/*nchar*/, " +
+			"	/*varchar*/, " +
+			"	/*nvarchar*/, " +
+			"	/*longvarchar*/, " +
+			"	/*clob*/, " +
+			"	/*nclob*/, " +
+			"	/*blob*/, " +
+			"	/*arr*/" +
+			")";
 
 	@Before
-	public void setUp() throws Exception {
-		config = UroboroSQL.builder(DriverManager.getConnection("jdbc:h2:mem:MapResultSetConverterTest")).build();
-		agent = config.agent();
-
-		String sql = "create table if not exists COLUMN_TYPE_TEST2 (" +
-				"	COL_INT				INT," +
-				"	COL_BOOLEAN			BOOLEAN," +
-				"	COL_TINYINT			TINYINT," +
-				"	COL_SMALLINT		SMALLINT," +
-				"	COL_BIGINT			BIGINT," +
-				"	COL_DECIMAL			DECIMAL," +
-				"	COL_DOUBLE			DOUBLE," +
-				"	COL_REAL			REAL," +
-				"	COL_TIME			TIME," +
-				"	COL_DATE			DATE," +
-				"	COL_TIMESTAMP		TIMESTAMP," +
-				"	COL_TIMESTAMPWTZ	TIMESTAMP WITH TIME ZONE," +
-				"	COL_BINARY			BINARY," +
-				"	COL_CHAR			CHAR," +
-				"	COL_NCHAR			NCHAR," +
-				"	COL_VARCHAR			VARCHAR," +
-				"	COL_NVARCHAR		NVARCHAR," +
-				"	COL_LONGVARCHAR		LONGVARCHAR," +
-				"	COL_CLOB			CLOB," +
-				"	COL_NCLOB			NCLOB," +
-				"	COL_BLOB			BLOB," +
-				"	COL_ARRAY			ARRAY" +
-				");";
-		agent.updateWith(sql).count();
-
-		agent.commit();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		agent.close();
+	public void setUp() {
+		url = "jdbc:h2:mem:" + this.getClass().getSimpleName() + System.currentTimeMillis();
 	}
 
 	@Test
 	public void testCreateRecord() throws Exception {
-		String sql = "insert into COLUMN_TYPE_TEST2 (" +
-				"	COL_INT," +
-				"	COL_BOOLEAN," +
-				"	COL_TINYINT," +
-				"	COL_SMALLINT," +
-				"	COL_BIGINT," +
-				"	COL_DECIMAL," +
-				"	COL_DOUBLE," +
-				"	COL_REAL," +
-				"	COL_TIME," +
-				"	COL_DATE," +
-				"	COL_TIMESTAMP," +
-				//				"	COL_TIMESTAMPWTZ," +
-				"	COL_BINARY," +
-				"	COL_CHAR," +
-				"	COL_NCHAR," +
-				"	COL_VARCHAR," +
-				"	COL_NVARCHAR," +
-				"	COL_LONGVARCHAR," +
-				"	COL_CLOB," +
-				"	COL_NCLOB," +
-				"	COL_BLOB," +
-				"	COL_ARRAY" +
-				") VALUES (" +
-				"	/*int*/, " +
-				"	/*boolean*/, " +
-				"	/*tinyint*/, " +
-				"	/*smallint*/, " +
-				"	/*bigint*/, " +
-				"	/*decimal*/, " +
-				"	/*double*/, " +
-				"	/*real*/, " +
-				"	/*time*/, " +
-				"	/*date*/, " +
-				"	/*timestamp*/, " +
-				//				"	/*timestampwtz*/, " +
-				"	/*binary*/, " +
-				"	/*char*/, " +
-				"	/*nchar*/, " +
-				"	/*varchar*/, " +
-				"	/*nvarchar*/, " +
-				"	/*longvarchar*/, " +
-				"	/*clob*/, " +
-				"	/*nclob*/, " +
-				"	/*blob*/, " +
-				"	/*arr*/" +
-				")";
+		SqlConfig config = UroboroSQL.builder(DriverManager.getConnection(url))
+				.build();
+		try (SqlAgent agent = config.agent()) {
 
-		String clob = StringUtils.repeat('1', 10000);
-		String nclob = StringUtils.repeat('あ', 10000);
-		byte[] binary = StringUtils.repeat('y', 20000).getBytes();
-		byte[] blob = StringUtils.repeat('x', 20000).getBytes();
-		int[] arr = { 1, 2 };
-		LocalTime time = LocalTime.of(10, 0, 0);
-		ZonedDateTime date = ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 0, 0, 0), ZoneId.of("Asia/Tokyo"));
-		Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2019, Month.MAY, 1, 10, 30, 0));
+			createTable(agent);
 
-		agent.updateWith(sql)
-				.param("int", 1)
-				.param("boolean", true)
-				.param("tinyint", 2)
-				.param("smallint", 3)
-				.param("bigint", 4l)
-				.param("decimal", new BigDecimal(5))
-				.param("double", 6d)
-				.param("real", 7f)
-				.param("time", time)
-				.param("date", date)
-				.param("timestamp", timestamp)
-				// h2db timestamp with time zone is not support rs.getTimestamp()
-				//				.param("timestampwtz",
-				//						ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 10, 45), ZoneId.of("Asia/Tokyo")))
-				.param("binary", binary)
-				.param("char", 'a')
-				.param("nchar", 'あ')
-				.param("varchar", "abc")
-				.param("nvarchar", "文字列")
-				.param("longvarchar", "abcabc")
-				.clobParam("clob", new StringReader(clob))
-				.clobParam("nclob", new StringReader(nclob))
-				.blobParam("blob", new ByteArrayInputStream(blob))
-				.param("arr", arr)
-				.count();
+			String clob = StringUtils.repeat('1', 10000);
+			String nclob = StringUtils.repeat('あ', 10000);
+			byte[] binary = StringUtils.repeat('y', 20000).getBytes();
+			byte[] blob = StringUtils.repeat('x', 20000).getBytes();
+			int[] arr = { 1, 2 };
+			LocalTime time = LocalTime.of(10, 0, 0);
+			ZonedDateTime date = ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 0, 0, 0),
+					config.getClock().getZone());
+			Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2019, Month.MAY, 1, 10, 30, 0));
 
-		{
+			agent.updateWith(INSERT_SQL)
+					.param("int", 1)
+					.param("boolean", true)
+					.param("tinyint", 2)
+					.param("smallint", 3)
+					.param("bigint", 4l)
+					.param("decimal", new BigDecimal(5))
+					.param("double", 6d)
+					.param("real", 7f)
+					.param("time", time)
+					.param("date", date)
+					.param("timestamp", timestamp)
+					// h2db timestamp with time zone is not support rs.getTimestamp()
+					//				.param("timestampwtz",
+					//						ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 10, 45), config.getClock().getZone()))
+					.param("binary", binary)
+					.param("char", 'a')
+					.param("nchar", 'あ')
+					.param("varchar", "abc")
+					.param("nvarchar", "文字列")
+					.param("longvarchar", "abcabc")
+					.clobParam("clob", new StringReader(clob))
+					.clobParam("nclob", new StringReader(nclob))
+					.blobParam("blob", new ByteArrayInputStream(blob))
+					.param("arr", arr)
+					.count();
+
 			Optional<Map<String, Object>> optional = agent.queryWith("select * from COLUMN_TYPE_TEST2").findFirst();
 			assertThat(optional.isPresent(), is(true));
 			Map<String, Object> row = optional.get();
@@ -190,11 +156,57 @@ public class MapResultSetConverterTest {
 			assertThat(row.get("COL_BLOB"), is(blob));
 			assertThat(row.get("COL_ARRAY"), is(arr));
 		}
+	}
 
-		{
+	@Test
+	public void testCreateRecordWithDialect() throws Exception {
+		SqlConfig config = UroboroSQL.builder(DriverManager.getConnection(url))
+				.setDialect(new Oracle12Dialect())
+				.build();
+		try (SqlAgent agent = config.agent()) {
+
+			createTable(agent);
+
+			String clob = StringUtils.repeat('1', 10000);
+			String nclob = StringUtils.repeat('あ', 10000);
+			byte[] binary = StringUtils.repeat('y', 20000).getBytes();
+			byte[] blob = StringUtils.repeat('x', 20000).getBytes();
+			int[] arr = { 1, 2 };
+			LocalTime time = LocalTime.of(10, 0, 0);
+			ZonedDateTime date = ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 0, 0, 0),
+					config.getClock().getZone());
+			Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2019, Month.MAY, 1, 10, 30, 0));
+
+			agent.updateWith(INSERT_SQL)
+					.param("int", 1)
+					.param("boolean", true)
+					.param("tinyint", 2)
+					.param("smallint", 3)
+					.param("bigint", 4l)
+					.param("decimal", new BigDecimal(5))
+					.param("double", 6d)
+					.param("real", 7f)
+					.param("time", time)
+					.param("date", date)
+					.param("timestamp", timestamp)
+					// h2db timestamp with time zone is not support rs.getTimestamp()
+					//				.param("timestampwtz",
+					//						ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 10, 45), config.getClock().getZone()))
+					.param("binary", binary)
+					.param("char", 'a')
+					.param("nchar", 'あ')
+					.param("varchar", "abc")
+					.param("nvarchar", "文字列")
+					.param("longvarchar", "abcabc")
+					.clobParam("clob", new StringReader(clob))
+					.clobParam("nclob", new StringReader(nclob))
+					.blobParam("blob", new ByteArrayInputStream(blob))
+					.param("arr", arr)
+					.count();
+
 			// constractor MapResultSetConverter(final Dialect dialect)
 			SqlContext context = config.contextWith("select * from COLUMN_TYPE_TEST2");
-			List<Map<String, Object>> result = agent.query(context, new MapResultSetConverter(new Oracle12Dialect()))
+			List<Map<String, Object>> result = agent.query(context, new MapResultSetConverter(config))
 					.collect(Collectors.toList());
 			assertThat(result.size(), is(1));
 			Map<String, Object> row = result.get(0);
@@ -221,14 +233,60 @@ public class MapResultSetConverterTest {
 			assertThat(row.get("COL_BLOB"), is(blob));
 			assertThat(row.get("COL_ARRAY"), is(arr));
 		}
+	}
 
-		{
+	@Test
+	public void testCreateRecordWithSnakeCase() throws Exception {
+		SqlConfig config = UroboroSQL.builder(DriverManager.getConnection(url))
+				.setDialect(new PostgresqlDialect())
+				.build();
+		try (SqlAgent agent = config.agent()) {
+
+			createTable(agent);
+
+			String clob = StringUtils.repeat('1', 10000);
+			String nclob = StringUtils.repeat('あ', 10000);
+			byte[] binary = StringUtils.repeat('y', 20000).getBytes();
+			byte[] blob = StringUtils.repeat('x', 20000).getBytes();
+			int[] arr = { 1, 2 };
+			LocalTime time = LocalTime.of(10, 0, 0);
+			ZonedDateTime date = ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 0, 0, 0),
+					config.getClock().getZone());
+			Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2019, Month.MAY, 1, 10, 30, 0));
+
+			agent.updateWith(INSERT_SQL)
+					.param("int", 1)
+					.param("boolean", true)
+					.param("tinyint", 2)
+					.param("smallint", 3)
+					.param("bigint", 4l)
+					.param("decimal", new BigDecimal(5))
+					.param("double", 6d)
+					.param("real", 7f)
+					.param("time", time)
+					.param("date", date)
+					.param("timestamp", timestamp)
+					// h2db timestamp with time zone is not support rs.getTimestamp()
+					//				.param("timestampwtz",
+					//						ZonedDateTime.of(LocalDateTime.of(2019, Month.MAY, 1, 10, 45), config.getClock().getZone()))
+					.param("binary", binary)
+					.param("char", 'a')
+					.param("nchar", 'あ')
+					.param("varchar", "abc")
+					.param("nvarchar", "文字列")
+					.param("longvarchar", "abcabc")
+					.clobParam("clob", new StringReader(clob))
+					.clobParam("nclob", new StringReader(nclob))
+					.blobParam("blob", new ByteArrayInputStream(blob))
+					.param("arr", arr)
+					.count();
+
 			// constractor MapResultSetConverter(final Dialect dialect)
 			SqlContext context = config.contextWith("select * from COLUMN_TYPE_TEST2");
 			List<Map<String, Object>> result = agent
 					.query(context,
-							new MapResultSetConverter(new PostgresqlDialect(), CaseFormat.UPPER_SNAKE_CASE,
-									new PropertyMapperManager()))
+							new MapResultSetConverter(config, CaseFormat.UPPER_SNAKE_CASE,
+									new PropertyMapperManager(config.getClock())))
 					.collect(Collectors.toList());
 			assertThat(result.size(), is(1));
 			Map<String, Object> row = result.get(0);
@@ -255,6 +313,34 @@ public class MapResultSetConverterTest {
 			assertThat(row.get("COL_BLOB"), is(blob));
 			assertThat(row.get("COL_ARRAY"), is(arr));
 		}
+	}
+
+	protected void createTable(final SqlAgent agent) {
+		String createTableSql = "create table if not exists COLUMN_TYPE_TEST2 (" +
+				"	COL_INT				INT," +
+				"	COL_BOOLEAN			BOOLEAN," +
+				"	COL_TINYINT			TINYINT," +
+				"	COL_SMALLINT		SMALLINT," +
+				"	COL_BIGINT			BIGINT," +
+				"	COL_DECIMAL			DECIMAL," +
+				"	COL_DOUBLE			DOUBLE," +
+				"	COL_REAL			REAL," +
+				"	COL_TIME			TIME," +
+				"	COL_DATE			DATE," +
+				"	COL_TIMESTAMP		TIMESTAMP," +
+				"	COL_TIMESTAMPWTZ	TIMESTAMP WITH TIME ZONE," +
+				"	COL_BINARY			BINARY," +
+				"	COL_CHAR			CHAR," +
+				"	COL_NCHAR			NCHAR," +
+				"	COL_VARCHAR			VARCHAR," +
+				"	COL_NVARCHAR		NVARCHAR," +
+				"	COL_LONGVARCHAR		LONGVARCHAR," +
+				"	COL_CLOB			CLOB," +
+				"	COL_NCLOB			NCLOB," +
+				"	COL_BLOB			BLOB," +
+				"	COL_ARRAY			ARRAY" +
+				");";
+		agent.updateWith(createTableSql).count();
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/mapping/mapper/ArrayPropertyMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/mapper/ArrayPropertyMapperTest.java
@@ -1,27 +1,35 @@
 package jp.co.future.uroborosql.mapping.mapper;
 
-import static jp.co.future.uroborosql.mapping.mapper.Helper.newResultSet;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static jp.co.future.uroborosql.mapping.mapper.Helper.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.SQLException;
+import java.time.Clock;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import jp.co.future.uroborosql.mapping.JavaType;
 
-import org.junit.Test;
-
 public class ArrayPropertyMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 		mapper.addMapper(new ArrayPropertyMapper());
 		java.sql.Array array = newDummyArray("a,b,c".split(","));
-		assertThat(mapper.getValue(JavaType.of(String[].class), newResultSet("getArray", array), 1), is("a,b,c".split(",")));
+		assertThat(mapper.getValue(JavaType.of(String[].class), newResultSet("getArray", array), 1),
+				is("a,b,c".split(",")));
 
 		array = newDummyArray(new Number[] { 1, 2, 3 });
 		assertThat(mapper.getValue(JavaType.of(Integer[].class), newResultSet(
@@ -44,6 +52,7 @@ public class ArrayPropertyMapperTest {
 				return null;
 			}
 		};
-		return (java.sql.Array) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[] { java.sql.Array.class }, handler);
+		return (java.sql.Array) Proxy.newProxyInstance(this.getClass().getClassLoader(),
+				new Class[] { java.sql.Array.class }, handler);
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapperTest.java
@@ -1,9 +1,8 @@
 package jp.co.future.uroborosql.mapping.mapper;
 
-import static jp.co.future.uroborosql.mapping.mapper.Helper.newResultSet;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static jp.co.future.uroborosql.mapping.mapper.Helper.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.sql.SQLException;
 import java.time.Clock;
@@ -26,18 +25,25 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 
-import jp.co.future.uroborosql.mapping.JavaType;
-
+import org.junit.Before;
 import org.junit.Test;
 
+import jp.co.future.uroborosql.mapping.JavaType;
+
 public class DateTimeApiPropertyMapperTest {
+	private Clock clock;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
-		LocalDateTime localDateTime = LocalDateTime.now();
-		OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, OffsetDateTime.now().getOffset());
-		ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, Clock.systemDefaultZone().getZone());
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
+		LocalDateTime localDateTime = LocalDateTime.now(this.clock);
+		OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, OffsetDateTime.now(this.clock).getOffset());
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, this.clock.getZone());
 
 		java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf(localDateTime);
 		LocalDate localDate = localDateTime.toLocalDate();
@@ -46,16 +52,22 @@ public class DateTimeApiPropertyMapperTest {
 		java.sql.Time time = new java.sql.Time(toTime(localTime));
 		OffsetTime offsetTime = offsetDateTime.toOffsetTime();
 
-		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", timestamp), 1), is(localDateTime));
-		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", timestamp), 1), is(offsetDateTime));
-		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", timestamp), 1), is(zonedDateTime));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", timestamp), 1),
+				is(localDateTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", timestamp), 1),
+				is(offsetDateTime));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", timestamp), 1),
+				is(zonedDateTime));
 		assertThat(mapper.getValue(JavaType.of(LocalDate.class), newResultSet("getDate", date), 1), is(localDate));
 		assertThat(mapper.getValue(JavaType.of(LocalTime.class), newResultSet("getTime", time), 1), is(localTime));
 		assertThat(mapper.getValue(JavaType.of(OffsetTime.class), newResultSet("getTime", time), 1), is(offsetTime));
 
-		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", null), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", null), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", null), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", null), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", null), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", null), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(LocalDate.class), newResultSet("getDate", null), 1), is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(LocalTime.class), newResultSet("getTime", null), 1), is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(OffsetTime.class), newResultSet("getTime", null), 1), is(nullValue()));
@@ -64,35 +76,46 @@ public class DateTimeApiPropertyMapperTest {
 
 	@Test
 	public void test2() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", 2000), 1), is(Year.of(2000)));
-		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 200004), 1), is(YearMonth.of(2000, 4)));
+		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 200004), 1),
+				is(YearMonth.of(2000, 4)));
 		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", 401), 1), is(MonthDay.of(4, 1)));
 		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", 4), 1), is(Month.APRIL));
 		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", 4), 1), is(DayOfWeek.THURSDAY));
 
-		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
 
 	}
 
 	@Test
 	public void test3() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 
-		LocalDate localDate = LocalDate.now();
+		LocalDate localDate = LocalDate.now(this.clock);
 		java.sql.Date date = java.sql.Date.valueOf(localDate);
-		JapaneseDate japaneseDate = JapaneseDate.of(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth());
+		JapaneseDate japaneseDate = JapaneseDate.of(localDate.getYear(), localDate.getMonthValue(),
+				localDate.getDayOfMonth());
 
-		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 2), 1), is(JapaneseEra.HEISEI));
+		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 2), 1),
+				is(JapaneseEra.HEISEI));
 		assertThat(mapper.getValue(JavaType.of(Era.class), newResultSet("getInt", 2), 1), is(nullValue()));
-		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", date), 1), is(japaneseDate));
-		assertThat(mapper.getValue(JavaType.of(ChronoLocalDate.class), newResultSet("getDate", null), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", date), 1),
+				is(japaneseDate));
+		assertThat(mapper.getValue(JavaType.of(ChronoLocalDate.class), newResultSet("getDate", null), 1),
+				is(nullValue()));
 
-		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 0, "wasNull", true), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", null), 1), is(nullValue()));
 
 	}

--- a/src/test/java/jp/co/future/uroborosql/mapping/mapper/PropertyMapperManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/mapper/PropertyMapperManagerTest.java
@@ -1,55 +1,76 @@
 package jp.co.future.uroborosql.mapping.mapper;
 
-import static jp.co.future.uroborosql.mapping.mapper.Helper.newProxy;
-import static jp.co.future.uroborosql.mapping.mapper.Helper.newResultSet;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static jp.co.future.uroborosql.mapping.mapper.Helper.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.*;
+import java.util.Date;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import jp.co.future.uroborosql.mapping.JavaType;
 
-import org.junit.Test;
-
 public class PropertyMapperManagerTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 		assertThat(mapper.getValue(JavaType.of(String.class), newResultSet("getString", "value"), 1), is("value"));
 		assertThat(mapper.getValue(JavaType.of(String.class), newResultSet("getString", null), 1), nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(boolean.class), newResultSet("getBoolean", true), 1), is(true));
-		assertThat(mapper.getValue(JavaType.of(boolean.class), newResultSet("getBoolean", false, "wasNull", false), 1), is(false));
-		assertThat(mapper.getValue(JavaType.of(boolean.class), newResultSet("getBoolean", false, "wasNull", true), 1), is(false));
+		assertThat(mapper.getValue(JavaType.of(boolean.class), newResultSet("getBoolean", false, "wasNull", false), 1),
+				is(false));
+		assertThat(mapper.getValue(JavaType.of(boolean.class), newResultSet("getBoolean", false, "wasNull", true), 1),
+				is(false));
 
 		assertThat(mapper.getValue(JavaType.of(Boolean.class), newResultSet("getBoolean", true), 1), is(true));
-		assertThat(mapper.getValue(JavaType.of(Boolean.class), newResultSet("getBoolean", false, "wasNull", false), 1), is(false));
-		assertThat(mapper.getValue(JavaType.of(Boolean.class), newResultSet("getBoolean", false, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Boolean.class), newResultSet("getBoolean", false, "wasNull", false), 1),
+				is(false));
+		assertThat(mapper.getValue(JavaType.of(Boolean.class), newResultSet("getBoolean", false, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(byte.class), newResultSet("getByte", (byte) 1), 1), is((byte) 1));
-		assertThat(mapper.getValue(JavaType.of(byte.class), newResultSet("getByte", (byte) 0, "wasNull", false), 1), is((byte) 0));
-		assertThat(mapper.getValue(JavaType.of(byte.class), newResultSet("getByte", (byte) 0, "wasNull", true), 1), is((byte) 0));
+		assertThat(mapper.getValue(JavaType.of(byte.class), newResultSet("getByte", (byte) 0, "wasNull", false), 1),
+				is((byte) 0));
+		assertThat(mapper.getValue(JavaType.of(byte.class), newResultSet("getByte", (byte) 0, "wasNull", true), 1),
+				is((byte) 0));
 
 		assertThat(mapper.getValue(JavaType.of(Byte.class), newResultSet("getByte", (byte) 1), 1), is((byte) 1));
-		assertThat(mapper.getValue(JavaType.of(Byte.class), newResultSet("getByte", (byte) 0, "wasNull", false), 1), is((byte) 0));
-		assertThat(mapper.getValue(JavaType.of(Byte.class), newResultSet("getByte", (byte) 0, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Byte.class), newResultSet("getByte", (byte) 0, "wasNull", false), 1),
+				is((byte) 0));
+		assertThat(mapper.getValue(JavaType.of(Byte.class), newResultSet("getByte", (byte) 0, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(short.class), newResultSet("getShort", (short) 1), 1), is((short) 1));
-		assertThat(mapper.getValue(JavaType.of(short.class), newResultSet("getShort", (short) 0, "wasNull", false), 1), is((short) 0));
-		assertThat(mapper.getValue(JavaType.of(short.class), newResultSet("getShort", (short) 0, "wasNull", true), 1), is((short) 0));
+		assertThat(mapper.getValue(JavaType.of(short.class), newResultSet("getShort", (short) 0, "wasNull", false), 1),
+				is((short) 0));
+		assertThat(mapper.getValue(JavaType.of(short.class), newResultSet("getShort", (short) 0, "wasNull", true), 1),
+				is((short) 0));
 
 		assertThat(mapper.getValue(JavaType.of(Short.class), newResultSet("getShort", (short) 1), 1), is((short) 1));
-		assertThat(mapper.getValue(JavaType.of(Short.class), newResultSet("getShort", (short) 0, "wasNull", false), 1), is((short) 0));
-		assertThat(mapper.getValue(JavaType.of(Short.class), newResultSet("getShort", (short) 0, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Short.class), newResultSet("getShort", (short) 0, "wasNull", false), 1),
+				is((short) 0));
+		assertThat(mapper.getValue(JavaType.of(Short.class), newResultSet("getShort", (short) 0, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(int.class), newResultSet("getInt", 1), 1), is(1));
 		assertThat(mapper.getValue(JavaType.of(int.class), newResultSet("getInt", 0, "wasNull", false), 1), is(0));
@@ -57,7 +78,8 @@ public class PropertyMapperManagerTest {
 
 		assertThat(mapper.getValue(JavaType.of(Integer.class), newResultSet("getInt", 1), 1), is(1));
 		assertThat(mapper.getValue(JavaType.of(Integer.class), newResultSet("getInt", 0, "wasNull", false), 1), is(0));
-		assertThat(mapper.getValue(JavaType.of(Integer.class), newResultSet("getInt", 0, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Integer.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(long.class), newResultSet("getLong", 1L), 1), is(1L));
 		assertThat(mapper.getValue(JavaType.of(long.class), newResultSet("getLong", 0L, "wasNull", false), 1), is(0L));
@@ -65,31 +87,44 @@ public class PropertyMapperManagerTest {
 
 		assertThat(mapper.getValue(JavaType.of(Long.class), newResultSet("getLong", 1L), 1), is(1L));
 		assertThat(mapper.getValue(JavaType.of(Long.class), newResultSet("getLong", 0L, "wasNull", false), 1), is(0L));
-		assertThat(mapper.getValue(JavaType.of(Long.class), newResultSet("getLong", 0L, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Long.class), newResultSet("getLong", 0L, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(float.class), newResultSet("getFloat", 1.2F), 1), is(1.2F));
-		assertThat(mapper.getValue(JavaType.of(float.class), newResultSet("getFloat", 0F, "wasNull", false), 1), is(0F));
+		assertThat(mapper.getValue(JavaType.of(float.class), newResultSet("getFloat", 0F, "wasNull", false), 1),
+				is(0F));
 		assertThat(mapper.getValue(JavaType.of(float.class), newResultSet("getFloat", 0F, "wasNull", true), 1), is(0F));
 
 		assertThat(mapper.getValue(JavaType.of(Float.class), newResultSet("getFloat", 1.2F), 1), is(1.2F));
-		assertThat(mapper.getValue(JavaType.of(Float.class), newResultSet("getFloat", 0F, "wasNull", false), 1), is(0F));
-		assertThat(mapper.getValue(JavaType.of(Float.class), newResultSet("getFloat", 0F, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Float.class), newResultSet("getFloat", 0F, "wasNull", false), 1),
+				is(0F));
+		assertThat(mapper.getValue(JavaType.of(Float.class), newResultSet("getFloat", 0F, "wasNull", true), 1),
+				nullValue());
 
 		assertThat(mapper.getValue(JavaType.of(double.class), newResultSet("getDouble", 1.2D), 1), is(1.2D));
-		assertThat(mapper.getValue(JavaType.of(double.class), newResultSet("getDouble", 0D, "wasNull", false), 1), is(0D));
-		assertThat(mapper.getValue(JavaType.of(double.class), newResultSet("getDouble", 0D, "wasNull", true), 1), is(0D));
+		assertThat(mapper.getValue(JavaType.of(double.class), newResultSet("getDouble", 0D, "wasNull", false), 1),
+				is(0D));
+		assertThat(mapper.getValue(JavaType.of(double.class), newResultSet("getDouble", 0D, "wasNull", true), 1),
+				is(0D));
 
 		assertThat(mapper.getValue(JavaType.of(Double.class), newResultSet("getDouble", 1.2D), 1), is(1.2D));
-		assertThat(mapper.getValue(JavaType.of(Double.class), newResultSet("getDouble", 0D, "wasNull", false), 1), is(0D));
-		assertThat(mapper.getValue(JavaType.of(Double.class), newResultSet("getDouble", 0D, "wasNull", true), 1), nullValue());
+		assertThat(mapper.getValue(JavaType.of(Double.class), newResultSet("getDouble", 0D, "wasNull", false), 1),
+				is(0D));
+		assertThat(mapper.getValue(JavaType.of(Double.class), newResultSet("getDouble", 0D, "wasNull", true), 1),
+				nullValue());
 
-		assertThat(mapper.getValue(JavaType.of(BigDecimal.class), newResultSet("getBigDecimal", BigDecimal.valueOf(123.123)), 1),
+		assertThat(
+				mapper.getValue(JavaType.of(BigDecimal.class),
+						newResultSet("getBigDecimal", BigDecimal.valueOf(123.123)), 1),
 				is(BigDecimal.valueOf(123.123)));
-		assertThat(mapper.getValue(JavaType.of(byte[].class), newResultSet("getBytes", "abc".getBytes(StandardCharsets.UTF_8)), 1),
+		assertThat(
+				mapper.getValue(JavaType.of(byte[].class),
+						newResultSet("getBytes", "abc".getBytes(StandardCharsets.UTF_8)), 1),
 				is("abc".getBytes(StandardCharsets.UTF_8)));
 
 		java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf(LocalDateTime.now());
-		assertThat(mapper.getValue(JavaType.of(java.sql.Timestamp.class), newResultSet("getTimestamp", timestamp), 1), is(timestamp));
+		assertThat(mapper.getValue(JavaType.of(java.sql.Timestamp.class), newResultSet("getTimestamp", timestamp), 1),
+				is(timestamp));
 
 		java.sql.Time time = java.sql.Time.valueOf(LocalTime.now());
 		assertThat(mapper.getValue(JavaType.of(java.sql.Time.class), newResultSet("getTime", time), 1), is(time));
@@ -114,24 +149,36 @@ public class PropertyMapperManagerTest {
 		assertThat(mapper.getValue(JavaType.of(java.sql.NClob.class), newResultSet("getNClob", nclob), 1), is(nclob));
 
 		java.sql.SQLXML sqlxml = newProxy(java.sql.SQLXML.class);
-		assertThat(mapper.getValue(JavaType.of(java.sql.SQLXML.class), newResultSet("getSQLXML", sqlxml), 1), is(sqlxml));
+		assertThat(mapper.getValue(JavaType.of(java.sql.SQLXML.class), newResultSet("getSQLXML", sqlxml), 1),
+				is(sqlxml));
 
-		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 1), 1), is(OptionalInt.of(1)));
-		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 0, "wasNull", false), 1), is(OptionalInt.of(0)));
-		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 0, "wasNull", true), 1), is(OptionalInt.empty()));
+		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 1), 1),
+				is(OptionalInt.of(1)));
+		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 0, "wasNull", false), 1),
+				is(OptionalInt.of(0)));
+		assertThat(mapper.getValue(JavaType.of(OptionalInt.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(OptionalInt.empty()));
 
-		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 1L), 1), is(OptionalLong.of(1L)));
-		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 0L, "wasNull", false), 1), is(OptionalLong.of(0L)));
-		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 0L, "wasNull", true), 1), is(OptionalLong.empty()));
+		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 1L), 1),
+				is(OptionalLong.of(1L)));
+		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 0L, "wasNull", false), 1),
+				is(OptionalLong.of(0L)));
+		assertThat(mapper.getValue(JavaType.of(OptionalLong.class), newResultSet("getLong", 0L, "wasNull", true), 1),
+				is(OptionalLong.empty()));
 
-		assertThat(mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 1.2D), 1), is(OptionalDouble.of(1.2D)));
-		assertThat(mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 0D, "wasNull", false), 1), is(OptionalDouble.of(0D)));
-		assertThat(mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 0D, "wasNull", true), 1), is(OptionalDouble.empty()));
+		assertThat(mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 1.2D), 1),
+				is(OptionalDouble.of(1.2D)));
+		assertThat(
+				mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 0D, "wasNull", false), 1),
+				is(OptionalDouble.of(0D)));
+		assertThat(
+				mapper.getValue(JavaType.of(OptionalDouble.class), newResultSet("getDouble", 0D, "wasNull", true), 1),
+				is(OptionalDouble.empty()));
 	}
 
 	@Test
 	public void testCustom() throws NoSuchMethodException, SecurityException, SQLException {
-		PropertyMapperManager mapper = new PropertyMapperManager();
+		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 
 		mapper.addMapper(new PropertyMapper<String>() {
 
@@ -141,7 +188,8 @@ public class PropertyMapperManagerTest {
 			}
 
 			@Override
-			public String getValue(final JavaType type, final ResultSet rs, final int columnIndex, final PropertyMapperManager mapperManager)
+			public String getValue(final JavaType type, final ResultSet rs, final int columnIndex,
+					final PropertyMapperManager mapperManager)
 					throws SQLException {
 				return rs.getString(columnIndex).toUpperCase();
 			}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.ZoneId;
@@ -16,10 +17,15 @@ import java.util.Date;
 import org.junit.Test;
 
 public class BindParameterMapperManagerTest {
+	private Clock clock;
+
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() throws ParseException {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 
 		assertThat(parameterMapperManager.toJdbc(null, null), is(nullValue()));
 
@@ -62,7 +68,7 @@ public class BindParameterMapperManagerTest {
 
 	@Test
 	public void testCustom() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 
 		parameterMapperManager.addMapper(new BindParameterMapper<String>() {
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapperTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -25,12 +26,20 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class DateTimeApiParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
+
 	@Test
 	public void testLocalDateTime() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(LocalDateTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Timestamp.class));
 		assertThat(mapper.toJdbc(LocalDateTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -39,7 +48,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testOffsetDateTime() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(OffsetDateTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Timestamp.class));
 		assertThat(
@@ -52,7 +61,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testZonedDateTime() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(createDateTime("2000-01-01T10:10:10"), null, null),
 				instanceOf(java.sql.Timestamp.class));
 		assertThat(mapper.toJdbc(
@@ -63,7 +72,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testLocalDate() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(LocalDate.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Date.class));
 		assertThat(mapper.toJdbc(LocalDate.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -72,7 +81,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testLocalTime() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(LocalTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Time.class));
 		assertThat(mapper.toJdbc(LocalTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -81,7 +90,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testOffsetTime() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(OffsetTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Time.class));
 		assertThat(mapper.toJdbc(OffsetTime.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -90,7 +99,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testYear() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(Year.of(2000), null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(Year.of(2000), null, null), is(2000));
 		assertThat(mapper.toJdbc(Year.of(200), null, null), is(200));
@@ -98,7 +107,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testYearMonth() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(YearMonth.of(2001, Month.JANUARY), null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(YearMonth.of(2001, Month.JANUARY), null, null), is(200101));
 		assertThat(mapper.toJdbc(YearMonth.of(201, Month.JANUARY), null, null), is(20101));
@@ -106,7 +115,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testMonthDay() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(MonthDay.of(Month.JANUARY, 10), null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(MonthDay.of(Month.JANUARY, 10), null, null), is(110));
 		assertThat(mapper.toJdbc(MonthDay.of(Month.JANUARY, 1), null, null), is(101));
@@ -114,7 +123,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testMonth() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(Month.JANUARY, null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(Month.JANUARY, null, null), is(1));
 		assertThat(mapper.toJdbc(Month.DECEMBER, null, null), is(12));
@@ -122,7 +131,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testDayOfWeek() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(DayOfWeek.SUNDAY, null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(DayOfWeek.SUNDAY, null, null), is(7));
 		assertThat(mapper.toJdbc(DayOfWeek.MONDAY, null, null), is(1));
@@ -130,7 +139,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testEra() {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(JapaneseEra.HEISEI, null, null), instanceOf(Integer.class));
 		assertThat(mapper.toJdbc(JapaneseEra.HEISEI, null, null), is(2));
 		assertThat(mapper.toJdbc(JapaneseEra.MEIJI, null, null), is(-1));
@@ -138,7 +147,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testChronoLocalDate() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(JapaneseDate.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Date.class));
 		assertThat(mapper.toJdbc(JapaneseDate.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -147,7 +156,7 @@ public class DateTimeApiParameterMapperTest {
 
 	@Test
 	public void testInstant() throws ParseException {
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(Instant.from(createDateTime("2000-01-01T10:10:10")), null, null),
 				instanceOf(java.sql.Timestamp.class));
 		assertThat(mapper.toJdbc(Instant.from(createDateTime("2000-01-01T10:10:10")), null, null),
@@ -174,7 +183,7 @@ public class DateTimeApiParameterMapperTest {
 			}
 		};
 
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), instanceOf(java.sql.Date.class));
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), is(createDate("2000-01-05")));
 	}
@@ -183,7 +192,7 @@ public class DateTimeApiParameterMapperTest {
 	public void testTemporalAccessorDate2() throws ParseException {
 		TemporalAccessor temporalAccessor = DateTimeFormatter.ofPattern("yyyy-MM-dd HH").parse("2000-05-05 10");
 
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), instanceOf(java.sql.Timestamp.class));
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), is(createTimestamp("2000-05-05T10:00:00")));
 	}
@@ -192,7 +201,7 @@ public class DateTimeApiParameterMapperTest {
 	public void testTemporalAccessorDate3() throws ParseException {
 		TemporalAccessor temporalAccessor = DateTimeFormatter.ofPattern("HH").parse("10");
 
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), instanceOf(java.sql.Time.class));
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), is(createTime("10:00:00")));
 	}
@@ -220,7 +229,7 @@ public class DateTimeApiParameterMapperTest {
 			}
 		};
 
-		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper();
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), instanceOf(TemporalAccessor.class));
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), is(temporalAccessor));
 	}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/DoubleArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/DoubleArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class DoubleArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		double[] array = { 111.11d, 222.22d };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/DoubleWrapperArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/DoubleWrapperArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class DoubleWrapperArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		Double[] array = { Double.valueOf(111.11d), Double.valueOf(222.22d) };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/IntArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/IntArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class IntArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		int[] array = { 111 };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/IntWrapperArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/IntWrapperArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class IntWrapperArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		Integer[] array = { Integer.valueOf(111), Integer.valueOf(222) };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/LongArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/LongArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class LongArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		long[] array = { 111L, 222L };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/LongWrapperArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/LongWrapperArrayParameterMapperTest.java
@@ -8,17 +8,25 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Array;
 import java.sql.Connection;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class LongWrapperArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(clock);
 		Array jdbcArray = newProxy(Array.class);
 		Long[] array = { Long.valueOf(111L), Long.valueOf(222L) };
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/OptionalParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/OptionalParameterMapperTest.java
@@ -3,15 +3,23 @@ package jp.co.future.uroborosql.parameter.mapper;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.time.Clock;
 import java.util.Optional;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class OptionalParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		String value = "ABC";
 
 		OptionalParameterMapper mapper = new OptionalParameterMapper();
@@ -24,7 +32,7 @@ public class OptionalParameterMapperTest {
 
 	@Test
 	public void testEmpty() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		OptionalParameterMapper mapper = new OptionalParameterMapper();
 		Optional<String> optional = Optional.empty();
 		assertThat(mapper.toJdbc(optional, null, parameterMapperManager), is(nullValue()));

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/StringArrayParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/StringArrayParameterMapperTest.java
@@ -11,14 +11,22 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.time.Clock;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class StringArrayParameterMapperTest {
+	private Clock clock = null;
+
+	@Before
+	public void setUp() {
+		this.clock = Clock.systemDefaultZone();
+	}
 
 	@Test
 	public void test() {
-		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager();
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 		Array jdbcArray = newProxy(Array.class);
 		String[] array = { "A" };
 

--- a/src/test/java/jp/co/future/uroborosql/parser/SqlParserTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parser/SqlParserTest.java
@@ -47,7 +47,7 @@ public class SqlParserTest {
 	private void sqlAssertion(final String original, final String expected) {
 		SqlParser parser = new SqlParserImpl(original, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -299,7 +299,7 @@ public class SqlParserTest {
 		String sql = "SELECT * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		assertEquals("1", sql, ctx.getExecutableSql());
@@ -310,7 +310,7 @@ public class SqlParserTest {
 		String sql = "SELECT /* empの全件検索 */ * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		assertEquals("1", sql, ctx.getExecutableSql());
@@ -322,7 +322,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT -- empの全件検索  * FROM emp WHERE job = ?/*job*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("job", "CLERK");
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -334,7 +334,7 @@ public class SqlParserTest {
 		String sql = "SELECT /*+ FIRST_ROWS */ * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		assertEquals("1", sql, ctx.getExecutableSql());
@@ -351,7 +351,7 @@ public class SqlParserTest {
 		String sql = "SELECT * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql + endChar, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		assertEquals("1", sql, ctx.getExecutableSql());
@@ -378,7 +378,7 @@ public class SqlParserTest {
 		String sql4 = " AND deptno = ";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		String job = "CLERK";
 		Integer deptno = new Integer(20);
 		ctx.param("job", job);
@@ -413,7 +413,7 @@ public class SqlParserTest {
 		String sql5 = "'CLERK'";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		Node root = transformer.getRoot();
@@ -435,7 +435,7 @@ public class SqlParserTest {
 		String sql3 = " AND 1 = 1";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		Integer empno = new Integer(7788);
 		ctx.param("empno", empno);
 		ContextTransformer transformer = parser.parse();
@@ -454,7 +454,7 @@ public class SqlParserTest {
 		String sql3 = "SELECT * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		String job = "CLERK";
 		ctx.param("job", job);
 		ContextTransformer transformer = parser.parse();
@@ -475,7 +475,7 @@ public class SqlParserTest {
 		assertEquals("8", " WHERE job = ", sqlNode2.getSql());
 		BindVariableNode varNode = (BindVariableNode) ifNode.getChild(1);
 		assertEquals("9", "job", varNode.getExpression());
-		SqlContext ctx2 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx2 = sqlConfig.context();
 		root.accept(ctx2);
 		System.out.println(ctx2.getExecutableSql());
 		assertEquals("10", sql3, ctx2.getExecutableSql());
@@ -486,7 +486,7 @@ public class SqlParserTest {
 		String sql = "/*IF aaa != null*/aaa/*IF bbb != null*/bbb/*END*//*END*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		Node root = transformer.getRoot();
@@ -501,7 +501,7 @@ public class SqlParserTest {
 		root.accept(ctx);
 		System.out.println("[" + ctx.getExecutableSql() + "]");
 		assertEquals("3", "aaabbb", ctx.getExecutableSql());
-		SqlContext ctx2 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx2 = sqlConfig.context();
 		ctx2.param("aaa", "hoge");
 		ctx2.param("bbb", null);
 		root.accept(ctx2);
@@ -516,7 +516,7 @@ public class SqlParserTest {
 		String sql3 = "SELECT * FROM emp";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		Emp emp = new Emp();
 		emp.setJob("CLERK");
 		ctx.param("emp", emp);
@@ -538,7 +538,7 @@ public class SqlParserTest {
 		assertEquals("8", " WHERE job = ", sqlNode2.getSql());
 		BindVariableNode varNode = (BindVariableNode) ifNode.getChild(1);
 		assertEquals("9", "emp.job", varNode.getExpression());
-		SqlContext ctx2 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx2 = sqlConfig.context();
 		root.accept(ctx2);
 		System.out.println(ctx2.getExecutableSql());
 		assertEquals("10", sql3, ctx2.getExecutableSql());
@@ -551,7 +551,7 @@ public class SqlParserTest {
 		String sql3 = "SELECT * FROM emp WHERE job is null";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		String job = "CLERK";
 		ctx.param("job", job);
 		ContextTransformer transformer = parser.parse();
@@ -563,7 +563,7 @@ public class SqlParserTest {
 		Object[] vars = ctx.getBindVariables();
 		assertEquals("2", 1, vars.length);
 		assertEquals("3", job, vars[0]);
-		SqlContext ctx2 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx2 = sqlConfig.context();
 		root.accept(ctx2);
 		System.out.println("[" + ctx2.getExecutableSql() + "]");
 		assertEquals("4", sql3, ctx2.getExecutableSql());
@@ -574,7 +574,7 @@ public class SqlParserTest {
 		String sql = "/*IF false*/aaa--ELSE bbb = /*bbb*/123/*END*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		Integer bbb = new Integer(123);
 		ctx.param("bbb", bbb);
 		ContextTransformer transformer = parser.parse();
@@ -591,7 +591,7 @@ public class SqlParserTest {
 		String sql = "/*IF false*/aaa--ELSE bbb/*IF false*/ccc--ELSE ddd/*END*//*END*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		System.out.println("[" + ctx.getExecutableSql() + "]");
@@ -604,7 +604,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT * FROM emp WHERE deptno = 10";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		System.out.println(ctx.getExecutableSql());
@@ -621,7 +621,7 @@ public class SqlParserTest {
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
 
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
 		Node root = transformer.getRoot();
@@ -630,7 +630,7 @@ public class SqlParserTest {
 		List<String> bNames = ctx.getBindNames();
 		assertEquals(0, bNames.size());
 
-		SqlContext ctx2 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx2 = sqlConfig.context();
 		ctx2.param("job", "CLERK");
 		ctx2.param("deptno", null);
 		root.accept(ctx2);
@@ -639,7 +639,7 @@ public class SqlParserTest {
 		List<String> bNames2 = ctx2.getBindNames();
 		assertEquals(1, bNames2.size());
 
-		SqlContext ctx3 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx3 = sqlConfig.context();
 		ctx3.param("job", "CLERK");
 		ctx3.param("deptno", new Integer(20));
 		root.accept(ctx3);
@@ -648,7 +648,7 @@ public class SqlParserTest {
 		List<String> bNames3 = ctx3.getBindNames();
 		assertEquals(2, bNames3.size());
 
-		SqlContext ctx4 = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx4 = sqlConfig.context();
 		ctx4.param("deptno", new Integer(20));
 		ctx4.param("job", null);
 		root.accept(ctx4);
@@ -664,7 +664,7 @@ public class SqlParserTest {
 		String sql2 = "WHERE aaa BETWEEN ?/*bbb*/ AND ?/*ccc*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("bbb", "111");
 		ctx.param("ccc", "222");
 		ContextTransformer transformer = parser.parse();
@@ -683,7 +683,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT * FROM emp WHERE deptno IN (?, ?)/*deptnoList*/ ORDER BY ename";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		List<Integer> deptnoList = new ArrayList<>();
 		deptnoList.add(new Integer(10));
 		deptnoList.add(new Integer(20));
@@ -704,7 +704,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT * FROM emp WHERE deptno IN (?, ?)/*deptnoList*/ ORDER BY ename";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		int[] deptnoArray = { 10, 20 };
 		ctx.param("deptnoList", deptnoArray);
 		ContextTransformer transformer = parser.parse();
@@ -723,7 +723,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT * FROM emp WHERE ename IN (?, ?)/*enames*/ AND job IN (?, ?)/*jobs*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		String[] enames = { "SCOTT", "MARY" };
 		String[] jobs = { "ANALYST", "FREE" };
 		ctx.param("enames", enames);
@@ -746,7 +746,7 @@ public class SqlParserTest {
 		String sql2 = "BETWEEN sal ?/*$1*/ AND ?/*$2*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("$1", new Integer(0));
 		ctx.param("$2", new Integer(1000));
 		ContextTransformer transformer = parser.parse();
@@ -767,7 +767,7 @@ public class SqlParserTest {
 		String sql4 = " AND deptno = ";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		Emp emp = new Emp();
 		emp.setJob("CLERK");
 		emp.setDeptno(new Integer(20));
@@ -799,7 +799,7 @@ public class SqlParserTest {
 		String sql2 = "?/*(count + 1)*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("count", 3);
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -816,7 +816,7 @@ public class SqlParserTest {
 		String sql2 = "SELECT * FROM EMP WHERE ENAME IN (?, ?)/*SF.split(enames, ',')*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param(StringFunction.SHORT_NAME, new StringFunction(new DefaultDialect()));
 		ctx.param("enames", "SCOTT,MARY");
 		ContextTransformer transformer = parser.parse();
@@ -847,7 +847,7 @@ public class SqlParserTest {
 		String sql = "INSERT INTO ITEM (ID, NUM) VALUES (/*id*/1, /*num*/20)";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("id", new Integer(0));
 		ctx.param("num", new Integer(1));
 		ContextTransformer transformer = parser.parse();
@@ -861,7 +861,7 @@ public class SqlParserTest {
 		String sql = "xx /*#aaa*/ xx";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("aaa", new Integer(0));
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -874,7 +874,7 @@ public class SqlParserTest {
 		String sql = "/*$emp.deptno*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		Emp emp = new Emp();
 		emp.setDeptno(new Integer(0));
 		ctx.param("emp", emp);
@@ -894,7 +894,7 @@ public class SqlParserTest {
 		String sql = "xx /*#aaa*/ xx";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("aaa", "bb'bb");
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -907,7 +907,7 @@ public class SqlParserTest {
 		String sql = "/*IF SF.isEmpty(val1)*/1=1 /*ELIF SF.containsAny(val2, val3)*/2=2 --ELSE 3=3/*END*/";
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("val1", null);
 		ctx.param("val2", "aaabbbccc");
 		ctx.param("val3", "ab");
@@ -959,7 +959,7 @@ public class SqlParserTest {
 			String sql = "select * from test where id = /*val1*/1 and name = /*val2*/'' and age = /*val3*/1";
 			SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 					sqlConfig.getDialect().isRemoveTerminator(), true);
-			SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+			SqlContext ctx = sqlConfig.context();
 			ctx.param("val1", "1");
 			ctx.param("val3", "20");
 
@@ -987,7 +987,7 @@ public class SqlParserTest {
 			String sql = "select * from test where id = /*val1*/1 and name = /*val2*/'' and age = /*val3*/1";
 			SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 					sqlConfig.getDialect().isRemoveTerminator(), true);
-			SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+			SqlContext ctx = sqlConfig.context();
 			ctx.param("val1", "1");
 
 			ContextTransformer transformer = parser.parse();
@@ -1014,7 +1014,7 @@ public class SqlParserTest {
 			String sql = "select * from test where id = /*val1*/1 and name = /*val2*/'' and age = /*val3*/1";
 			SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 					sqlConfig.getDialect().isRemoveTerminator(), true);
-			SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+			SqlContext ctx = sqlConfig.context();
 			ctx.param("val1", "1");
 			ctx.param("val2", "aa");
 			ctx.param("val3", "20");
@@ -1035,7 +1035,7 @@ public class SqlParserTest {
 				StandardCharsets.UTF_8);
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("param1", "1");
 
 		ContextTransformer transformer = parser.parse();
@@ -1054,7 +1054,7 @@ public class SqlParserTest {
 				StandardCharsets.UTF_8);
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("param1", "2");
 
 		ContextTransformer transformer = parser.parse();
@@ -1073,7 +1073,7 @@ public class SqlParserTest {
 
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("projectStage", "ci");
 
 		ContextTransformer transformer = parser.parse();
@@ -1088,7 +1088,7 @@ public class SqlParserTest {
 
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -1102,7 +1102,7 @@ public class SqlParserTest {
 
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("bindEnum", TestEnum1.A);
 
 		ContextTransformer transformer = parser.parse();
@@ -1117,7 +1117,7 @@ public class SqlParserTest {
 
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 		ctx.param("bindEnum", TestEnum1.A);
 
 		ContextTransformer transformer = parser.parse();
@@ -1133,7 +1133,7 @@ public class SqlParserTest {
 
 		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
 				sqlConfig.getDialect().isRemoveTerminator(), true);
-		SqlContext ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		SqlContext ctx = sqlConfig.context();
 
 		ContextTransformer transformer = parser.parse();
 		transformer.transform(ctx);
@@ -1144,7 +1144,7 @@ public class SqlParserTest {
 
 		parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(), sqlConfig.getDialect().isRemoveTerminator(),
 				true);
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 
 		transformer = parser.parse();
 		transformer.transform(ctx);
@@ -1155,7 +1155,7 @@ public class SqlParserTest {
 
 		parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(), sqlConfig.getDialect().isRemoveTerminator(),
 				true);
-		ctx = sqlConfig.getSqlContextFactory().createSqlContext();
+		ctx = sqlConfig.context();
 
 		transformer = parser.parse();
 		transformer.transform(ctx);


### PR DESCRIPTION
fixed #189 
- SqlConfig#getClock()
- BindParameterMapperManager and PropertyMapperManager accept Clock object.
- DateTimeApiPropertyMapper and DateTimeApiParameterMapper use the passed Clock object.
