### PR TITLE
add DateTimeAPI to String ParameterMappers and testcases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.co.future</groupId>
 	<artifactId>uroborosql</artifactId>
-	<version>0.18.3-SNAPSHOT</version>
+	<version>0.19.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>uroboroSQL</name>
 	<description>Developer-oriented and SQL centric database access library</description>

--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -863,9 +863,9 @@ public abstract class AbstractAgent implements SqlAgent {
 	@Override
 	public <E> Stream<E> updatesAndReturn(final Class<E> entityType, final Stream<E> entities,
 			final UpdatesCondition<? super E> condition) {
-		List<E> updatedEntites = new ArrayList<>();
-		batchUpdate(entityType, entities, condition, updatedEntites);
-		return updatedEntites.stream();
+		List<E> updatedEntities = new ArrayList<>();
+		batchUpdate(entityType, entities, condition, updatedEntities);
+		return updatedEntities.stream();
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactory.java
@@ -24,7 +24,7 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  */
 public interface SqlAgentFactory extends SqlConfigAware {
 	/** ファクトリBean名 */
-	String FACTORY_BEAN_NAME = "sqlAagentFactory";
+	String FACTORY_BEAN_NAME = "sqlAgentFactory";
 
 	/**
 	 * プロパティ:SQL実行でエラーが発生した場合にリトライ対象とするSQLエラーコード<br>

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -1341,7 +1341,7 @@ public class SqlAgentImpl extends AbstractAgent {
 					Map<Object, List<E>> updatedEntityMap = updatedEntities.stream()
 							.collect(Collectors.groupingBy(e -> keyColumn.getValue(e)));
 
-					// updatedEntitesのサイズが大きいとin句の上限にあたるため、1000件ずつに分割して検索する
+					// updatedEntitiesのサイズが大きいとin句の上限にあたるため、1000件ずつに分割して検索する
 					List<Object> keyList = new ArrayList<>(updatedEntityMap.keySet());
 					int entitySize = updatedEntities.size();
 

--- a/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
@@ -593,7 +593,7 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 		 */
 		SortOrder(final String col, final Order order, final Nulls nulls) {
 			if (col == null) {
-				throw new UroborosqlRuntimeException("argment col is required.");
+				throw new UroborosqlRuntimeException("argument col is required.");
 			}
 			this.col = CaseFormat.CAMEL_CASE.convert(col);
 			this.order = order != null ? order : Order.ASCENDING;

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -124,7 +124,7 @@ public class SqlContextImpl implements SqlContext {
 	private final List<String> bindNames = new ArrayList<>();
 
 	/** バインド変数リスト */
-	private final List<Object> bindValiables = new ArrayList<>();
+	private final List<Object> bindVariables = new ArrayList<>();
 
 	/** 有効フラグ（BEGIN句で使用） */
 	private boolean enabled = true;
@@ -881,8 +881,8 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.parser.TransformContext#addBindVariable(java.lang.Object)
 	 */
 	@Override
-	public TransformContext addBindVariable(final Object bindValiable) {
-		bindValiables.add(bindValiable);
+	public TransformContext addBindVariable(final Object bindVariable) {
+		bindVariables.add(bindVariable);
 		return this;
 	}
 
@@ -892,9 +892,9 @@ public class SqlContextImpl implements SqlContext {
 	 * @see jp.co.future.uroborosql.parser.TransformContext#addBindVariables(java.lang.Object[])
 	 */
 	@Override
-	public TransformContext addBindVariables(final Object[] bindValiables) {
-		for (Object bindValiable : bindValiables) {
-			this.bindValiables.add(bindValiable);
+	public TransformContext addBindVariables(final Object[] bindVariables) {
+		for (Object bindVariable : bindVariables) {
+			this.bindVariables.add(bindVariable);
 		}
 		return this;
 	}
@@ -906,7 +906,7 @@ public class SqlContextImpl implements SqlContext {
 	 */
 	@Override
 	public Object[] getBindVariables() {
-		return bindValiables.toArray();
+		return bindVariables.toArray();
 	}
 
 	/**
@@ -1226,7 +1226,7 @@ public class SqlContextImpl implements SqlContext {
 	public String formatParams() {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < bindNames.size(); i++) {
-			sb.append(String.format("[%s=%s]", bindNames.get(i), bindValiables.get(i)));
+			sb.append(String.format("[%s=%s]", bindNames.get(i), bindVariables.get(i)));
 		}
 		return sb.toString();
 	}

--- a/src/main/java/jp/co/future/uroborosql/coverage/CoberturaCoverageHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/coverage/CoberturaCoverageHandler.java
@@ -48,7 +48,7 @@ import jp.co.future.uroborosql.utils.StringUtils;
  * <pre>
  * デフォルトコンストラクタで生成される場合、レポートファイルの出力先は以下のように決定されます。
  *
- * sysytem property "uroborosql.sql.coverage.file" が指定された場合、指定されたPATHに xmlレポートを出力します。
+ * system property "uroborosql.sql.coverage.file" が指定された場合、指定されたPATHに xmlレポートを出力します。
  * 指定の無い場合、デフォルトで "./target/coverage/sql-cover.xml" に xmlレポートを出力します。
  * </pre>
  *
@@ -116,11 +116,11 @@ public class CoberturaCoverageHandler implements CoverageHandler {
 	 */
 	private static class LineBranch {
 		@SuppressWarnings("unused")
-		private final int rowIndxx;
+		private final int rowIndex;
 		private final Map<Range, PointBranch> branches = new HashMap<>();
 
-		private LineBranch(final int rowIndxx) {
-			this.rowIndxx = rowIndxx;
+		private LineBranch(final int rowIndex) {
+			this.rowIndex = rowIndex;
 		}
 
 		private void add(final Range idx, final BranchCoverageState state) {
@@ -228,7 +228,7 @@ public class CoberturaCoverageHandler implements CoverageHandler {
 	 * コンストラクタ<br>
 	 *
 	 * <pre>
-	 * sysytem property "uroborosql.sql.coverage.file" が指定された場合、指定されたPATHに xmlレポートを出力します。
+	 * system property "uroborosql.sql.coverage.file" が指定された場合、指定されたPATHに xmlレポートを出力します。
 	 * 指定の無い場合、デフォルトで "./target/coverage/sql-cover.xml" に xmlレポートを出力します。
 	 * </pre>
 	 */

--- a/src/main/java/jp/co/future/uroborosql/coverage/reports/html/HtmlReportCoverageHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/coverage/reports/html/HtmlReportCoverageHandler.java
@@ -37,7 +37,7 @@ import jp.co.future.uroborosql.utils.StringUtils;
  * htmlのカバレッジレポートを出力する
  *
  * <pre>
- * sysytem property "uroborosql.sql.coverage" に "jp.co.future.uroborosql.coverage.reports.html.HtmlReportCoverageHandler" を指定することで
+ * system property "uroborosql.sql.coverage" に "jp.co.future.uroborosql.coverage.reports.html.HtmlReportCoverageHandler" を指定することで
  * 本機能を利用することができます。
  * </pre>
  *
@@ -53,7 +53,7 @@ public class HtmlReportCoverageHandler implements CoverageHandler {
 	 * コンストラクタ<br>
 	 *
 	 * <pre>
-	 * sysytem property "uroborosql.sql.coverage.dir" が指定された場合、指定されたPATHに レポートを出力します。
+	 * system property "uroborosql.sql.coverage.dir" が指定された場合、指定されたPATHに レポートを出力します。
 	 * 指定の無い場合、デフォルトで "./target/coverage/sql" に レポートを出力します。
 	 * </pre>
 	 */

--- a/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
@@ -11,8 +11,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.Clock;
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -25,6 +28,10 @@ import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoLocalDate;
 import java.time.chrono.Era;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Optional;
@@ -32,6 +39,7 @@ import java.util.TimeZone;
 
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.mapping.JavaType;
+import jp.co.future.uroborosql.utils.StringUtils;
 
 /**
  * Date and Time API用{@link PropertyMapper}
@@ -39,6 +47,33 @@ import jp.co.future.uroborosql.mapping.JavaType;
  * @author ota
  */
 public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccessor> {
+	/**
+	 * yyyyMMddHHmmss文字列からLocalDateTimeに変換するためのフォーマッター.
+	 */
+	private static final DateTimeFormatter FORMATTER_SHORT_DATE_TIME = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+	/**
+	 * yyyyMMddHHmmssSSS文字列からLocalDateTimeに変換するためのフォーマッター.<br>
+	 * Java8での不具合のため、DateTimeFormatterはBuilderを使用して生成する.
+	 */
+	private static final DateTimeFormatter FORMATTER_SHORT_DATE_TIME_WITH_MILLS = new DateTimeFormatterBuilder()
+			.appendPattern("yyyyMMddHHmmss").appendValue(ChronoField.MILLI_OF_SECOND, 3).toFormatter();
+
+	/**
+	 * HHmm文字列からLocalTimeに変換するためのフォーマッター.
+	 */
+	private static final DateTimeFormatter FORMATTER_SHORT_TIME_WITHOUT_SEC = DateTimeFormatter.ofPattern("HHmm");
+
+	/**
+	 * HHmmss文字列からLocalTimeに変換するためのフォーマッター.
+	 */
+	private static final DateTimeFormatter FORMATTER_SHORT_TIME = DateTimeFormatter.ofPattern("HHmmss");
+
+	/**
+	 * HHmmssSSS文字列からLocalTimeに変換するためのフォーマッター.
+	 */
+	private static final DateTimeFormatter FORMATTER_SHORT_TIME_WITH_MILLS = DateTimeFormatter.ofPattern("HHmmssSSS");
+
 	/**
 	 * 日時の変換に使用するClock
 	 */
@@ -114,66 +149,61 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 			final PropertyMapperManager mapperManager) throws SQLException {
 		Class<?> rawType = type.getRawType();
 		if (LocalDateTime.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getTimestamp(columnIndex))
-					.map(java.sql.Timestamp::toLocalDateTime)
+			return getLocalDateTime(rs, columnIndex)
 					.orElse(null);
 		}
 		if (OffsetDateTime.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getTimestamp(columnIndex))
-					.map(java.sql.Timestamp::toLocalDateTime)
+			return getLocalDateTime(rs, columnIndex)
 					.map(d -> OffsetDateTime.of(d, OffsetDateTime.now(clock).getOffset()))
 					.orElse(null);
 		}
 		if (ZonedDateTime.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getTimestamp(columnIndex))
-					.map(java.sql.Timestamp::toLocalDateTime)
+			return getLocalDateTime(rs, columnIndex)
 					.map(d -> ZonedDateTime.of(d, clock.getZone()))
 					.orElse(null);
 		}
 		if (LocalDate.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getDate(columnIndex))
-					.map(java.sql.Date::toLocalDate)
+			return getLocalDate(rs, columnIndex)
 					.orElse(null);
 		}
 		if (LocalTime.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getTime(columnIndex))
-					.map(this::sqlTimeToLocalTime)
+			return getLocalTime(rs, columnIndex)
 					.orElse(null);
 		}
 		if (OffsetTime.class.equals(rawType)) {
-			return Optional.ofNullable(rs.getTime(columnIndex))
-					.map(this::sqlTimeToOffsetTime)
+			return getLocalTime(rs, columnIndex)
+					.map(time -> OffsetTime.of(time, clock.getZone().getRules().getOffset(Instant.EPOCH)))
 					.orElse(null);
 		}
 
 		if (Year.class.equals(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			return rs.wasNull() ? null : Year.of(value);
 		}
 		if (YearMonth.class.equals(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			if (rs.wasNull()) {
 				return null;
 			}
 			return YearMonth.of(value / 100, value % 100);
 		}
 		if (MonthDay.class.equals(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			if (rs.wasNull()) {
 				return null;
 			}
 			return MonthDay.of(value / 100, value % 100);
 		}
 		if (Month.class.equals(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			return rs.wasNull() ? null : Month.of(value);
 		}
 		if (DayOfWeek.class.equals(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			return rs.wasNull() ? null : DayOfWeek.of(value);
 		}
 		if (Era.class.isAssignableFrom(rawType)) {
-			int value = rs.getInt(columnIndex);
+			int value = getInt(rs, columnIndex);
 			try {
 				return rs.wasNull() ? null : (Era) rawType.getMethod("of", int.class).invoke(null, value);
 			} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
@@ -183,11 +213,10 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 
 		// JapaneseDate等のChronoLocalDateの変換
 		if (ChronoLocalDate.class.isAssignableFrom(rawType)) {
-			java.sql.Date date = rs.getDate(columnIndex);
-			if (date == null) {
+			LocalDate localDate = getLocalDate(rs, columnIndex).orElse(null);
+			if (localDate == null) {
 				return null;
 			}
-			LocalDate localDate = date.toLocalDate();
 
 			try {
 				return (ChronoLocalDate) rawType.getMethod("of", int.class, int.class, int.class).invoke(null,
@@ -203,16 +232,149 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 	}
 
 	/**
-	 * {@link java.sql.Time} から {@link OffsetTime} への変換を行う.
+	 * ResultSetの指定したカラムの値からintを取得する.<br>
 	 *
-	 * @param time 変換する{@link java.sql.Time}
-	 * @return 変換後の{@link OffsetTime}
+	 * カラムの型が文字列の場合はintへの変換を試みる.
+	 *
+	 * @param rs 検索結果
+	 * @param columnIndex カラムインデックス
+	 * @return 変換したint. カラムの値がnullまたは空文字の場合は0を返却
+	 * @throws SQLException
 	 */
-	private OffsetTime sqlTimeToOffsetTime(final java.sql.Time time) {
-		long milliseconds = time.getTime();
-		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
-		calendar.setTimeInMillis(milliseconds);
-		return OffsetDateTime.ofInstant(calendar.toInstant(), clock.getZone()).toOffsetTime();
+	private int getInt(final ResultSet rs, final int columnIndex) throws SQLException {
+		int columnType = rs.getMetaData().getColumnType(columnIndex);
+		if (isStringType(columnType)) {
+			String str = rs.getString(columnIndex);
+			if (StringUtils.isEmpty(str)) {
+				return 0;
+			} else if (StringUtils.isNumeric(str)) {
+				return Integer.parseInt(str);
+			} else {
+				throw new UroborosqlRuntimeException("Text '" + str + "' could not be parsed to integer.");
+			}
+		} else {
+			return rs.getInt(columnIndex);
+		}
+	}
+
+	/**
+	 * ResultSetの指定したカラムの値から{@link LocalDate}オブジェクトを取得する.<br>
+	 *
+	 * カラムの型が文字列の場合は{@link LocalDate}への変換を試みる.
+	 *
+	 * @param rs 検索結果
+	 * @param columnIndex カラムインデックス
+	 * @return 変換した{@link LocalDate}
+	 * @throws SQLException
+	 */
+	private Optional<LocalDate> getLocalDate(final ResultSet rs, final int columnIndex) throws SQLException {
+		int columnType = rs.getMetaData().getColumnType(columnIndex);
+		if (isStringType(columnType)) {
+			return Optional.ofNullable(rs.getString(columnIndex))
+					.map(str -> {
+						try {
+							if (StringUtils.isEmpty(str)) {
+								return null;
+							} else if (str.length() == 8) { // yyyyMMdd
+								return LocalDate.parse(str, DateTimeFormatter.BASIC_ISO_DATE);
+							} else { // yyyy-MM-dd
+								return LocalDate.parse(str, DateTimeFormatter.ISO_LOCAL_DATE);
+							}
+						} catch (DateTimeParseException ex) {
+							throw new UroborosqlRuntimeException(ex);
+						}
+					});
+		} else {
+			return Optional.ofNullable(rs.getDate(columnIndex))
+					.map(java.sql.Date::toLocalDate);
+		}
+	}
+
+	/**
+	 * ResultSetの指定したカラムの値から{@link LocalDateTime}オブジェクトを取得する.<br>
+	 *
+	 * カラムの型が文字列の場合は{@link LocalDateTime}への変換を試みる.
+	 *
+	 * @param rs 検索結果
+	 * @param columnIndex カラムインデックス
+	 * @return 変換した{@link LocalDateTime}
+	 * @throws SQLException
+	 */
+	private Optional<LocalDateTime> getLocalDateTime(final ResultSet rs, final int columnIndex) throws SQLException {
+		int columnType = rs.getMetaData().getColumnType(columnIndex);
+		if (isStringType(columnType)) {
+			return Optional.ofNullable(rs.getString(columnIndex))
+					.map(str -> {
+						try {
+							if (StringUtils.isEmpty(str)) {
+								return null;
+							} else if (str.length() == 14) { // yyyyMMddHHmmss
+								return LocalDateTime.parse(str, FORMATTER_SHORT_DATE_TIME);
+							} else if (str.length() == 17) { // yyyyMMddHHmmssSSS
+								return LocalDateTime.parse(str, FORMATTER_SHORT_DATE_TIME_WITH_MILLS);
+							} else { // yyyy-MM-ddTHH:mm:ss, yyyy-MM-ddTHH:mm:ss.SSS
+								return LocalDateTime.parse(str, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+							}
+						} catch (DateTimeParseException ex) {
+							throw new UroborosqlRuntimeException(ex);
+						}
+					});
+		} else {
+			return Optional.ofNullable(rs.getTimestamp(columnIndex))
+					.map(Timestamp::toLocalDateTime);
+		}
+	}
+
+	/**
+	 * ResultSetの指定したカラムの値から{@link LocalTime}オブジェクトを取得する.<br>
+	 *
+	 * カラムの型が文字列の場合は{@link LocalTime}への変換を試みる.
+	 *
+	 * @param rs 検索結果
+	 * @param columnIndex カラムインデックス
+	 * @return 変換した{@link LocalTime}
+	 * @throws SQLException
+	 */
+	private Optional<LocalTime> getLocalTime(final ResultSet rs, final int columnIndex) throws SQLException {
+		int columnType = rs.getMetaData().getColumnType(columnIndex);
+		if (isStringType(columnType)) {
+			return Optional.ofNullable(rs.getString(columnIndex))
+					.map(str -> {
+						try {
+							if (StringUtils.isEmpty(str)) {
+								return null;
+							} else if (str.length() == 4) { // HHmm
+								return LocalTime.parse(str, FORMATTER_SHORT_TIME_WITHOUT_SEC);
+							} else if (str.length() == 6) { // HHmmss
+								return LocalTime.parse(str, FORMATTER_SHORT_TIME);
+							} else if (str.length() == 9) { // HHmmssSSS
+								return LocalTime.parse(str, FORMATTER_SHORT_TIME_WITH_MILLS);
+							} else { // HH:mm, HH:mm:ss, HH:mm:ss.SSS
+								return LocalTime.parse(str, DateTimeFormatter.ISO_LOCAL_TIME);
+							}
+						} catch (DateTimeParseException ex) {
+							throw new UroborosqlRuntimeException(ex);
+						}
+					});
+		} else {
+			return Optional.ofNullable(rs.getTime(columnIndex))
+					.map(this::sqlTimeToLocalTime);
+		}
+	}
+
+	/**
+	 * 文字列として扱えるカラム型を判定する
+	 *
+	 * @param columnType カラム型
+	 * @return 文字列として扱える場合<code>true</code>
+	 */
+	private boolean isStringType(final int columnType) {
+		return columnType == Types.CHAR ||
+				columnType == Types.NCHAR ||
+				columnType == Types.VARCHAR ||
+				columnType == Types.NVARCHAR ||
+				columnType == Types.LONGVARCHAR ||
+				columnType == Types.LONGNVARCHAR;
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapper.java
@@ -33,9 +33,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
 import java.util.Optional;
-import java.util.TimeZone;
 
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.mapping.JavaType;
@@ -358,7 +356,7 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 					});
 		} else {
 			return Optional.ofNullable(rs.getTime(columnIndex))
-					.map(this::sqlTimeToLocalTime);
+					.map(time -> Instant.ofEpochMilli(time.getTime()).atZone(clock.getZone()).toLocalTime());
 		}
 	}
 
@@ -375,18 +373,5 @@ public class DateTimeApiPropertyMapper implements PropertyMapper<TemporalAccesso
 				columnType == Types.NVARCHAR ||
 				columnType == Types.LONGVARCHAR ||
 				columnType == Types.LONGNVARCHAR;
-	}
-
-	/**
-	 * {@link java.sql.Time} から {@link LocalTime} への変換を行う.
-	 *
-	 * @param time 変換する{@link java.sql.Time}
-	 * @return 変換後の{@link LocalTime}
-	 */
-	private LocalTime sqlTimeToLocalTime(final java.sql.Time time) {
-		long milliseconds = time.getTime();
-		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
-		calendar.setTimeInMillis(milliseconds);
-		return LocalDateTime.ofInstant(calendar.toInstant(), clock.getZone()).toLocalTime();
 	}
 }

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
@@ -62,6 +62,9 @@ public final class BindParameterMapperManager {
 	public BindParameterMapperManager(final Clock clock) {
 		mappers = new CopyOnWriteArrayList<>(LOADED_MAPPERS);
 		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+
+		mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
+				.forEach(m -> ((BindParameterMapperWithClock<?>) m).setClock(clock));
 	}
 
 	/**
@@ -73,6 +76,9 @@ public final class BindParameterMapperManager {
 	public BindParameterMapperManager(final BindParameterMapperManager parameterMapperManager, final Clock clock) {
 		mappers = new CopyOnWriteArrayList<>(parameterMapperManager.mappers);
 		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+
+		mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
+				.forEach(m -> ((BindParameterMapperWithClock<?>) m).setClock(clock));
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManager.java
@@ -54,16 +54,19 @@ public final class BindParameterMapperManager {
 
 	private final DateTimeApiParameterMapper dateTimeApiParameterMapper;
 
+	private final Clock clock;
+
 	/**
 	 * コンストラクタ.
 	 *
 	 * @param clock Clock
 	 */
 	public BindParameterMapperManager(final Clock clock) {
-		mappers = new CopyOnWriteArrayList<>(LOADED_MAPPERS);
-		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+		this.mappers = new CopyOnWriteArrayList<>(LOADED_MAPPERS);
+		this.dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+		this.clock = clock;
 
-		mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
+		this.mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
 				.forEach(m -> ((BindParameterMapperWithClock<?>) m).setClock(clock));
 	}
 
@@ -74,10 +77,11 @@ public final class BindParameterMapperManager {
 	 * @param clock clock
 	 */
 	public BindParameterMapperManager(final BindParameterMapperManager parameterMapperManager, final Clock clock) {
-		mappers = new CopyOnWriteArrayList<>(parameterMapperManager.mappers);
-		dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+		this.mappers = new CopyOnWriteArrayList<>(parameterMapperManager.mappers);
+		this.dateTimeApiParameterMapper = new DateTimeApiParameterMapper(clock);
+		this.clock = clock;
 
-		mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
+		this.mappers.stream().filter(BindParameterMapperWithClock.class::isInstance)
 				.forEach(m -> ((BindParameterMapperWithClock<?>) m).setClock(clock));
 	}
 
@@ -87,6 +91,9 @@ public final class BindParameterMapperManager {
 	 * @param parameterMapper {@link BindParameterMapper}
 	 */
 	public void addMapper(final BindParameterMapper<?> parameterMapper) {
+		if (parameterMapper instanceof BindParameterMapperWithClock) {
+			((BindParameterMapperWithClock<?>) parameterMapper).setClock(this.clock);
+		}
 		mappers.add(parameterMapper);
 	}
 

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperWithClock.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperWithClock.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper;
+
+import java.time.Clock;
+
+/**
+ * パラメータをJDBCが受け入れられる型に変換するインターフェース. 日付変換を行うためにClockを使用する.
+ *
+ * @param <T> 変換対象の型
+ *
+ * @author H.Sugimoto
+ */
+public interface BindParameterMapperWithClock<T> extends BindParameterMapper<T> {
+	/**
+	 * Clock の取得
+	 * @return Clock
+	 */
+	Clock getClock();
+
+	/**
+	 * Clock の設定
+	 * @param clock Clock
+	 */
+	void setClock(Clock clock);
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapper.java
@@ -33,7 +33,7 @@ import java.util.TimeZone;
  *
  * @author ota
  */
-public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalAccessor> {
+public class DateTimeApiParameterMapper implements BindParameterMapperWithClock<TemporalAccessor> {
 
 	/**
 	 * 標準時間フィールド群
@@ -64,7 +64,7 @@ public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalA
 	/**
 	 * 日時の変換に使用するClock
 	 */
-	private final Clock clock;
+	private Clock clock;
 
 	/**
 	 * コンストラクタ.
@@ -83,6 +83,16 @@ public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalA
 	@Override
 	public Class<TemporalAccessor> targetType() {
 		return TemporalAccessor.class;
+	}
+
+	@Override
+	public Clock getClock() {
+		return clock;
+	}
+
+	@Override
+	public void setClock(final Clock clock) {
+		this.clock = clock;
 	}
 
 	/**
@@ -111,7 +121,7 @@ public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalA
 			return new java.sql.Time(toTime(original));
 		}
 		if (original instanceof OffsetTime) {
-			Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
+			Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(getClock().getZone()));
 			int year = calendar.get(Calendar.YEAR);
 			long thisYearDate = ((OffsetTime) original).atDate(LocalDate.of(year, Month.JANUARY, 1)).toInstant()
 					.toEpochMilli();
@@ -147,7 +157,7 @@ public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalA
 		// JapaneseDate等のChronoLocalDateの変換 Dateに変換
 		if (original instanceof ChronoLocalDate) {
 			return new java.sql.Date(((ChronoLocalDate) original).atTime(LocalTime.MIDNIGHT)
-					.atZone(clock.getZone()).toInstant().toEpochMilli());
+					.atZone(getClock().getZone()).toInstant().toEpochMilli());
 		}
 
 		// その他の型
@@ -186,7 +196,7 @@ public class DateTimeApiParameterMapper implements BindParameterMapper<TemporalA
 	 * @return カレンダー時間のミリ秒
 	 */
 	private long toTime(final TemporalAccessor temporalAccessor) {
-		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(clock.getZone()));
+		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(getClock().getZone()));
 		setField(calendar, Calendar.YEAR, temporalAccessor, ChronoField.YEAR, 0, 1970);
 		setField(calendar, Calendar.MONTH, temporalAccessor, ChronoField.MONTH_OF_YEAR, -1, 0);
 		setField(calendar, Calendar.DATE, temporalAccessor, ChronoField.DAY_OF_MONTH, 0, 1);

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapper.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper;
+
+import java.sql.Connection;
+
+/**
+ * 空文字をNULLに変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class EmptyStringToNullParameterMapper implements BindParameterMapper<String> {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<String> targetType() {
+		return String.class;
+	}
+
+	@Override
+	public boolean canAccept(final Object object) {
+		if (object instanceof String) {
+			return ((String) object).isEmpty();
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final String original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return original.isEmpty() ? null : original;
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapper.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.LocalDateTime} / {@link java.time.OffsetDateTime} / {@link java.time.ZonedDateTime} を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class DateTimeToStringParameterMapper implements BindParameterMapper<TemporalAccessor> {
+	/**
+	 * LocalDateTime/OffsetDateTime/ZonedDateTime から yyyyMMddHHmmssSSS文字列 に変換するためのフォーマッター.<br>
+	 * Java8での不具合のため、DateTimeFormatterはBuilderを使用して生成する.
+	 */
+	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendPattern("yyyyMMddHHmmss").appendValue(ChronoField.MILLI_OF_SECOND, 3).toFormatter();
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<TemporalAccessor> targetType() {
+		return TemporalAccessor.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#canAccept(java.lang.Object)
+	 */
+	@Override
+	public boolean canAccept(final Object object) {
+		return LocalDateTime.class.isInstance(object) ||
+				OffsetDateTime.class.isInstance(object) ||
+				ZonedDateTime.class.isInstance(object);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final TemporalAccessor original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return FORMATTER.format(original);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapper.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperWithClock;
+
+/**
+ * {@link java.util.Date}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class DateToStringParameterMapper implements BindParameterMapperWithClock<Date> {
+
+	private Clock clock;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<Date> targetType() {
+		return Date.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#canAccept(java.lang.Object)
+	 */
+	@Override
+	public boolean canAccept(final Object object) {
+		return Date.class.isInstance(object) && !Time.class.isInstance(object)
+				&& !Timestamp.class.isInstance(object);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final Date original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		if (original instanceof java.sql.Date) {
+			return DateTimeFormatter.BASIC_ISO_DATE.format(((java.sql.Date) original).toLocalDate());
+		} else {
+			return DateTimeFormatter.BASIC_ISO_DATE.format(original.toInstant().atZone(clock.getZone()).toLocalDate());
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapperWithClock#getClock()
+	 */
+	@Override
+	public Clock getClock() {
+		return clock;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapperWithClock#setClock(java.time.Clock)
+	 */
+	@Override
+	public void setClock(final Clock clock) {
+		this.clock = clock;
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.DayOfWeek;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.DayOfWeek}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class DayOfWeekToStringParameterMapper implements BindParameterMapper<DayOfWeek> {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<DayOfWeek> targetType() {
+		return DayOfWeek.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final DayOfWeek original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return String.valueOf(original.getValue());
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapper.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.LocalDate}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class LocalDateToStringParameterMapper implements BindParameterMapper<LocalDate> {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<LocalDate> targetType() {
+		return LocalDate.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final LocalDate original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return DateTimeFormatter.BASIC_ISO_DATE.format(original);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapper.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.MonthDay}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class MonthDayToStringParameterMapper implements BindParameterMapper<MonthDay> {
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MMdd");
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<MonthDay> targetType() {
+		return MonthDay.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final MonthDay original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return original.format(FORMATTER);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapper.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.Month;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+import jp.co.future.uroborosql.utils.StringUtils;
+
+/**
+ * {@link java.time.Month}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class MonthToStringParameterMapper implements BindParameterMapper<Month> {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<Month> targetType() {
+		return Month.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final Month original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return StringUtils.leftPad(String.valueOf(original.getValue()), 2, '0');
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapper.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.sql.Time;
+import java.time.format.DateTimeFormatter;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.sql.Time}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class SqlTimeToStringParameterMapper implements BindParameterMapper<Time> {
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<Time> targetType() {
+		return Time.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final Time original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return FORMATTER.format(original.toLocalTime());
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapper.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.LocalTime} / {@link java.time.OffsetTime} を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class TimeToStringParameterMapper implements BindParameterMapper<TemporalAccessor> {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<TemporalAccessor> targetType() {
+		return TemporalAccessor.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#canAccept(java.lang.Object)
+	 */
+	@Override
+	public boolean canAccept(final Object object) {
+		return LocalTime.class.isInstance(object) ||
+				OffsetTime.class.isInstance(object);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final TemporalAccessor original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return FORMATTER.format(original);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapper.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.YearMonth}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class YearMonthToStringParameterMapper implements BindParameterMapper<YearMonth> {
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<YearMonth> targetType() {
+		return YearMonth.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final YearMonth original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return original.format(FORMATTER);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapper.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import java.sql.Connection;
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+/**
+ * {@link java.time.Year}を文字列に変換する{@link BindParameterMapper}
+ *
+ * @author H.Sugimoto
+ */
+public class YearToStringParameterMapper implements BindParameterMapper<Year> {
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy");
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#targetType()
+	 */
+	@Override
+	public Class<Year> targetType() {
+		return Year.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.parameter.mapper.BindParameterMapper#toJdbc(java.lang.Object, java.sql.Connection, jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager)
+	 */
+	@Override
+	public Object toJdbc(final Year original, final Connection connection,
+			final BindParameterMapperManager parameterMapperManager) {
+		return original.format(FORMATTER);
+	}
+}

--- a/src/main/java/jp/co/future/uroborosql/parser/TransformContext.java
+++ b/src/main/java/jp/co/future/uroborosql/parser/TransformContext.java
@@ -100,18 +100,18 @@ public interface TransformContext {
 	/**
 	 * バインド変数追加。
 	 *
-	 * @param bindValiable バインド変数
+	 * @param bindVariable バインド変数
 	 * @return TransformContext
 	 */
-	TransformContext addBindVariable(Object bindValiable);
+	TransformContext addBindVariable(Object bindVariable);
 
 	/**
 	 * バインド変数一括追加。
 	 *
-	 * @param bindValiables バインド変数配列
+	 * @param bindVariables バインド変数配列
 	 * @return TransformContext
 	 */
-	TransformContext addBindVariables(Object[] bindValiables);
+	TransformContext addBindVariables(Object[] bindVariables);
 
 	/**
 	 * バインド変数配列取得。

--- a/src/main/java/jp/co/future/uroborosql/store/NioSqlManagerImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/store/NioSqlManagerImpl.java
@@ -215,7 +215,7 @@ public class NioSqlManagerImpl implements SqlManager {
 				log.debug("WatchService catched InterruptedException.");
 				break;
 			} catch (Throwable ex) {
-				log.error("Unexpected exception occured.", ex);
+				log.error("Unexpected exception occurred.", ex);
 				break;
 			}
 
@@ -532,7 +532,7 @@ public class NioSqlManagerImpl implements SqlManager {
 						traverse(child, watch, remove);
 					}
 				} catch (IOException ex) {
-					throw new UroborosqlRuntimeException("I/O error occured.", ex);
+					throw new UroborosqlRuntimeException("I/O error occurred.", ex);
 				}
 			}
 		} else if (path.toString().endsWith(fileExtension)) {

--- a/src/main/java/jp/co/future/uroborosql/store/SqlLoaderImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/store/SqlLoaderImpl.java
@@ -385,9 +385,9 @@ public class SqlLoaderImpl implements SqlLoader {
 	 * @return トリム後文字列
 	 */
 	private String trimSlash(final String sql) {
-		String trimedSql = sql.trim();
-		if (trimedSql.endsWith(PATH_SEPARATOR) && !trimedSql.endsWith("*/")) {
-			return StringUtils.removeEnd(trimedSql, PATH_SEPARATOR);
+		String trimmedSql = sql.trim();
+		if (trimmedSql.endsWith(PATH_SEPARATOR) && !trimmedSql.endsWith("*/")) {
+			return StringUtils.removeEnd(trimmedSql, PATH_SEPARATOR);
 		} else {
 			return sql;
 		}

--- a/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
@@ -326,7 +326,7 @@ public class SqlBatchTest extends AbstractDbTest {
 				.by((ctx, row) -> ctx.batchCount() == 10)
 				.batchWhen((agent, ctx) -> agent.commit())
 				.errorWhen((agent, ctx, ex) -> {
-					log.error("error occured. ex:{}", ex.getMessage());
+					log.error("error occurred. ex:{}", ex.getMessage());
 				})
 				.count();
 

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
@@ -140,7 +140,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
 		agent.required(() -> {
-			List<Product> insertedEntites = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
 				e.setProductName(e.getProductName() + "_new");
 				e.setProductKanaName(e.getProductKanaName() + "_new");
@@ -148,8 +148,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				return e;
 			})).collect(Collectors.toList());
 
-			assertThat(insertedEntites.get(0).getProductName(), is("商品名1_new"));
-			assertThat(insertedEntites.get(1).getVersionNo(), is(0));
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
 		});
 	}
 
@@ -162,7 +162,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
 		agent.required(() -> {
-			List<Product> insertedEntites = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
 				e.setProductName(e.getProductName() + "_new");
 				e.setProductKanaName(e.getProductKanaName() + "_new");
@@ -170,8 +170,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				return e;
 			}), InsertsType.BATCH).collect(Collectors.toList());
 
-			assertThat(insertedEntites.get(0).getProductName(), is("商品名1_new"));
-			assertThat(insertedEntites.get(1).getVersionNo(), is(0));
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
 		});
 	}
 
@@ -184,7 +184,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
 		agent.required(() -> {
-			List<Product> insertedEntites = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
 				e.setProductName(e.getProductName() + "_new");
 				e.setProductKanaName(e.getProductKanaName() + "_new");
@@ -192,8 +192,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				return e;
 			}), InsertsType.BULK).collect(Collectors.toList());
 
-			assertThat(insertedEntites.get(0).getProductName(), is("商品名1_new"));
-			assertThat(insertedEntites.get(1).getVersionNo(), is(0));
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
 		});
 	}
 
@@ -206,7 +206,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
 		agent.required(() -> {
-			List<Product> insertedEntites = agent
+			List<Product> insertedEntities = agent
 					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
 						e.setProductId(e.getProductId() + 10);
 						e.setProductName(e.getProductName() + "_new");
@@ -215,8 +215,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 						return e;
 					})).collect(Collectors.toList());
 
-			assertThat(insertedEntites.get(0).getProductName(), is("商品名1_new"));
-			assertThat(insertedEntites.get(1).getVersionNo(), is(0));
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
 		});
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -389,7 +389,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 					"create table if not exists test_entity_multi_key (id integer not null, end_at timestamp with time zone not null, name text not null, version integer not null, primary key (id, end_at))")
 					.count();
 
-			List<TestEntityMultiKey> entites = IntStream.range(1, 10)
+			List<TestEntityMultiKey> entities = IntStream.range(1, 10)
 					.mapToObj(i -> {
 						TestEntityMultiKey entity = new TestEntityMultiKey();
 						entity.setId(i);
@@ -398,9 +398,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 						entity.setVersion(i);
 						return entity;
 					}).collect(Collectors.toList());
-			assertThat(agent.inserts(TestEntityMultiKey.class, entites.stream()), is(9));
+			assertThat(agent.inserts(TestEntityMultiKey.class, entities.stream()), is(9));
 
-			agent.updatesAndReturn(entites.stream().map(e -> {
+			agent.updatesAndReturn(entities.stream().map(e -> {
 				e.setName(e.getName() + "_new");
 				return e;
 			})).peek(e -> {
@@ -423,14 +423,14 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 					"create table if not exists test_entity (id serial not null, name text not null, version integer not null, primary key (id))")
 					.count();
 
-			List<TestEntity> entites = IntStream.range(1, 10)
+			List<TestEntity> entities = IntStream.range(1, 10)
 					.mapToObj(i -> {
 						TestEntity entity = new TestEntity();
 						entity.setName("名前" + i);
 						entity.setVersion(0);
 						return entity;
 					}).collect(Collectors.toList());
-			assertThat(agent.inserts(TestEntity.class, entites.stream()), is(9));
+			assertThat(agent.inserts(TestEntity.class, entities.stream()), is(9));
 
 			int newId = 100;
 			int count = agent.update(TestEntity.class)

--- a/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
@@ -953,7 +953,7 @@ public class SqlQueryTest extends AbstractDbTest {
 	 * クエリ実行処理のテストケース。
 	 */
 	@Test
-	public void testQueryMapResuletSetConverter() throws Exception {
+	public void testQueryMapResultSetConverter() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
 

--- a/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/SqlParamUtilsTest.java
@@ -30,7 +30,7 @@ public class SqlParamUtilsTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testSetSqlParams() {
-		String sql = "/*key1*/, /*key2*/, /*key3*/(), /*CLS_AGE_DEFALUT*/, /*$CLS_FLAG_OFF*/";
+		String sql = "/*key1*/, /*key2*/, /*key3*/(), /*CLS_AGE_DEFAULT*/, /*$CLS_FLAG_OFF*/";
 		SqlContext ctx = sqlConfig.context();
 		ctx.setSql(sql);
 		SqlParamUtils.getSqlParams(ctx.getSql(), sqlConfig);
@@ -215,7 +215,7 @@ public class SqlParamUtilsTest {
 	public void testGetSqlParams() {
 		Set<String> params = SqlParamUtils
 				.getSqlParams(
-						"select * from test where id = /*id*/1 and name = /*name*/'name1 age = /*CLS_AGE_DEFALUT*/0",
+						"select * from test where id = /*id*/1 and name = /*name*/'name1 age = /*CLS_AGE_DEFAULT*/0",
 						sqlConfig);
 		assertThat(params, contains("id", "name"));
 		assertThat(params, not(contains("CLS_AGE_DEFAULT")));

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextFactoryAutoParameterBinderTest.java
@@ -95,7 +95,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 
 			Map<String, Object> row = agent.query("example/select_product").param("product_id", productId).first();
 			assertThat(row.get("INS_DATETIME"), is(Timestamp.valueOf(insDate)));
-			// QueryAutoPrameterBinderはupdateでは適用されないためupdDateとなる
+			// QueryAutoParameterBinderはupdateでは適用されないためupdDateとなる
 			assertThat(row.get("UPD_DATETIME"), is(Timestamp.valueOf(updDate)));
 
 			config.getSqlContextFactory().removeQueryAutoParameterBinder(binder);
@@ -133,7 +133,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 
 			Map<String, Object> row = agent.query("example/select_product").param("product_id", productId).first();
 			assertThat(row.get("INS_DATETIME"), is(Timestamp.valueOf(insDate)));
-			// UpdateAutoPrameterBinderのほうが後で設定されるため、上書きされる）
+			// UpdateAutoParameterBinderのほうが後で設定されるため、上書きされる）
 			assertThat(row.get("UPD_DATETIME"), is(Timestamp.valueOf(updDate)));
 
 			// UpdateAutoParameterBinderはQueryでは適用されない
@@ -255,7 +255,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 
 			Map<String, Object> row = agent.query("example/select_product").param("product_id", productId).first();
 			assertThat(row.get("INS_DATETIME"), is(Timestamp.valueOf(insDate)));
-			// UpdateAutoPrameterBinderのほうが後で設定されるため、上書きされる）
+			// UpdateAutoParameterBinderのほうが後で設定されるため、上書きされる）
 			assertThat(row.get("UPD_DATETIME"), is(Timestamp.valueOf(updDate.plusDays(1))));
 		}
 
@@ -294,7 +294,7 @@ public class SqlContextFactoryAutoParameterBinderTest {
 
 			Map<String, Object> row = agent.query("example/select_product").param("product_id", productId).first();
 			assertThat(row.get("INS_DATETIME"), is(Timestamp.valueOf(insDate)));
-			// UpdateAutoPrameterBinderのほうが後で設定されるため、上書きされる）
+			// UpdateAutoParameterBinderのほうが後で設定されるため、上書きされる）
 			assertThat(row.get("UPD_DATETIME"), is(Timestamp.valueOf(updDate)));
 		}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/IdentityGeneratedKeysTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/IdentityGeneratedKeysTest.java
@@ -227,17 +227,17 @@ public class IdentityGeneratedKeysTest {
 				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
 						.get("ID");
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -260,17 +260,17 @@ public class IdentityGeneratedKeysTest {
 						.mapToLong(map -> (Long) map.get("CURRENT_VALUE"))
 						.findFirst().getAsLong();
 
-				List<TestAutoEntityWithNoId> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoId> entities = new ArrayList<>();
 				TestAutoEntityWithNoId test1 = new TestAutoEntityWithNoId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoId test2 = new TestAutoEntityWithNoId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoId test3 = new TestAutoEntityWithNoId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -293,17 +293,17 @@ public class IdentityGeneratedKeysTest {
 						.mapToLong(map -> (Long) map.get("CURRENT_VALUE"))
 						.findFirst().getAsLong();
 
-				List<TestAutoEntityWithNoIdObj> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoIdObj> entities = new ArrayList<>();
 				TestAutoEntityWithNoIdObj test1 = new TestAutoEntityWithNoIdObj("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoIdObj test2 = new TestAutoEntityWithNoIdObj("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoIdObj test3 = new TestAutoEntityWithNoIdObj("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -328,20 +328,20 @@ public class IdentityGeneratedKeysTest {
 
 				long idVal = currVal + 100;
 
-				List<TestAutoEntityWithNoIdObj> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoIdObj> entities = new ArrayList<>();
 				TestAutoEntityWithNoIdObj test1 = new TestAutoEntityWithNoIdObj("name1");
 				test1.id = idVal + 1;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoIdObj test2 = new TestAutoEntityWithNoIdObj("name2");
 				test2.id = idVal + 2;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoIdObj test3 = new TestAutoEntityWithNoIdObj("name3");
 				test3.id = idVal + 3;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(idVal + 1));
 				assertThat(test2.getId(), is(idVal + 2));
 				assertThat(test3.getId(), is(idVal + 3));
@@ -361,20 +361,20 @@ public class IdentityGeneratedKeysTest {
 						.get("ID");
 				long idVal = currVal + 100;
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
 				test1.id = idVal++;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
 				test2.id = idVal++;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
 				test3.id = idVal++;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -393,17 +393,17 @@ public class IdentityGeneratedKeysTest {
 				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
 						.get("ID");
 
-				List<TestEntityWithIdObj> entites = new ArrayList<>();
+				List<TestEntityWithIdObj> entities = new ArrayList<>();
 				TestEntityWithIdObj test1 = new TestEntityWithIdObj("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithIdObj test2 = new TestEntityWithIdObj("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithIdObj test3 = new TestEntityWithIdObj("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -423,20 +423,20 @@ public class IdentityGeneratedKeysTest {
 						.get("ID");
 				long idVal = currVal + 100;
 
-				List<TestEntityWithIdObj> entites = new ArrayList<>();
+				List<TestEntityWithIdObj> entities = new ArrayList<>();
 				TestEntityWithIdObj test1 = new TestEntityWithIdObj("name1");
 				test1.id = idVal;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithIdObj test2 = new TestEntityWithIdObj("name2");
 				test2.id = idVal + 1;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithIdObj test3 = new TestEntityWithIdObj("name3");
 				test3.id = idVal + 2;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream());
+				agent.inserts(entities.stream());
 				assertThat(test1.getId(), is(idVal));
 				assertThat(test2.getId(), is(idVal + 1));
 				assertThat(test3.getId(), is(idVal + 2));
@@ -455,17 +455,17 @@ public class IdentityGeneratedKeysTest {
 				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
 						.get("ID");
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -488,17 +488,17 @@ public class IdentityGeneratedKeysTest {
 						.mapToLong(map -> (Long) map.get("CURRENT_VALUE"))
 						.findFirst().getAsLong();
 
-				List<TestAutoEntityWithNoId> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoId> entities = new ArrayList<>();
 				TestAutoEntityWithNoId test1 = new TestAutoEntityWithNoId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoId test2 = new TestAutoEntityWithNoId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoId test3 = new TestAutoEntityWithNoId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -521,17 +521,17 @@ public class IdentityGeneratedKeysTest {
 						.mapToLong(map -> (Long) map.get("CURRENT_VALUE"))
 						.findFirst().getAsLong();
 
-				List<TestAutoEntityWithNoIdObj> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoIdObj> entities = new ArrayList<>();
 				TestAutoEntityWithNoIdObj test1 = new TestAutoEntityWithNoIdObj("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoIdObj test2 = new TestAutoEntityWithNoIdObj("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoIdObj test3 = new TestAutoEntityWithNoIdObj("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -556,20 +556,20 @@ public class IdentityGeneratedKeysTest {
 
 				long idVal = currVal + 100;
 
-				List<TestAutoEntityWithNoIdObj> entites = new ArrayList<>();
+				List<TestAutoEntityWithNoIdObj> entities = new ArrayList<>();
 				TestAutoEntityWithNoIdObj test1 = new TestAutoEntityWithNoIdObj("name1");
 				test1.id = idVal + 1;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestAutoEntityWithNoIdObj test2 = new TestAutoEntityWithNoIdObj("name2");
 				test2.id = idVal + 2;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestAutoEntityWithNoIdObj test3 = new TestAutoEntityWithNoIdObj("name3");
 				test3.id = idVal + 3;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(idVal + 1));
 				assertThat(test2.getId(), is(idVal + 2));
 				assertThat(test3.getId(), is(idVal + 3));
@@ -589,20 +589,20 @@ public class IdentityGeneratedKeysTest {
 						.get("ID");
 				long idVal = currVal + 100;
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
 				test1.id = idVal;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
 				test2.id = idVal + 1;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
 				test3.id = idVal + 2;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(++currVal));
 				assertThat(test2.getId(), is(++currVal));
 				assertThat(test3.getId(), is(++currVal));
@@ -622,20 +622,20 @@ public class IdentityGeneratedKeysTest {
 						.get("ID");
 				long idVal = currVal + 100;
 
-				List<TestEntityWithIdObj> entites = new ArrayList<>();
+				List<TestEntityWithIdObj> entities = new ArrayList<>();
 				TestEntityWithIdObj test1 = new TestEntityWithIdObj("name1");
 				test1.id = idVal;
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithIdObj test2 = new TestEntityWithIdObj("name2");
 				test2.id = idVal + 1;
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithIdObj test3 = new TestEntityWithIdObj("name3");
 				test3.id = idVal + 2;
-				entites.add(test3);
+				entities.add(test3);
 
-				agent.inserts(entites.stream(), InsertsType.BATCH);
+				agent.inserts(entities.stream(), InsertsType.BATCH);
 				assertThat(test1.getId(), is(idVal));
 				assertThat(test2.getId(), is(idVal + 1));
 				assertThat(test3.getId(), is(idVal + 2));
@@ -654,17 +654,17 @@ public class IdentityGeneratedKeysTest {
 				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
 						.get("ID");
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				List<TestEntityWithId> insertedEntities = agent.insertsAndReturn(entites.stream())
+				List<TestEntityWithId> insertedEntities = agent.insertsAndReturn(entities.stream())
 						.collect(Collectors.toList());
 				assertThat(insertedEntities.get(0).getId(), is(++currVal));
 				assertThat(insertedEntities.get(1).getId(), is(++currVal));
@@ -684,17 +684,17 @@ public class IdentityGeneratedKeysTest {
 				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
 						.get("ID");
 
-				List<TestEntityWithId> entites = new ArrayList<>();
+				List<TestEntityWithId> entities = new ArrayList<>();
 				TestEntityWithId test1 = new TestEntityWithId("name1");
-				entites.add(test1);
+				entities.add(test1);
 
 				TestEntityWithId test2 = new TestEntityWithId("name2");
-				entites.add(test2);
+				entities.add(test2);
 
 				TestEntityWithId test3 = new TestEntityWithId("name3");
-				entites.add(test3);
+				entities.add(test3);
 
-				List<TestEntityWithId> insertedEntities = agent.insertsAndReturn(entites.stream(), InsertsType.BATCH)
+				List<TestEntityWithId> insertedEntities = agent.insertsAndReturn(entities.stream(), InsertsType.BATCH)
 						.collect(Collectors.toList());
 				assertThat(insertedEntities.get(0).getId(), is(++currVal));
 				assertThat(insertedEntities.get(1).getId(), is(++currVal));

--- a/src/test/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/mapper/DateTimeApiPropertyMapperTest.java
@@ -21,6 +21,7 @@ import java.time.chrono.ChronoLocalDate;
 import java.time.chrono.Era;
 import java.time.chrono.JapaneseDate;
 import java.time.chrono.JapaneseEra;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
@@ -54,47 +55,153 @@ public class DateTimeApiPropertyMapperTest {
 
 		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", timestamp), 1),
 				is(localDateTime));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(localDateTime)), 1),
+				is(localDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(localDateTime)),
+				1), is(localDateTime));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class),
+				newResultSet("getTimestamp",
+						DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").format(localDateTime)),
+				1), is(localDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)),
+				1), is(localDateTime));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)), 1),
+				is(localDateTime));
+
 		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", timestamp), 1),
 				is(offsetDateTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(localDateTime)), 1),
+				is(offsetDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(localDateTime)),
+				1), is(offsetDateTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class),
+				newResultSet("getTimestamp",
+						DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").format(localDateTime)),
+				1), is(offsetDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)),
+				1), is(offsetDateTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)), 1),
+				is(offsetDateTime));
+
 		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", timestamp), 1),
 				is(zonedDateTime));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(localDateTime)), 1),
+				is(zonedDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(localDateTime)),
+				1), is(zonedDateTime));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class),
+				newResultSet("getTimestamp",
+						DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").format(localDateTime)),
+				1), is(zonedDateTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)),
+				1), is(zonedDateTime));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class),
+				newResultSet("getTimestamp", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime)), 1),
+				is(zonedDateTime));
+
 		assertThat(mapper.getValue(JavaType.of(LocalDate.class), newResultSet("getDate", date), 1), is(localDate));
+		assertThat(mapper.getValue(JavaType.of(LocalDate.class),
+				newResultSet("getDate", DateTimeFormatter.BASIC_ISO_DATE.format(localDate)), 1), is(localDate));
+		assertThat(mapper.getValue(JavaType.of(LocalDate.class),
+				newResultSet("getDate", DateTimeFormatter.ISO_LOCAL_DATE.format(localDate)), 1), is(localDate));
+
 		assertThat(mapper.getValue(JavaType.of(LocalTime.class), newResultSet("getTime", time), 1), is(localTime));
+		assertThat(mapper.getValue(JavaType.of(LocalTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmm").format(localTime)), 1),
+				is(localTime.withSecond(0).with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(LocalTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmmss").format(localTime)), 1),
+				is(localTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(LocalTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmmssSSS").format(localTime)), 1),
+				is(localTime));
+		assertThat(mapper.getValue(JavaType.of(LocalTime.class),
+				newResultSet("getTime", DateTimeFormatter.ISO_LOCAL_TIME.format(localTime)), 1),
+				is(localTime));
+
 		assertThat(mapper.getValue(JavaType.of(OffsetTime.class), newResultSet("getTime", time), 1), is(offsetTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmm").format(localTime)), 1),
+				is(offsetTime.withSecond(0).with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(OffsetTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmmss").format(localTime)), 1),
+				is(offsetTime.with(ChronoField.MILLI_OF_SECOND, 0L)));
+		assertThat(mapper.getValue(JavaType.of(OffsetTime.class),
+				newResultSet("getTime", DateTimeFormatter.ofPattern("HHmmssSSS").format(localTime)), 1),
+				is(offsetTime));
+		assertThat(mapper.getValue(JavaType.of(OffsetTime.class),
+				newResultSet("getTime", DateTimeFormatter.ISO_LOCAL_TIME.format(localTime)), 1),
+				is(offsetTime));
 
 		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", null), 1),
 				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(LocalDateTime.class), newResultSet("getTimestamp", ""), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", null), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(OffsetDateTime.class), newResultSet("getTimestamp", ""), 1),
 				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", null), 1),
 				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(ZonedDateTime.class), newResultSet("getTimestamp", ""), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(LocalDate.class), newResultSet("getDate", null), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(LocalDate.class), newResultSet("getDate", ""), 1), is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(LocalTime.class), newResultSet("getTime", null), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(LocalTime.class), newResultSet("getTime", ""), 1), is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(OffsetTime.class), newResultSet("getTime", null), 1), is(nullValue()));
-
+		assertThat(mapper.getValue(JavaType.of(OffsetTime.class), newResultSet("getTime", ""), 1), is(nullValue()));
 	}
 
 	@Test
 	public void test2() throws NoSuchMethodException, SecurityException, SQLException {
 		PropertyMapperManager mapper = new PropertyMapperManager(this.clock);
 		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", 2000), 1), is(Year.of(2000)));
+		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", "2000"), 1), is(Year.of(2000)));
 		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 200004), 1),
 				is(YearMonth.of(2000, 4)));
+		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", "200004"), 1),
+				is(YearMonth.of(2000, 4)));
 		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", 401), 1), is(MonthDay.of(4, 1)));
+		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", "401"), 1),
+				is(MonthDay.of(4, 1)));
 		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", 4), 1), is(Month.APRIL));
+		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", "4"), 1), is(Month.APRIL));
 		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", 4), 1), is(DayOfWeek.THURSDAY));
+		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", "4"), 1),
+				is(DayOfWeek.THURSDAY));
 
 		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", 0, "wasNull", true), 1),
 				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(Year.class), newResultSet("getInt", "", "wasNull", true), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(YearMonth.class), newResultSet("getInt", "", "wasNull", true), 1),
 				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", 0, "wasNull", true), 1),
 				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(MonthDay.class), newResultSet("getInt", "", "wasNull", true), 1),
+				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", 0, "wasNull", true), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(Month.class), newResultSet("getInt", "", "wasNull", true), 1),
 				is(nullValue()));
 		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", 0, "wasNull", true), 1),
 				is(nullValue()));
-
+		assertThat(mapper.getValue(JavaType.of(DayOfWeek.class), newResultSet("getInt", "", "wasNull", true), 1),
+				is(nullValue()));
 	}
 
 	@Test
@@ -108,15 +215,30 @@ public class DateTimeApiPropertyMapperTest {
 
 		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 2), 1),
 				is(JapaneseEra.HEISEI));
+		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", "2"), 1),
+				is(JapaneseEra.HEISEI));
+
 		assertThat(mapper.getValue(JavaType.of(Era.class), newResultSet("getInt", 2), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(Era.class), newResultSet("getInt", "2"), 1), is(nullValue()));
+
 		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", date), 1),
 				is(japaneseDate));
+		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class),
+				newResultSet("getDate", DateTimeFormatter.BASIC_ISO_DATE.format(localDate)), 1),
+				is(japaneseDate));
+
 		assertThat(mapper.getValue(JavaType.of(ChronoLocalDate.class), newResultSet("getDate", null), 1),
+				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(ChronoLocalDate.class), newResultSet("getDate", ""), 1),
 				is(nullValue()));
 
 		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", 0, "wasNull", true), 1),
 				is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(JapaneseEra.class), newResultSet("getInt", "", "wasNull", true), 1),
