### PR TITLE
add PessimisticLockException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.co.future</groupId>
 	<artifactId>uroborosql</artifactId>
-	<version>0.19.0-SNAPSHOT</version>
+	<version>0.18.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>uroboroSQL</name>
 	<description>Developer-oriented and SQL centric database access library</description>

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -157,9 +157,7 @@ public class SqlAgentImpl extends AbstractAgent {
 						String sqlState = ex.getSQLState();
 						Set<String> pessimisticLockingErrorCodes = dialect.getPessimisticLockingErrorCodes();
 						if (maxRetryCount > loopCount) {
-							if (getSqlRetryCodes().contains(errorCode) || getSqlRetryCodes().contains(sqlState)
-									|| pessimisticLockingErrorCodes.contains(errorCode)
-									|| pessimisticLockingErrorCodes.contains(sqlState)) {
+							if (getSqlRetryCodes().contains(errorCode) || getSqlRetryCodes().contains(sqlState)) {
 								if (LOG.isDebugEnabled()) {
 									LOG.debug(String.format(
 											"Caught the error code to be retried.(%d times). Retry after %,3d ms.",
@@ -173,7 +171,12 @@ public class SqlAgentImpl extends AbstractAgent {
 									}
 								}
 							} else {
-								throw ex;
+								if (pessimisticLockingErrorCodes.contains(errorCode)
+										|| pessimisticLockingErrorCodes.contains(sqlState)) {
+									throw new PessimisticLockException(sqlContext, ex);
+								} else {
+									throw ex;
+								}
 							}
 						} else {
 							if (pessimisticLockingErrorCodes.contains(errorCode)

--- a/src/main/java/jp/co/future/uroborosql/dialect/DefaultDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/DefaultDialect.java
@@ -6,6 +6,9 @@
  */
 package jp.co.future.uroborosql.dialect;
 
+import java.util.Collections;
+import java.util.Set;
+
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 
@@ -70,5 +73,15 @@ public class DefaultDialect extends AbstractDialect {
 	@Override
 	public String getSequenceNextValSql(final String sequenceName) {
 		throw new UroborosqlRuntimeException("Sequence is not supported.");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return Collections.emptySet();
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -8,6 +8,7 @@ package jp.co.future.uroborosql.dialect;
 
 import java.sql.SQLType;
 import java.util.List;
+import java.util.Set;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
 import jp.co.future.uroborosql.enums.ForUpdateType;
@@ -220,4 +221,6 @@ public interface Dialect {
 	default String getModLiteral(final String dividend, final String divisor) {
 		return dividend + " % " + divisor;
 	}
+
+	Set<String> getPessimisticLockingErrorCodes();
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/H2Dialect.java
@@ -6,7 +6,9 @@
  */
 package jp.co.future.uroborosql.dialect;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -15,6 +17,15 @@ import java.util.stream.Collectors;
  * @author H.Sugimoto
  */
 public class H2Dialect extends AbstractDialect {
+	/**
+	 * 悲観ロックのErrorCode もしくは SqlState. H2DBの場合はSqlStateで判定する.
+	 * <pre>
+	 * テーブル {0} のロック試行がタイムアウトしました
+	 * Timeout trying to lock table {0}; SQL statement: [50200-199]
+	 * </pre>
+	 */
+	private static final Set<String> pessimisticLockingErrorCodes = Collections.singleton("50200");
+
 	/**
 	 * コンストラクタ
 	 */
@@ -107,5 +118,15 @@ public class H2Dialect extends AbstractDialect {
 		String hintStr = "$1 USE INDEX " + hints.stream().collect(Collectors.joining(", ", "(", ")"))
 				+ System.lineSeparator();
 		return new StringBuilder(sql.toString().replaceFirst("((FROM|from)\\s+[^\\s]+)\\s*", hintStr));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return pessimisticLockingErrorCodes;
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
@@ -7,7 +7,9 @@
 package jp.co.future.uroborosql.dialect;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jp.co.future.uroborosql.enums.ForUpdateType;
@@ -18,6 +20,12 @@ import jp.co.future.uroborosql.enums.ForUpdateType;
  * @author H.Sugimoto
  */
 public class MsSqlDialect extends AbstractDialect {
+	/**
+	 * 悲観ロックのErrorCode もしくは SqlState. MSSQLの場合はErrorCodeで判定する.
+	 * <pre>SQL Error [1222] [S00045]: ロック要求がタイムアウトしました。 </pre>
+	 */
+	private static final Set<String> pessimisticLockingErrorCodes = Collections.singleton("1222");
+
 	/**
 	 * コンストラクタ
 	 */
@@ -126,4 +134,13 @@ public class MsSqlDialect extends AbstractDialect {
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return pessimisticLockingErrorCodes;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MySqlDialect.java
@@ -6,7 +6,9 @@
  */
 package jp.co.future.uroborosql.dialect;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
@@ -17,6 +19,12 @@ import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
  * @author H.Sugimoto
  */
 public class MySqlDialect extends AbstractDialect {
+	/**
+	 * 悲観ロックのErrorCode もしくは SqlState. MySQLの場合はErrorCodeで判定する.
+	 * <pre>ERROR 3572 (HY000): Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.</pre>
+	 */
+	private static final Set<String> pessimisticLockingErrorCodes = Collections.singleton("3572");
+
 	/**
 	 * コンストラクタ
 	 */
@@ -103,6 +111,16 @@ public class MySqlDialect extends AbstractDialect {
 	public StringBuilder addOptimizerHints(final StringBuilder sql, final List<String> hints) {
 		String hintStr = "$1 " + hints.stream().collect(Collectors.joining(" ")) + System.lineSeparator();
 		return new StringBuilder(sql.toString().replaceFirst("((FROM|from)\\s+[^\\s]+)\\s*", hintStr));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return pessimisticLockingErrorCodes;
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
@@ -6,7 +6,11 @@
  */
 package jp.co.future.uroborosql.dialect;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jp.co.future.uroborosql.connection.ConnectionSupplier;
@@ -17,6 +21,14 @@ import jp.co.future.uroborosql.connection.ConnectionSupplier;
  * @author H.Sugimoto
  */
 public abstract class OracleDialect extends AbstractDialect {
+	/**
+	 * 悲観ロックのErrorCode もしくは SqlState. Oracleの場合errorCodeで判定する.
+	 * <pre>ORA-00054: リソース・ビジー。NOWAITが指定されているか、タイムアウトしました</pre>
+	 * <pre>ORA-30006: リソース・ビジー; WAITタイムアウトの期限に達しました。</pre>
+	 */
+	private static final Set<String> pessimisticLockingErrorCodes = Collections
+			.unmodifiableSet(new HashSet<>(Arrays.asList("54", "30006")));
+
 	/**
 	 * コンストラクタ
 	 * @param escapeChar like検索時のエスケープ文字
@@ -131,5 +143,15 @@ public abstract class OracleDialect extends AbstractDialect {
 	public StringBuilder addOptimizerHints(final StringBuilder sql, final List<String> hints) {
 		String hintStr = "$1 /*+ " + hints.stream().collect(Collectors.joining(" ")) + " */";
 		return new StringBuilder(sql.toString().replaceFirst("(SELECT( /\\*.+\\*/)*)", hintStr));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return pessimisticLockingErrorCodes;
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/PostgresqlDialect.java
@@ -8,7 +8,9 @@ package jp.co.future.uroborosql.dialect;
 
 import java.sql.JDBCType;
 import java.sql.SQLType;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jp.co.future.uroborosql.mapping.JavaType;
@@ -19,6 +21,12 @@ import jp.co.future.uroborosql.mapping.JavaType;
  * @author H.Sugimoto
  */
 public class PostgresqlDialect extends AbstractDialect {
+	/**
+	 * 悲観ロックのErrorCode もしくは SqlState. Postgresqlの場合はSqlStateで判定する.
+	 * <pre>Error [55P03]: ERROR: リレーション"XXX"の行ロックを取得できませんでした</pre>
+	 */
+	private static final Set<String> pessimisticLockingErrorCodes = Collections.singleton("55P03");
+
 	/**
 	 * コンストラクタ
 	 */
@@ -150,4 +158,13 @@ public class PostgresqlDialect extends AbstractDialect {
 		return sql.insert(0, hintStr);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#getPessimisticLockingErrorCodes()
+	 */
+	@Override
+	public Set<String> getPessimisticLockingErrorCodes() {
+		return pessimisticLockingErrorCodes;
+	}
 }

--- a/src/main/java/jp/co/future/uroborosql/exception/PessimisticLockException.java
+++ b/src/main/java/jp/co/future/uroborosql/exception/PessimisticLockException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.exception;
+
+import jp.co.future.uroborosql.context.SqlContext;
+
+/**
+ * 悲観的排他制御の実行時例外
+ *
+ * @author H.Sugimoto
+ */
+public class PessimisticLockException extends UroborosqlRuntimeException {
+
+	public PessimisticLockException(final SqlContext context) {
+		super(createMessage(context));
+	}
+
+	public PessimisticLockException(final SqlContext context, final Throwable cause) {
+		super(createMessage(context), cause);
+	}
+
+	public PessimisticLockException(final String message) {
+		super(message);
+	}
+
+	public PessimisticLockException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public PessimisticLockException(final Throwable cause) {
+		super(cause);
+	}
+
+	private static String createMessage(final SqlContext context) {
+		return String.format("An error occurred due to pessimistic locking.\nExecuted SQL [\n%s]\nparams:%s",
+				context.getExecutableSql(), context.formatParams());
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentPessimisticLockTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentPessimisticLockTest.java
@@ -1,0 +1,75 @@
+package jp.co.future.uroborosql;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.exception.PessimisticLockException;
+import jp.co.future.uroborosql.utils.StringUtils;
+
+/**
+ * 悲観ロックのテスト
+ *
+ * @author H.Sugimoto
+ */
+public class SqlAgentPessimisticLockTest {
+	private static SqlConfig config;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		config = UroboroSQL.builder("jdbc:h2:mem:SqlAgentPessimisticLockTest;DB_CLOSE_DELAY=-1;MVCC=true;", "sa", "sa")
+				.setSqlAgentFactory(new SqlAgentFactoryImpl().setQueryTimeout(10))
+				.build();
+		try (SqlAgent agent = config.agent()) {
+			String[] ddls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/ddl/create_tables.sql")),
+					StandardCharsets.UTF_8).split(";");
+			for (String ddl : ddls) {
+				if (StringUtils.isNotBlank(ddl)) {
+					agent.updateWith(ddl.trim()).count();
+				}
+			}
+			String[] sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/setup/insert_product.sql")),
+					StandardCharsets.UTF_8).split(";");
+			for (String sql : sqls) {
+				if (StringUtils.isNotBlank(sql)) {
+					agent.updateWith(sql.trim()).count();
+				}
+			}
+		}
+	}
+
+	/**
+	 * クエリ実行のリトライ
+	 */
+	@Test
+	public void testQueryNoRetry() throws Exception {
+		String sql = "select * from product where product_id = 1 for update";
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				List<Map<String, Object>> products1 = agent.queryWith(sql).collect();
+				assertThat(products1.size(), is(1));
+
+				agent.requiresNew(() -> {
+					try {
+						agent.queryWith(sql).collect();
+						fail();
+					} catch (PessimisticLockException ex) {
+						// OK
+					} catch (Exception ex) {
+						fail();
+					}
+				});
+				agent.setRollbackOnly();
+			});
+		}
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
@@ -225,7 +225,7 @@ public class SqlAgentRetryTest {
 			query.collect();
 			fail();
 		} catch (PessimisticLockException ex) {
-			assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount - 1));
+			assertThat(query.context().contextAttrs().get("__retryCount"), is(0));
 		} catch (Exception ex) {
 			fail();
 		}

--- a/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlAgentRetryTest.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Before;
@@ -20,6 +21,7 @@ import org.junit.Test;
 
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.exception.PessimisticLockException;
 import jp.co.future.uroborosql.exception.UroborosqlSQLException;
 import jp.co.future.uroborosql.filter.AbstractSqlFilter;
 import jp.co.future.uroborosql.fluent.Procedure;
@@ -202,6 +204,30 @@ public class SqlAgentRetryTest {
 			assertThat(query.context().contextAttrs().get("__retryCount"), is(0));
 			assertThat(ex.getErrorCode(), is(errorCode));
 			assertThat(ex.getSQLState(), is(sqlState));
+		}
+	}
+
+	/**
+	 * クエリ実行のリトライ（リトライ対象外のエラー発生）
+	 */
+	@Test
+	public void testQueryRetryWithPessimisticLock() throws Exception {
+		int retryCount = 3;
+		int errorCode = 50200;
+		// SqlRetryCodeListを空にして、悲観ロック対象エラーコードで判定する
+		config.getSqlAgentFactory().setSqlRetryCodeList(Collections.emptyList());
+		config.getSqlFilterManager().addSqlFilter(new RetrySqlFilter(retryCount, errorCode));
+
+		SqlQuery query = null;
+		try {
+			query = agent.query("example/select_product").param("product_id", Arrays.asList(0, 1))
+					.retry(retryCount - 1);
+			query.collect();
+			fail();
+		} catch (PessimisticLockException ex) {
+			assertThat(query.context().contextAttrs().get("__retryCount"), is(retryCount - 1));
+		} catch (Exception ex) {
+			fail();
 		}
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -252,4 +252,9 @@ public class DefaultDialectTest {
 		hints.add("USE_NL");
 		dialect.addOptimizerHints(sql, hints);
 	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes().isEmpty(), is(true));
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -142,6 +143,11 @@ public class H2DialectTest {
 				is("SELECT /* SQL_ID */" + System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1 USE INDEX (test1_ix, test2_ix)"
 						+ System.lineSeparator()));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("50200")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -173,6 +174,11 @@ public class MsSqlDialectTest {
 						+ System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1 WITH (UPDLOCK, ROWLOCK, NOWAIT, INDEX (PUBLIC.TEST_1 test_ix), USE_NL)"
 						+ System.lineSeparator()));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("1222")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -146,6 +147,11 @@ public class MySqlDialectTest {
 						+ System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1 INDEX (PUBLIC.TEST_1 test_ix) USE_NL"
 						+ System.lineSeparator()));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("3572")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -183,6 +184,11 @@ public class Oracle10DialectTest {
 		assertThat(dialect.addOptimizerHints(sql, hints).toString(),
 				is("SELECT /* SQL_ID */ /*+ INDEX (PUBLIC.TEST_1 test_ix) USE_NL */" + System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1"));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("54", "30006")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -183,6 +184,11 @@ public class Oracle11DialectTest {
 		assertThat(dialect.addOptimizerHints(sql, hints).toString(),
 				is("SELECT /* SQL_ID */ /*+ INDEX (PUBLIC.TEST_1 test_ix) USE_NL */" + System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1"));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("54", "30006")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -191,6 +192,11 @@ public class Oracle12DialectTest {
 		assertThat(dialect.addOptimizerHints(sql, hints).toString(),
 				is("SELECT /* SQL_ID */ /*+ INDEX (PUBLIC.TEST_1 test_ix) USE_NL */" + System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1"));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("54", "30006")));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
@@ -2,6 +2,7 @@ package jp.co.future.uroborosql.dialect;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -166,6 +167,11 @@ public class PostgresqlDialectTest {
 						+ System.lineSeparator() + "SELECT"
 						+ System.lineSeparator()
 						+ " * FROM PUBLIC.TEST_1"));
+	}
+
+	@Test
+	public void testGetPessimisticLockingErrorCodes() {
+		assertThat(dialect.getPessimisticLockingErrorCodes(), is(containsInAnyOrder("55P03")));
 	}
 
 }


### PR DESCRIPTION
Modified to throw a dedicated PessimisticLockException instead of SQLException to make it easier for the caller to determine the pessimistic lock exception.
A method to fetch pessimistic lock error SQLErrorCode (or SQLState) is added to Dialect.

In addition, the following specification changes have been made.

- Until now
If the maximum retry count is 1 or more and the SQLErrorCode (or SQLState) of the thrown SQLException is included in SQLErrorCode (or SQLState) specified in `SqlAgentFactory#setSqlRetryCodeList(java.util.List)`, it is a target for retry.

- After change
The maximum retry count is 1 or more, and the SQLErrorCode (or SQLState) of the thrown SQLException is defined by SQLErrorCode (or SQLState) specified in `SqlAgentFactory#setSqlRetryCodeList(java.util.List)` or `Dialect#getPessimisticLockingErrorCodes()` If it is included in SQLErrorCode (or SQLState), it is a target for retry.