### PR TITLE
fix SqlContextFactory initialize bug.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
@@ -149,12 +149,12 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	 */
 	@Override
 	public void initialize() {
+		parameterMapperManager = new BindParameterMapperManager(getSqlConfig().getClock());
+
 		Map<String, Parameter> paramMap = new HashMap<>();
 		paramMap.putAll(buildConstParamMap());
 		paramMap.putAll(buildEnumConstParamMap());
-
 		constParameterMap = Collections.unmodifiableMap(paramMap);
-		parameterMapperManager = new BindParameterMapperManager(getSqlConfig().getClock());
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextFactoryImpl.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.ResultSet;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -88,7 +89,8 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	private int defaultResultSetConcurrency = ResultSet.CONCUR_READ_ONLY;
 
 	/** パラメータ変換マネージャ */
-	private BindParameterMapperManager parameterMapperManager;
+	private BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(
+			Clock.systemDefaultZone());
 
 	/**
 	 * {@inheritDoc}
@@ -149,7 +151,7 @@ public class SqlContextFactoryImpl implements SqlContextFactory {
 	 */
 	@Override
 	public void initialize() {
-		parameterMapperManager = new BindParameterMapperManager(getSqlConfig().getClock());
+		parameterMapperManager = new BindParameterMapperManager(parameterMapperManager, getSqlConfig().getClock());
 
 		Map<String, Parameter> paramMap = new HashMap<>();
 		paramMap.putAll(buildConstParamMap());


### PR DESCRIPTION
Fixed a bug that NPE occurs when setting constants with  
SqlContextFactory#setConstantClassNames()  
or  
SqlContextFactory#setEnumConstantPackageNames()  
and calling UroboroSQLBuilder#build().