### PR TITLE
Initial value of InsertsType changed from BULK to BATCH.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractAgent.java
@@ -79,16 +79,17 @@ public abstract class AbstractAgent implements SqlAgent {
 	/** 例外発生にロールバックが必要なDBでリトライを実現するために設定するSavepointの名前 */
 	protected static final String RETRY_SAVEPOINT_NAME = "__retry_savepoint";
 
-	/** バッチカウントの初期値 */
-	protected static final int DEFAULT_BATCH_COUNT = 1000;
+	/** BATCH-INSERT用のバッチフレームの判定条件 */
+	protected static final InsertsCondition<Object> DEFAULT_BATCH_INSERTS_WHEN_CONDITION = (context, count,
+			row) -> count == 1000;
 
-	/** 一括INSERT用のバッチフレームの判定条件 */
-	protected static final InsertsCondition<Object> DEFAULT_INSERTS_WHEN_CONDITION = (context, count,
-			row) -> count == DEFAULT_BATCH_COUNT;
+	/** BULK-INSERT用のバッチフレームの判定条件 */
+	protected static final InsertsCondition<Object> DEFAULT_BULK_INSERTS_WHEN_CONDITION = (context, count,
+			row) -> count == 10;
 
 	/** 一括UPDATE用のバッチフレームの判定条件 */
 	protected static final UpdatesCondition<Object> DEFAULT_UPDATES_WHEN_CONDITION = (context, count,
-			row) -> count == DEFAULT_BATCH_COUNT;
+			row) -> count == 1000;
 
 	/** カバレッジハンドラ */
 	protected static AtomicReference<CoverageHandler> coverageHandlerRef = new AtomicReference<>();