+				is(nullValue()));
+
 		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", null), 1), is(nullValue()));
+		assertThat(mapper.getValue(JavaType.of(JapaneseDate.class), newResultSet("getDate", ""), 1), is(nullValue()));
 
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
@@ -72,7 +72,7 @@ public class BindParameterMapperManagerTest {
 	}
 
 	@Test
-	public void testWithCostom() throws ParseException {
+	public void testWithCustom() throws ParseException {
 		BindParameterMapperManager original = new BindParameterMapperManager(this.clock);
 		original.addMapper(new EmptyStringToNullParameterMapper());
 		DateToStringParameterMapper mapper = new DateToStringParameterMapper();

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/BindParameterMapperManagerTest.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -14,11 +15,15 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.util.Date;
 
+import org.junit.Before;
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.legacy.DateToStringParameterMapper;
 
 public class BindParameterMapperManagerTest {
 	private Clock clock;
 
+	@Before
 	public void setUp() {
 		this.clock = Clock.systemDefaultZone();
 	}
@@ -67,6 +72,23 @@ public class BindParameterMapperManagerTest {
 	}
 
 	@Test
+	public void testWithCostom() throws ParseException {
+		BindParameterMapperManager original = new BindParameterMapperManager(this.clock);
+		original.addMapper(new EmptyStringToNullParameterMapper());
+		DateToStringParameterMapper mapper = new DateToStringParameterMapper();
+		original.addMapper(mapper);
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(original, this.clock);
+
+		Date date = Date.from(LocalDate.parse("2000-01-01").atStartOfDay(this.clock.getZone()).toInstant());
+		assertThat(parameterMapperManager.toJdbc(date, null), is("20000101"));
+
+		assertThat(parameterMapperManager.canAcceptByStandard(date), is(true));
+
+		parameterMapperManager.removeMapper(mapper);
+		assertThat(parameterMapperManager.toJdbc(date, null), is(instanceOf(Timestamp.class)));
+	}
+
+	@Test
 	public void testCustom() {
 		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
 
@@ -81,6 +103,40 @@ public class BindParameterMapperManagerTest {
 			public Object toJdbc(final String original, final Connection connection,
 					final BindParameterMapperManager parameterMapperManager) {
 				return original.toLowerCase();
+			}
+		});
+		assertThat(parameterMapperManager.toJdbc("S", null), is("s"));
+
+		assertThat(parameterMapperManager.toJdbc(true, null), is(true));
+
+	}
+
+	@Test
+	public void testCustomWithClock() {
+		BindParameterMapperManager parameterMapperManager = new BindParameterMapperManager(this.clock);
+
+		parameterMapperManager.addMapper(new BindParameterMapperWithClock<String>() {
+			private Clock clock;
+
+			@Override
+			public Class<String> targetType() {
+				return String.class;
+			}
+
+			@Override
+			public Object toJdbc(final String original, final Connection connection,
+					final BindParameterMapperManager parameterMapperManager) {
+				return original.toLowerCase();
+			}
+
+			@Override
+			public Clock getClock() {
+				return this.clock;
+			}
+
+			@Override
+			public void setClock(final Clock clock) {
+				this.clock = clock;
 			}
 		});
 		assertThat(parameterMapperManager.toJdbc("S", null), is("s"));

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/DateTimeApiParameterMapperTest.java
@@ -234,6 +234,13 @@ public class DateTimeApiParameterMapperTest {
 		assertThat(mapper.toJdbc(temporalAccessor, null, null), is(temporalAccessor));
 	}
 
+	@Test
+	public void testClock() {
+		DateTimeApiParameterMapper mapper = new DateTimeApiParameterMapper(this.clock);
+		mapper.setClock(this.clock);
+		assertThat(mapper.getClock(), is(this.clock));
+	}
+
 	private java.sql.Timestamp createTimestamp(final String s) throws ParseException {
 		return java.sql.Timestamp.valueOf(LocalDateTime.parse(s));
 	}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapperTest.java
@@ -1,0 +1,28 @@
+package jp.co.future.uroborosql.parameter.mapper;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+
+import org.junit.Test;
+
+public class EmptyStringToNullParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		EmptyStringToNullParameterMapper mapper = new EmptyStringToNullParameterMapper();
+
+		assertThat(mapper.toJdbc("", null, null), is(nullValue()));
+		assertThat(mapper.toJdbc("str", null, null), is("str"));
+	}
+
+	@Test
+	public void testCanAccept() throws Exception {
+		EmptyStringToNullParameterMapper mapper = new EmptyStringToNullParameterMapper();
+
+		assertThat(mapper.canAccept(""), is(true));
+		assertThat(mapper.canAccept("str"), is(false));
+		assertThat(mapper.canAccept(1), is(false));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/EmptyStringToNullParameterMapperTest.java
@@ -25,4 +25,11 @@ public class EmptyStringToNullParameterMapperTest {
 		assertThat(mapper.canAccept("str"), is(false));
 		assertThat(mapper.canAccept(1), is(false));
 	}
+
+	@Test
+	public void testTargetType() throws Exception {
+		EmptyStringToNullParameterMapper mapper = new EmptyStringToNullParameterMapper();
+
+		assertThat(mapper.targetType(), sameInstance(String.class));
+	}
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapperTest.java
@@ -1,0 +1,56 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
+
+public class DateTimeToStringParameterMapperTest {
+
+	@Test
+	public void testLocalDateTime() throws ParseException {
+		DateTimeToStringParameterMapper mapper = new DateTimeToStringParameterMapper();
+		LocalDateTime dateTime = LocalDateTime.of(2020, 01, 02, 11, 22, 33, 123000000);
+
+		assertThat(mapper.toJdbc(dateTime, null, null), is("20200102112233123"));
+	}
+
+	@Test
+	public void testOffsetDateTime() throws ParseException {
+		DateTimeToStringParameterMapper mapper = new DateTimeToStringParameterMapper();
+		LocalDateTime localDateTime = LocalDateTime.of(2020, 01, 02, 11, 22, 33, 123000000);
+		ZoneOffset offset = Clock.systemDefaultZone().getZone().getRules().getOffset(localDateTime);
+		OffsetDateTime dateTime = OffsetDateTime.of(localDateTime, offset);
+
+		assertThat(mapper.toJdbc(dateTime, null, null), is("20200102112233123"));
+	}
+
+	@Test
+	public void testZonedDateTime() throws ParseException {
+		DateTimeToStringParameterMapper mapper = new DateTimeToStringParameterMapper();
+		LocalDateTime localDateTime = LocalDateTime.of(2020, 01, 02, 11, 22, 33, 123000000);
+		ZonedDateTime dateTime = ZonedDateTime.of(localDateTime, Clock.systemDefaultZone().getZone());
+
+		assertThat(mapper.toJdbc(dateTime, null, null), is("20200102112233123"));
+	}
+
+	@Test
+	public void testCanAccept() throws Exception {
+		DateTimeToStringParameterMapper mapper = new DateTimeToStringParameterMapper();
+
+		assertThat(mapper.canAccept(LocalDateTime.now()), is(true));
+		assertThat(mapper.canAccept(OffsetDateTime.now()), is(true));
+		assertThat(mapper.canAccept(ZonedDateTime.now()), is(true));
+		assertThat(mapper.canAccept(LocalDate.now()), is(false));
+		assertThat(mapper.canAccept(LocalTime.now()), is(false));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateTimeToStringParameterMapperTest.java
@@ -11,8 +11,11 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class DateTimeToStringParameterMapperTest {
 
@@ -53,4 +56,22 @@ public class DateTimeToStringParameterMapperTest {
 		assertThat(mapper.canAccept(LocalDate.now()), is(false));
 		assertThat(mapper.canAccept(LocalTime.now()), is(false));
 	}
+
+	@Test
+	public void testTargetType() throws Exception {
+		DateTimeToStringParameterMapper mapper = new DateTimeToStringParameterMapper();
+
+		assertThat(mapper.targetType(), sameInstance(TemporalAccessor.class));
+	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new DateTimeToStringParameterMapper());
+
+		LocalDateTime dateTime = LocalDateTime.of(2020, 01, 02, 11, 22, 33, 123000000);
+
+		assertThat(manager.toJdbc(dateTime, null), is("20200102112233123"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapperTest.java
@@ -1,0 +1,47 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.Test;
+
+public class DateToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		DateToStringParameterMapper mapper = new DateToStringParameterMapper();
+		mapper.setClock(Clock.systemDefaultZone());
+		Date date = Date.from(LocalDate.parse("2000-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant());
+
+		assertThat(mapper.toJdbc(date, null, null), is("20000101"));
+	}
+
+	@Test
+	public void testSqlDate() throws ParseException {
+		DateToStringParameterMapper mapper = new DateToStringParameterMapper();
+		mapper.setClock(Clock.systemDefaultZone());
+		Date date = Date.from(LocalDate.parse("2000-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant());
+		java.sql.Date sqlDate = new java.sql.Date(date.getTime());
+		assertThat(mapper.toJdbc(sqlDate, null, null), is("20000101"));
+	}
+
+	@Test
+	public void testCanAccept() throws Exception {
+		DateToStringParameterMapper mapper = new DateToStringParameterMapper();
+		mapper.setClock(Clock.systemDefaultZone());
+
+		assertThat(mapper.canAccept(new Date()), is(true));
+		assertThat(mapper.canAccept(new java.sql.Date(new Date().getTime())), is(true));
+		assertThat(mapper.canAccept(new Time(new Date().getTime())), is(false));
+		assertThat(mapper.canAccept(new Timestamp(new Date().getTime())), is(false));
+
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DateToStringParameterMapperTest.java
@@ -13,6 +13,8 @@ import java.util.Date;
 
 import org.junit.Test;
 
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
 public class DateToStringParameterMapperTest {
 
 	@Test
@@ -42,6 +44,24 @@ public class DateToStringParameterMapperTest {
 		assertThat(mapper.canAccept(new java.sql.Date(new Date().getTime())), is(true));
 		assertThat(mapper.canAccept(new Time(new Date().getTime())), is(false));
 		assertThat(mapper.canAccept(new Timestamp(new Date().getTime())), is(false));
-
+		assertThat(mapper.canAccept("str"), is(false));
 	}
+
+	@Test
+	public void testTargetType() throws Exception {
+		DateToStringParameterMapper mapper = new DateToStringParameterMapper();
+		mapper.setClock(Clock.systemDefaultZone());
+
+		assertThat(mapper.targetType(), sameInstance(Date.class));
+	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new DateToStringParameterMapper());
+
+		Date date = Date.from(LocalDate.parse("2000-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant());
+		assertThat(manager.toJdbc(date, null), is("20000101"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapperTest.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.DayOfWeek;
+
+import org.junit.Test;
+
+public class DayOfWeekToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		DayOfWeekToStringParameterMapper mapper = new DayOfWeekToStringParameterMapper();
+
+		assertThat(mapper.toJdbc(DayOfWeek.SUNDAY, null, null), is("7"));
+		assertThat(mapper.toJdbc(DayOfWeek.FRIDAY, null, null), is("5"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/DayOfWeekToStringParameterMapperTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.DayOfWeek;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class DayOfWeekToStringParameterMapperTest {
 
@@ -17,4 +20,13 @@ public class DayOfWeekToStringParameterMapperTest {
 		assertThat(mapper.toJdbc(DayOfWeek.SUNDAY, null, null), is("7"));
 		assertThat(mapper.toJdbc(DayOfWeek.FRIDAY, null, null), is("5"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new DayOfWeekToStringParameterMapper());
+
+		assertThat(manager.toJdbc(DayOfWeek.SUNDAY, null), is("7"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapperTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.LocalDate;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class LocalDateToStringParameterMapperTest {
 
@@ -17,4 +20,15 @@ public class LocalDateToStringParameterMapperTest {
 
 		assertThat(mapper.toJdbc(localDate, null, null), is("20030202"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new LocalDateToStringParameterMapper());
+
+		LocalDate localDate = LocalDate.of(2003, 2, 2);
+
+		assertThat(manager.toJdbc(localDate, null), is("20030202"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/LocalDateToStringParameterMapperTest.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+public class LocalDateToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		LocalDateToStringParameterMapper mapper = new LocalDateToStringParameterMapper();
+		LocalDate localDate = LocalDate.of(2003, 2, 2);
+
+		assertThat(mapper.toJdbc(localDate, null, null), is("20030202"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapperTest.java
@@ -4,10 +4,13 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.Month;
 import java.time.MonthDay;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class MonthDayToStringParameterMapperTest {
 
@@ -18,4 +21,13 @@ public class MonthDayToStringParameterMapperTest {
 		assertThat(mapper.toJdbc(MonthDay.of(Month.JANUARY, 1), null, null), is("0101"));
 		assertThat(mapper.toJdbc(MonthDay.of(Month.DECEMBER, 31), null, null), is("1231"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new MonthDayToStringParameterMapper());
+
+		assertThat(manager.toJdbc(MonthDay.of(Month.JANUARY, 1), null), is("0101"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthDayToStringParameterMapperTest.java
@@ -1,0 +1,21 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.Month;
+import java.time.MonthDay;
+
+import org.junit.Test;
+
+public class MonthDayToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		MonthDayToStringParameterMapper mapper = new MonthDayToStringParameterMapper();
+
+		assertThat(mapper.toJdbc(MonthDay.of(Month.JANUARY, 1), null, null), is("0101"));
+		assertThat(mapper.toJdbc(MonthDay.of(Month.DECEMBER, 31), null, null), is("1231"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapperTest.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.Month;
+
+import org.junit.Test;
+
+public class MonthToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		MonthToStringParameterMapper mapper = new MonthToStringParameterMapper();
+
+		assertThat(mapper.toJdbc(Month.APRIL, null, null), is("04"));
+		assertThat(mapper.toJdbc(Month.NOVEMBER, null, null), is("11"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/MonthToStringParameterMapperTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.Month;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class MonthToStringParameterMapperTest {
 
@@ -16,5 +19,13 @@ public class MonthToStringParameterMapperTest {
 
 		assertThat(mapper.toJdbc(Month.APRIL, null, null), is("04"));
 		assertThat(mapper.toJdbc(Month.NOVEMBER, null, null), is("11"));
+	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new MonthToStringParameterMapper());
+
+		assertThat(manager.toJdbc(Month.APRIL, null), is("04"));
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapperTest.java
@@ -1,0 +1,21 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.sql.Time;
+import java.text.ParseException;
+import java.time.LocalTime;
+
+import org.junit.Test;
+
+public class SqlTimeToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		SqlTimeToStringParameterMapper mapper = new SqlTimeToStringParameterMapper();
+		Time time = Time.valueOf(LocalTime.parse("11:22:33"));
+
+		assertThat(mapper.toJdbc(time, null, null), is("112233"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/SqlTimeToStringParameterMapperTest.java
@@ -5,9 +5,12 @@ import static org.junit.Assert.*;
 
 import java.sql.Time;
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.LocalTime;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class SqlTimeToStringParameterMapperTest {
 
@@ -18,4 +21,15 @@ public class SqlTimeToStringParameterMapperTest {
 
 		assertThat(mapper.toJdbc(time, null, null), is("112233"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new SqlTimeToStringParameterMapper());
+
+		Time time = Time.valueOf(LocalTime.parse("11:22:33"));
+
+		assertThat(manager.toJdbc(time, null), is("112233"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapperTest.java
@@ -1,0 +1,51 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import org.junit.Test;
+
+public class TimeToStringParameterMapperTest {
+
+	@Test
+	public void testLocalTime() throws ParseException {
+		TimeToStringParameterMapper mapper = new TimeToStringParameterMapper();
+		LocalTime localTime = LocalTime.of(11, 22, 33);
+		assertThat(mapper.toJdbc(localTime, null, null), is("112233"));
+
+		localTime = LocalTime.of(11, 22);
+		assertThat(mapper.toJdbc(localTime, null, null), is("112200"));
+	}
+
+	@Test
+	public void testOffsetTime() throws ParseException {
+		TimeToStringParameterMapper mapper = new TimeToStringParameterMapper();
+		LocalTime localTime = LocalTime.of(11, 22, 33);
+		ZoneOffset offset = Clock.systemDefaultZone().getZone().getRules().getOffset(localTime.atDate(LocalDate.now()));
+		OffsetTime offsetTime = OffsetTime.of(localTime, offset);
+		assertThat(mapper.toJdbc(offsetTime, null, null), is("112233"));
+
+		offsetTime = OffsetTime.of(LocalTime.of(11, 22), offset);
+		assertThat(mapper.toJdbc(offsetTime, null, null), is("112200"));
+	}
+
+	@Test
+	public void testCanAccept() throws Exception {
+		TimeToStringParameterMapper mapper = new TimeToStringParameterMapper();
+
+		assertThat(mapper.canAccept(LocalTime.now()), is(true));
+		assertThat(mapper.canAccept(OffsetTime.now()), is(true));
+		assertThat(mapper.canAccept(LocalDate.now()), is(false));
+		assertThat(mapper.canAccept(LocalDateTime.now()), is(false));
+		assertThat(mapper.canAccept(OffsetDateTime.now()), is(false));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/TimeToStringParameterMapperTest.java
@@ -11,8 +11,11 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.temporal.TemporalAccessor;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class TimeToStringParameterMapperTest {
 
@@ -48,4 +51,22 @@ public class TimeToStringParameterMapperTest {
 		assertThat(mapper.canAccept(LocalDateTime.now()), is(false));
 		assertThat(mapper.canAccept(OffsetDateTime.now()), is(false));
 	}
+
+	@Test
+	public void testTargetType() throws Exception {
+		TimeToStringParameterMapper mapper = new TimeToStringParameterMapper();
+
+		assertThat(mapper.targetType(), sameInstance(TemporalAccessor.class));
+	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new TimeToStringParameterMapper());
+
+		LocalTime localTime = LocalTime.of(11, 22, 33);
+
+		assertThat(manager.toJdbc(localTime, null), is("112233"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapperTest.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.YearMonth;
+
+import org.junit.Test;
+
+public class YearMonthToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		YearMonthToStringParameterMapper mapper = new YearMonthToStringParameterMapper();
+		YearMonth yearMonth = YearMonth.of(2020, 4);
+
+		assertThat(mapper.toJdbc(yearMonth, null, null), is("202004"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearMonthToStringParameterMapperTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.YearMonth;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class YearMonthToStringParameterMapperTest {
 
@@ -17,4 +20,15 @@ public class YearMonthToStringParameterMapperTest {
 
 		assertThat(mapper.toJdbc(yearMonth, null, null), is("202004"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new YearMonthToStringParameterMapper());
+
+		YearMonth yearMonth = YearMonth.of(2020, 4);
+
+		assertThat(manager.toJdbc(yearMonth, null), is("202004"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapperTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.Year;
 
 import org.junit.Test;
+
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class YearToStringParameterMapperTest {
 
@@ -17,4 +20,15 @@ public class YearToStringParameterMapperTest {
 
 		assertThat(mapper.toJdbc(year, null, null), is("2020"));
 	}
+
+	@Test
+	public void testManagerToJdbc() throws Exception {
+		BindParameterMapperManager manager = new BindParameterMapperManager(Clock.systemDefaultZone());
+		manager.addMapper(new YearToStringParameterMapper());
+
+		Year year = Year.of(2020);
+
+		assertThat(manager.toJdbc(year, null), is("2020"));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapperTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parameter/mapper/legacy/YearToStringParameterMapperTest.java
@@ -1,0 +1,20 @@
+package jp.co.future.uroborosql.parameter.mapper.legacy;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+import java.time.Year;
+
+import org.junit.Test;
+
+public class YearToStringParameterMapperTest {
+
+	@Test
+	public void test() throws ParseException {
+		YearToStringParameterMapper mapper = new YearToStringParameterMapper();
+		Year year = Year.of(2020);
+
+		assertThat(mapper.toJdbc(year, null, null), is("2020"));
+	}
+}

--- a/src/test/java/jp/co/future/uroborosql/store/NioSqlManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/store/NioSqlManagerTest.java
@@ -390,7 +390,7 @@ public class NioSqlManagerTest {
 			Thread.sleep(WAIT_TIME);
 
 			assertThat(manager.existSql(sqlName), is(true));
-			assertThat(manager.getSql(sqlName), containsString("default")); // dialect が削除された段階でdefalutが有効になる
+			assertThat(manager.getSql(sqlName), containsString("default")); // dialect が削除された段階でdefaultが有効になる
 
 			Thread.sleep(WAIT_TIME);
 
@@ -746,7 +746,7 @@ public class NioSqlManagerTest {
 			Thread.sleep(WAIT_TIME);
 
 			assertThat(manager.existSql(sqlName), is(true));
-			assertThat(manager.getSql(sqlName), containsString("default")); // dialect が削除された段階でdefalutが有効になる
+			assertThat(manager.getSql(sqlName), containsString("default")); // dialect が削除された段階でdefaultが有効になる
 
 			Thread.sleep(WAIT_TIME);
 

--- a/src/test/java/jp/co/future/uroborosql/testlog/TestAppender.java
+++ b/src/test/java/jp/co/future/uroborosql/testlog/TestAppender.java
@@ -34,10 +34,10 @@ public class TestAppender extends AbstractEncodedAppender<ILoggingEvent> {
 		bufferedReader.lines().forEach(this::append);
 	}
 
-	private void append(String encodeedLog) {
+	private void append(String encodedLog) {
 		List<String> logs = LOGS_LIST.get();
 		if (logs != null) {
-			logs.add(encodeedLog);
+			logs.add(encodedLog);
 		}
 	}
 


### PR DESCRIPTION
In legacy system, date or date and time may be stored in a character string type (char or varchar) column.  
Added custom ParameterMapper that converts java.time API-> String so that conversion to and from java.time API types (LocalDate, OffsetDateTime, etc.) is possible in such a system.  
In addition, modified to DateTimeApiPropertyMapper so that conversion to string type column-> java.time API can be performed.