### PR TITLE
Add savepointScope method to SqlAgent

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -445,6 +445,26 @@ public abstract class AbstractAgent implements SqlAgent {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.tx.TransactionManager#savepointScope(jp.co.future.uroborosql.tx.SQLSupplier)
+	 */
+	@Override
+	public <R> R savepointScope(final SQLSupplier<R> supplier) {
+		return transactionManager.savepointScope(supplier);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.tx.TransactionManager#savepointScope(jp.co.future.uroborosql.tx.SQLRunnable)
+	 */
+	@Override
+	public void savepointScope(final SQLRunnable runnable) {
+		transactionManager.savepointScope(runnable);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.SqlAgent#rollback()
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 
 /**
  * ローカルトランザクションマネージャ
@@ -334,9 +333,9 @@ public class LocalTransactionManager implements TransactionManager {
 			this.txCtxStack.push(txContext);
 			try {
 				return supplier.get();
-			} catch (Exception ex) {
+			} catch (Throwable th) {
 				txContext.setRollbackOnly();
-				throw ex;
+				throw th;
 			} finally {
 				try {
 					txContext.close();
@@ -404,9 +403,9 @@ public class LocalTransactionManager implements TransactionManager {
 		setSavepoint(savepointName);
 		try {
 			return supplier.get();
-		} catch (UroborosqlRuntimeException ex) {
+		} catch (Throwable th) {
 			rollback(savepointName);
-			throw ex;
+			throw th;
 		} finally {
 			releaseSavepoint(savepointName);
 		}

--- a/src/main/java/jp/co/future/uroborosql/tx/TransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/TransactionManager.java
@@ -103,4 +103,21 @@ public interface TransactionManager extends ConnectionManager {
 	 */
 	void rollback(String savepointName);
 
+	/**
+	 * セーブポイントを設定した上でsupplierの内容を実行する.<br>
+	 * 処理が成功した場合はセーブポイントを開放し、失敗した場合は設定したセーブポイントまでロールバックする.
+	 *
+	 * @param supplier 実行する処理
+	 * @param <R> 結果の型
+	 * @return supplierの処理結果
+	 */
+	<R> R savepointScope(SQLSupplier<R> supplier);
+
+	/**
+	 * セーブポイントを設定した上でrunnableの内容を実行する.<br>
+	 * 処理が成功した場合はセーブポイントを開放し、失敗した場合は設定したセーブポイントまでロールバックする.
+	 *
+	 * @param runnable 実行する処理
+	 */
+	void savepointScope(SQLRunnable runnable);
 }

--- a/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
@@ -342,16 +342,18 @@ public class LocalTxManagerTest {
 								agent.savepointScope(() -> {
 									ins(agent, 3, "C");
 									assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
-									throw new UroborosqlRuntimeException();
+									throw new IllegalStateException();
 								});
-							} catch (UroborosqlRuntimeException ex) {
+							} catch (Exception ex) {
 								assertThat(select(agent), is(Arrays.asList("A", "B")));
-								throw new UroborosqlRuntimeException();
+								assertThat(ex, is(instanceOf(IllegalStateException.class)));
+								throw ex;
 							}
 							fail();
 						});
-					} catch (UroborosqlRuntimeException ex) {
+					} catch (Exception ex) {
 						assertThat(select(agent), is(Arrays.asList("A")));
+						assertThat(ex, is(instanceOf(IllegalStateException.class)));
 					}
 				});
 				assertThat(select(agent), is(Arrays.asList("A")));
@@ -370,10 +372,11 @@ public class LocalTxManagerTest {
 							ins(agent, 2, "B");
 							return select(agent);
 						}), is(Arrays.asList("A", "B")));
-						throw new UroborosqlRuntimeException();
+						throw new IllegalAccessError();
 					});
-				} catch (UroborosqlRuntimeException ex) {
+				} catch (Throwable th) {
 					assertThat(select(agent), is(Matchers.emptyCollectionOf(String.class)));
+					assertThat(th, is(instanceOf(IllegalAccessError.class)));
 				}
 			});
 		}

--- a/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
@@ -333,33 +333,28 @@ public class LocalTxManagerTest {
 	public void testSavepointScopeRunnable() {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				try {
-					agent.savepointScope(() -> {
-						ins(agent, 1, "A");
-						try {
-							agent.savepointScope(() -> {
-								ins(agent, 2, "B");
-								try {
-									agent.savepointScope(() -> {
-										ins(agent, 3, "C");
-										assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
-										throw new UroborosqlRuntimeException();
-									});
-								} catch (UroborosqlRuntimeException ex) {
-									assertThat(select(agent), is(Arrays.asList("A", "B")));
+				agent.savepointScope(() -> {
+					ins(agent, 1, "A");
+					try {
+						agent.savepointScope(() -> {
+							ins(agent, 2, "B");
+							try {
+								agent.savepointScope(() -> {
+									ins(agent, 3, "C");
+									assertThat(select(agent), is(Arrays.asList("A", "B", "C")));
 									throw new UroborosqlRuntimeException();
-								}
-								fail();
-							});
-						} catch (UroborosqlRuntimeException ex) {
-							assertThat(select(agent), is(Arrays.asList("A")));
-							throw new UroborosqlRuntimeException();
-						}
-						fail();
-					});
-				} catch (UroborosqlRuntimeException ex) {
-					assertThat(select(agent), is(Matchers.emptyCollectionOf(String.class)));
-				}
+								});
+							} catch (UroborosqlRuntimeException ex) {
+								assertThat(select(agent), is(Arrays.asList("A", "B")));
+								throw new UroborosqlRuntimeException();
+							}
+							fail();
+						});
+					} catch (UroborosqlRuntimeException ex) {
+						assertThat(select(agent), is(Arrays.asList("A")));
+					}
+				});
+				assertThat(select(agent), is(Arrays.asList("A")));
 			});
 		}
 	}


### PR DESCRIPTION
Added savepointScope method to make transaction control using savepoint easier to use.

Until now

```java
agent().setSavepoint("xxx");
try {
    // do something
} catch (UroborosqlRuntimeException ex) {
    agent().rollback("xxx");
    throw ex;
} finally {
    agent().releaseSavepoint("xxx");
}
```

Was required, but by using savepointScope(), it can be implemented as follows.

```java
agent().savepointScope(() -> {
    // do something
});
```