@@ -121,7 +122,7 @@ public abstract class AbstractAgent implements SqlAgent {
 	protected CaseFormat defaultMapKeyCaseFormat = CaseFormat.UPPER_SNAKE_CASE;
 
 	/** デフォルトの{@link InsertsType} */
-	protected InsertsType defaultInsertsType = InsertsType.BULK;
+	protected InsertsType defaultInsertsType = InsertsType.BATCH;
 
 	static {
 		// SQLカバレッジ取得用のクラス名を設定する。指定がない場合、またはfalseが指定された場合はカバレッジを収集しない。
@@ -664,7 +665,9 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> int inserts(final Class<E> entityType, final Stream<E> entities) {
-		return inserts(entityType, entities, DEFAULT_INSERTS_WHEN_CONDITION);
+		return inserts(entityType, entities,
+				InsertsType.BATCH.equals(defaultInsertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+						: DEFAULT_BULK_INSERTS_WHEN_CONDITION);
 	}
 
 	/**
@@ -674,7 +677,10 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> int inserts(final Class<E> entityType, final Stream<E> entities, final InsertsType insertsType) {
-		return inserts(entityType, entities, DEFAULT_INSERTS_WHEN_CONDITION, insertsType);
+		return inserts(entityType, entities,
+				InsertsType.BATCH.equals(insertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+						: DEFAULT_BULK_INSERTS_WHEN_CONDITION,
+				insertsType);
 	}
 
 	/**
@@ -719,7 +725,8 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> int inserts(final Stream<E> entities) {
-		return inserts(entities, DEFAULT_INSERTS_WHEN_CONDITION);
+		return inserts(entities, InsertsType.BATCH.equals(defaultInsertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+				: DEFAULT_BULK_INSERTS_WHEN_CONDITION);
 	}
 
 	/**
@@ -729,7 +736,8 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> int inserts(final Stream<E> entities, final InsertsType insertsType) {
-		return inserts(entities, DEFAULT_INSERTS_WHEN_CONDITION, insertsType);
+		return inserts(entities, InsertsType.BATCH.equals(insertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+				: DEFAULT_BULK_INSERTS_WHEN_CONDITION, insertsType);
 	}
 
 	/**
@@ -768,7 +776,9 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> Stream<E> insertsAndReturn(final Class<E> entityType, final Stream<E> entities) {
-		return insertsAndReturn(entityType, entities, DEFAULT_INSERTS_WHEN_CONDITION);
+		return insertsAndReturn(entityType, entities,
+				InsertsType.BATCH.equals(defaultInsertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+						: DEFAULT_BULK_INSERTS_WHEN_CONDITION);
 	}
 
 	/**
@@ -779,7 +789,10 @@ public abstract class AbstractAgent implements SqlAgent {
 	@Override
 	public <E> Stream<E> insertsAndReturn(final Class<E> entityType, final Stream<E> entities,
 			final InsertsType insertsType) {
-		return insertsAndReturn(entityType, entities, DEFAULT_INSERTS_WHEN_CONDITION, insertsType);
+		return insertsAndReturn(entityType, entities,
+				InsertsType.BATCH.equals(insertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+						: DEFAULT_BULK_INSERTS_WHEN_CONDITION,
+				insertsType);
 	}
 
 	/**
@@ -824,7 +837,9 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> Stream<E> insertsAndReturn(final Stream<E> entities) {
-		return insertsAndReturn(entities, DEFAULT_INSERTS_WHEN_CONDITION);
+		return insertsAndReturn(entities,
+				InsertsType.BATCH.equals(defaultInsertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+						: DEFAULT_BULK_INSERTS_WHEN_CONDITION);
 	}
 
 	/**
@@ -834,7 +849,8 @@ public abstract class AbstractAgent implements SqlAgent {
 	 */
 	@Override
 	public <E> Stream<E> insertsAndReturn(final Stream<E> entities, final InsertsType insertsType) {
-		return insertsAndReturn(entities, DEFAULT_INSERTS_WHEN_CONDITION, insertsType);
+		return insertsAndReturn(entities, InsertsType.BATCH.equals(insertsType) ? DEFAULT_BATCH_INSERTS_WHEN_CONDITION
+				: DEFAULT_BULK_INSERTS_WHEN_CONDITION, insertsType);
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentFactoryImpl.java
@@ -341,7 +341,7 @@ public class SqlAgentFactoryImpl implements SqlAgentFactory {
 	@Override
 	public InsertsType getDefaultInsertsType() {
 		return InsertsType.valueOf(settings.getOrDefault(PROPS_KEY_DEFAULT_INSERTS_TYPE,
-				InsertsType.BULK.toString()));
+				InsertsType.BATCH.toString()));
 	}
 
 	/**

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,6 +56,23 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			})), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -69,6 +87,30 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 	}
 
 	/**
+	 * Entityを使った一括挿入処理のテストケース（Streamが空の場合）。
+	 */
+	@Test
+	public void testInsertsEmpty() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> emptyList = Collections.emptyList();
+			assertThat(agent.inserts(emptyList.stream()), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			List<Product> emptyList = Collections.emptyList();
+			assertThat(agent.inserts(emptyList.stream()), is(0));
+		});
+	}
+
+	/**
 	 * Entityを使った一括挿入処理のテストケース。
 	 */
 	@Test
@@ -76,6 +118,23 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BATCH), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -97,6 +156,23 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BULK), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			assertThat(agent.inserts(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -118,6 +194,23 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			})), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -135,10 +228,98 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 	 * Entityを使った一括挿入処理のテストケース。
 	 */
 	@Test
+	public void testInsertsWithEntityTypeAndInsertsType() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BATCH), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BULK), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BATCH), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			assertThat(agent.inserts(Product.class, agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BULK), is(2));
+			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+		});
+	}
+
+	/**
+	 * Entityを使った一括挿入処理のテストケース。
+	 */
+	@Test
 	public void testInsertsAndReturn() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			})).collect(Collectors.toList());
