### PR TITLE
Fixed a bug that bind parameter candidate is invalid in SQL-REPL

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlParamUtils.java
@@ -312,10 +312,10 @@ public final class SqlParamUtils {
 			params.add(((EmbeddedValueNode) node).getExpression());
 		} else if (node instanceof IfNode) {
 			traverseIfNode(parser, (IfNode) node, params);
-		}
-
-		for (int i = 0; i < node.getChildSize(); i++) {
-			traverseNode(parser, node.getChild(i), params);
+		} else {
+			for (int i = 0; i < node.getChildSize(); i++) {
+				traverseNode(parser, node.getChild(i), params);
+			}
 		}
 	}
 
@@ -328,6 +328,10 @@ public final class SqlParamUtils {
 	 */
 	private static void traverseIfNode(final ExpressionParser parser, final IfNode ifNode, final Set<String> params) {
 		parser.parse(ifNode.getExpression()).collectParams(params);
+
+		for (int i = 0; i < ifNode.getChildSize(); i++) {
+			traverseNode(parser, ifNode.getChild(i), params);
+		}
 		if (ifNode.getElseIfNode() != null) {
 			traverseIfNode(parser, ifNode.getElseIfNode(), params);
 		}

--- a/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
@@ -225,9 +225,9 @@ public class SqlParamUtilsTest {
 	public void testGetSqlParamsIfNode() {
 		Set<String> params = SqlParamUtils
 				.getSqlParams(
-						"select * from test where /*IF id != null*/id = /*id*/1 /*ELIF name != null*/and name = /*name*/'name1' /*ELIF age != null*/and age = /*age*/0*/ /*ELSE*/and height = /*height*/0 /*END*/",
+						"select * from test where /*IF id != null*/id = /*id*/1 and id2 = /*id2*/'' /*ELIF name != null*/and name = /*name*/'name1' and name2 = /*name2*/'name2' /*ELIF age != null*/and age = /*age*/0 and age2 = /*age2*/1 */ /*ELSE*/and height = /*height*/0 and height2 = /*height2*/1 /*END*/",
 						sqlConfig);
-		assertThat(params, contains("id", "name", "age", "height"));
+		assertThat(params, contains("id", "id2", "name", "name2", "age", "age2", "height", "height2"));
 		assertThat(params, not(contains("CLS_AGE_DEFAULT")));
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
@@ -222,6 +222,40 @@ public class SqlParamUtilsTest {
 	}
 
 	@Test
+	public void testGetSqlParamsIfNode() {
+		Set<String> params = SqlParamUtils
+				.getSqlParams(
+						"select * from test where /*IF id != null*/id = /*id*/1 /*ELIF name != null*/and name = /*name*/'name1' /*ELIF age != null*/and age = /*age*/0*/ /*ELSE*/and height = /*height*/0 /*END*/",
+						sqlConfig);
+		assertThat(params, contains("id", "name", "age", "height"));
+		assertThat(params, not(contains("CLS_AGE_DEFAULT")));
+	}
+
+	@Test
+	public void testGetSqlParamsParenExpression() {
+		Set<String> params = SqlParamUtils
+				.getSqlParams(
+						"select * from test /*BEGIN*/ where /*IF ids != null*/ id in /*ids*/() /*END*/ /*END*/",
+						sqlConfig);
+		assertThat(params, contains("ids"));
+	}
+
+	@Test
+	public void testGetSqlParamsEmbeddedExpression() {
+		Set<String> params = SqlParamUtils
+				.getSqlParams(
+						"select * from /*$tableName*/ /*BEGIN*/ where /*IF ids != null*/ id in /*ids*/() /*END*/ /*END*/",
+						sqlConfig);
+		assertThat(params, contains("tableName", "ids"));
+
+		params = SqlParamUtils
+				.getSqlParams(
+						"select * from /*$TABLE_NAME*/ /*BEGIN*/ where /*IF ids != null*/ id in /*ids*/() /*END*/ /*END*/",
+						sqlConfig);
+		assertThat(params, contains("TABLE_NAME", "ids"));
+	}
+
+	@Test
 	public void testParseLine() {
 		String[] parts = SqlParamUtils.parseLine("update /sss/bbb param1=[1, 2, 3] param2=3 param3=[1, 2]");
 		assertThat(parts, arrayContaining("update", "/sss/bbb", "param1=[1,2,3]", "param2=3", "param3=[1,2]"));


### PR DESCRIPTION
Fixed a bug that bind parameters in elif and else branches are not displayed as candidates in SQL-REPL.