+
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -154,6 +335,30 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 	}
 
 	/**
+	 * Entityを使った一括挿入処理のテストケース（Streamが空の場合）。
+	 */
+	@Test
+	public void testInsertsAndReturnEmpty() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> emptyList = Collections.emptyList();
+			assertThat(agent.insertsAndReturn(emptyList.stream()).collect(Collectors.toList()).size(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			List<Product> emptyList = Collections.emptyList();
+			assertThat(agent.insertsAndReturn(emptyList.stream()).collect(Collectors.toList()).size(), is(0));
+		});
+	}
+
+	/**
 	 * Entityを使った一括挿入処理のテストケース。
 	 */
 	@Test
@@ -161,6 +366,24 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BATCH).collect(Collectors.toList());
+
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -183,6 +406,24 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
+				e.setProductId(e.getProductId() + 10);
+				e.setProductName(e.getProductName() + "_new");
+				e.setProductKanaName(e.getProductKanaName() + "_new");
+				e.setProductDescription(e.getProductDescription() + "_new");
+				return e;
+			}), InsertsType.BULK).collect(Collectors.toList());
+
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
 		agent.required(() -> {
 			List<Product> insertedEntities = agent.insertsAndReturn(agent.query(Product.class).stream().map(e -> {
 				e.setProductId(e.getProductId() + 10);
@@ -205,6 +446,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
 
+		agent.setDefaultInsertsType(InsertsType.BATCH);
 		agent.required(() -> {
 			List<Product> insertedEntities = agent
 					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
@@ -215,6 +457,102 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 						return e;
 					})).collect(Collectors.toList());
 
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent
+					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
+						e.setProductId(e.getProductId() + 10);
+						e.setProductName(e.getProductName() + "_new");
+						e.setProductKanaName(e.getProductKanaName() + "_new");
+						e.setProductDescription(e.getProductDescription() + "_new");
+						return e;
+					})).collect(Collectors.toList());
+
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+	}
+
+	/**
+	 * Entityを使った一括挿入処理のテストケース。
+	 */
+	@Test
+	public void testInsertsAndReturnWithTypeAndInsertsType() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent
+					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
+						e.setProductId(e.getProductId() + 10);
+						e.setProductName(e.getProductName() + "_new");
+						e.setProductKanaName(e.getProductKanaName() + "_new");
+						e.setProductDescription(e.getProductDescription() + "_new");
+						return e;
+					}), InsertsType.BATCH)
+					.collect(Collectors.toList());
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BATCH);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent
+					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
+						e.setProductId(e.getProductId() + 10);
+						e.setProductName(e.getProductName() + "_new");
+						e.setProductKanaName(e.getProductKanaName() + "_new");
+						e.setProductDescription(e.getProductDescription() + "_new");
+						return e;
+					}), InsertsType.BULK)
+					.collect(Collectors.toList());
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent
+					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
+						e.setProductId(e.getProductId() + 10);
+						e.setProductName(e.getProductName() + "_new");
+						e.setProductKanaName(e.getProductKanaName() + "_new");
+						e.setProductDescription(e.getProductDescription() + "_new");
+						return e;
+					}), InsertsType.BATCH)
+					.collect(Collectors.toList());
+			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
+			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
+		});
+
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.setDefaultInsertsType(InsertsType.BULK);
+		agent.required(() -> {
+			List<Product> insertedEntities = agent
+					.insertsAndReturn(Product.class, agent.query(Product.class).stream().map(e -> {
+						e.setProductId(e.getProductId() + 10);
+						e.setProductName(e.getProductName() + "_new");
+						e.setProductKanaName(e.getProductKanaName() + "_new");
+						e.setProductDescription(e.getProductDescription() + "_new");
+						return e;
+					}), InsertsType.BULK)
+					.collect(Collectors.toList());
 			assertThat(insertedEntities.get(0).getProductName(), is("商品名1_new"));
 			assertThat(insertedEntities.get(1).getVersionNo(), is(0));
 		});


### PR DESCRIPTION
Since BATCH-INSERT has higher performance than BULK-INSERT, BATCH-INSERT is the default.  
Also, when BULK-INSERT is specified, the default value of the number of records to be inserted at one time is changed from 1000 to 10.
(In the case of 1000 cases, INSERT performance may deteriorate depending on the DB type)