### PR TITLE
Fix to accept Object type as an argument of each method of StringFunction.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -756,7 +756,7 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		String camelColName = col.getCamelColumnName();
 		// フィールドがセットされていない場合はカラム自体を削る
 		if (isStringType(col.getDataType())) {
-			if (emptyStringEqualsNull) {
+			if (emptyStringEqualsNull && !col.isNullable()) {
 				original.append("/*IF SF.isNotEmpty(").append(camelColName).append(") */")
 						.append(System.lineSeparator());
 			} else {

--- a/src/main/java/jp/co/future/uroborosql/utils/StringFunction.java
+++ b/src/main/java/jp/co/future/uroborosql/utils/StringFunction.java
@@ -7,6 +7,7 @@
 package jp.co.future.uroborosql.utils;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import jp.co.future.uroborosql.dialect.Dialect;
 
@@ -58,7 +59,7 @@ public final class StringFunction {
 	 * @return null または 空文字の場合<code>true</code>
 	 */
 	public boolean isEmpty(final Object obj) {
-		return StringUtils.isEmpty(Objects.toString(obj, ""));
+		return StringUtils.isEmpty(getStringValue(obj, ""));
 	}
 
 	/**
@@ -78,7 +79,7 @@ public final class StringFunction {
 	 * @return null、空文字のいずれでもない場合<code>true</code>
 	 */
 	public boolean isNotEmpty(final Object obj) {
-		return StringUtils.isNotEmpty(Objects.toString(obj, ""));
+		return StringUtils.isNotEmpty(getStringValue(obj, ""));
 	}
 
 	/**
@@ -98,7 +99,7 @@ public final class StringFunction {
 	 * @return null または 空文字もしくは空白の場合<code>true</code>
 	 */
 	public boolean isBlank(final Object obj) {
-		return StringUtils.isBlank(Objects.toString(obj, ""));
+		return StringUtils.isBlank(getStringValue(obj, ""));
 	}
 
 	/**
@@ -118,7 +119,7 @@ public final class StringFunction {
 	 * @return null、空文字、空白のいずれでもない場合<code>true</code>
 	 */
 	public boolean isNotBlank(final Object obj) {
-		return StringUtils.isNotBlank(Objects.toString(obj, ""));
+		return StringUtils.isNotBlank(getStringValue(obj, ""));
 	}
 
 	/**
@@ -134,11 +135,11 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#trim(String)
 	 *
-	 * @param str トリムする文字列
+	 * @param obj トリムする文字列を表すオブジェクト
 	 * @return トリム後の文字列。入力が<code>null</code>の場合は<code>null</code>
 	 */
-	public String trim(final String str) {
-		return StringUtils.trim(str);
+	public String trim(final Object obj) {
+		return StringUtils.trim(getStringValue(obj));
 	}
 
 	/**
@@ -155,11 +156,11 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#trimToEmpty(String)
 	 *
-	 * @param str トリムする文字列
+	 * @param obj トリムする文字列を表すオブジェクト
 	 * @return トリム後の文字列。入力が<code>null</code>の場合は空文字となる
 	 */
-	public String trimToEmpty(final String str) {
-		return StringUtils.trimToEmpty(str);
+	public String trimToEmpty(final Object obj) {
+		return StringUtils.trimToEmpty(getStringValue(obj));
 	}
 
 	/**
@@ -176,12 +177,12 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#left(String, int)
 	 *
-	 * @param str 対象文字列
+	 * @param obj 対象文字列を表すオブジェクト
 	 * @param len 文字数
 	 * @return 文字列の先頭から文字数で指定した長さの文字列
 	 */
-	public String left(final String str, final int len) {
-		return StringUtils.left(str, len);
+	public String left(final Object obj, final int len) {
+		return StringUtils.left(getStringValue(obj), len);
 	}
 
 	/**
@@ -198,12 +199,12 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#right(String, int)
 	 *
-	 * @param str 対象文字列
+	 * @param obj 対象文字列を表すオブジェクト
 	 * @param len 文字数
 	 * @return 文字列の最後から文字数で指定した長さの文字列
 	 */
-	public String right(final String str, final int len) {
-		return StringUtils.right(str, len);
+	public String right(final Object obj, final int len) {
+		return StringUtils.right(getStringValue(obj), len);
 	}
 
 	/**
@@ -222,13 +223,13 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#mid(String, int, int)
 	 *
-	 * @param str 対象文字列
+	 * @param obj 対象文字列を表すオブジェクト
 	 * @param pos 開始位置
 	 * @param len 文字数
 	 * @return 文字列の開始位置から文字数で指定した長さの文字列
 	 */
-	public String mid(final String str, final int pos, final int len) {
-		return StringUtils.mid(str, pos, len);
+	public String mid(final Object obj, final int pos, final int len) {
+		return StringUtils.mid(getStringValue(obj), pos, len);
 	}
 
 	/**
@@ -245,12 +246,12 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#rightPad(String, int)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @param size 文字埋め後の長さ
 	 * @return 指定した長さになるまで末尾に空白を埋めた文字列
 	 */
-	public String rightPad(final String str, final int size) {
-		return StringUtils.rightPad(str, size);
+	public String rightPad(final Object obj, final int size) {
+		return StringUtils.rightPad(getStringValue(obj), size);
 	}
 
 	/**
@@ -267,13 +268,13 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#rightPad(String, int, char)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @param size 文字埋め後の長さ
 	 * @param padChar 埋め込み文字
 	 * @return 指定した長さになるまで末尾に埋め込み文字を埋めた文字列
 	 */
-	public String rightPad(final String str, final int size, final char padChar) {
-		return StringUtils.rightPad(str, size, padChar);
+	public String rightPad(final Object obj, final int size, final char padChar) {
+		return StringUtils.rightPad(getStringValue(obj), size, padChar);
 	}
 
 	/**
@@ -290,12 +291,12 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#leftPad(String, int)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @param size 文字埋め後の長さ
 	 * @return 指定した長さになるまで先頭に空白を埋めた文字列
 	 */
-	public String leftPad(final String str, final int size) {
-		return StringUtils.leftPad(str, size);
+	public String leftPad(final Object obj, final int size) {
+		return StringUtils.leftPad(getStringValue(obj), size);
 	}
 
 	/**
@@ -312,13 +313,13 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#leftPad(String, int, char)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @param size 文字埋め後の長さ
 	 * @param padChar 埋め込み文字
 	 * @return 指定した長さになるまで末尾に埋め込み文字を埋めた文字列
 	 */
-	public String leftPad(final String str, final int size, final char padChar) {
-		return StringUtils.leftPad(str, size, padChar);
+	public String leftPad(final Object obj, final int size, final char padChar) {
+		return StringUtils.leftPad(getStringValue(obj), size, padChar);
 	}
 
 	/**
@@ -336,11 +337,11 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#split(String)
 	 *
-	 * @param str  変換元文字列 または {@code null}
+	 * @param obj  変換元文字列を表すオブジェクト または {@code null}
 	 * @return 空白で区切った文字列配列
 	 */
-	public String[] split(final String str) {
-		return StringUtils.split(str);
+	public String[] split(final Object obj) {
+		return StringUtils.split(getStringValue(obj));
 	}
 
 	/**
@@ -358,12 +359,12 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#split(String, char)
 	 *
-	 * @param str 変換元文字列 または {@code null}
+	 * @param obj 変換元文字列を表すオブジェクト または {@code null}
 	 * @param separatorChar 区切り文字
 	 * @return 区切り文字で区切った文字列配列
 	 */
-	public String[] split(final String str, final char separatorChar) {
-		return StringUtils.split(str, separatorChar);
+	public String[] split(final Object obj, final char separatorChar) {
+		return StringUtils.split(getStringValue(obj), separatorChar);
 	}
 
 	/**
@@ -381,13 +382,13 @@ public final class StringFunction {
 	 *
 	 * @see StringUtils#split(String, String, int)
 	 *
-	 * @param str 変換元文字列 または {@code null}
+	 * @param obj 変換元文字列を表すオブジェクト または {@code null}
 	 * @param separatorChars 区切り文字
 	 * @param max 作成する配列の最大値。最大値を超える場合は最後の要素に残りのすべての文字列が入る
 	 * @return 区切り文字で区切った文字列配列
 	 */
-	public String[] split(final String str, final String separatorChars, final int max) {
-		return StringUtils.split(str, separatorChars, max);
+	public String[] split(final Object obj, final String separatorChars, final int max) {
+		return StringUtils.split(getStringValue(obj), separatorChars, max);
 	}
 
 	/**
@@ -403,11 +404,11 @@ public final class StringFunction {
 	 * @see StringUtils#capitalize(String)
 	 * @see #uncapitalize(String)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @return 先頭を大文字にした文字列
 	 */
-	public String capitalize(final String str) {
-		return StringUtils.capitalize(str);
+	public String capitalize(final Object obj) {
+		return StringUtils.capitalize(getStringValue(obj));
 	}
 
 	/**
@@ -423,11 +424,11 @@ public final class StringFunction {
 	 * @see StringUtils#uncapitalize(String)
 	 * @see #capitalize(String)
 	 *
-	 * @param str 文字列
+	 * @param obj 文字列を表すオブジェクト
 	 * @return 先頭を小文字にした文字列
 	 */
-	public String uncapitalize(final String str) {
-		return StringUtils.uncapitalize(str);
+	public String uncapitalize(final Object obj) {
+		return StringUtils.uncapitalize(getStringValue(obj));
 	}
 
 	/**
@@ -442,17 +443,18 @@ public final class StringFunction {
 	 *  - null -&gt; %
 	 * </pre>
 	 *
-	 * @param text テキスト
+	 * @param obj テキストを表すオブジェクト
 	 * @return 指定されたテキストで始まるLIKE句用の検索文字列
 	 */
-	public String startsWith(final CharSequence text) {
+	public String startsWith(final Object obj) {
 		if (dialect == null) {
 			throw new IllegalStateException("dialect is not set.");
 		}
-		if (StringUtils.isEmpty(text)) {
+		CharSequence val = getStringValue(obj);
+		if (StringUtils.isEmpty(val)) {
 			return "%";
 		} else {
-			return dialect.escapeLikePattern(text) + "%";
+			return dialect.escapeLikePattern(val) + "%";
 		}
 	}
 
@@ -468,17 +470,18 @@ public final class StringFunction {
 	 *  - null -&gt; %
 	 * </pre>
 	 *
-	 * @param text テキスト
+	 * @param obj テキストを表すオブジェクト
 	 * @return 指定されたテキストを含むLIKE句用の検索文字列
 	 */
-	public String contains(final CharSequence text) {
+	public String contains(final Object obj) {
 		if (dialect == null) {
 			throw new IllegalStateException("dialect is not set.");
 		}
-		if (StringUtils.isEmpty(text)) {
+		CharSequence val = getStringValue(obj);
+		if (StringUtils.isEmpty(val)) {
 			return "%";
 		} else {
-			return "%" + dialect.escapeLikePattern(text) + "%";
+			return "%" + dialect.escapeLikePattern(val) + "%";
 		}
 	}
 
@@ -494,17 +497,18 @@ public final class StringFunction {
 	 *  - null -&gt; %
 	 * </pre>
 	 *
-	 * @param text テキスト
+	 * @param obj テキストを表すオブジェクト
 	 * @return 指定されたテキストで終わるLIKE句用の検索文字列
 	 */
-	public String endsWith(final CharSequence text) {
+	public String endsWith(final Object obj) {
 		if (dialect == null) {
 			throw new IllegalStateException("dialect is not set.");
 		}
-		if (StringUtils.isEmpty(text)) {
+		CharSequence val = getStringValue(obj);
+		if (StringUtils.isEmpty(val)) {
 			return "%";
 		} else {
-			return "%" + dialect.escapeLikePattern(text);
+			return "%" + dialect.escapeLikePattern(val);
 		}
 	}
 
@@ -557,6 +561,32 @@ public final class StringFunction {
 	 */
 	public Long incrementLong(final Long num) {
 		return num + 1L;
+	}
+
+	/**
+	 * 引数のオブジェクトを文字列に変換した値を取得する.
+	 *
+	 * @param obj 変換対象オブジェクト
+	 * @return オブジェクトの文字列表現
+	 */
+	private String getStringValue(final Object obj) {
+		return getStringValue(obj, null);
+	}
+
+	/**
+	 * 引数のオブジェクトを文字列に変換した値を取得する.
+	 *
+	 * @param obj 変換対象オブジェクト
+	 * @param nullDefault objが<code>null</code>の場合の初期値
+	 * @return オブジェクトの文字列表現
+	 */
+	private String getStringValue(final Object obj, final String nullDefault) {
+		Object val = obj instanceof Optional ? ((Optional<?>) obj).orElse(null) : obj;
+		if (val instanceof String) {
+			return String.class.cast(val);
+		} else {
+			return Objects.toString(val, nullDefault);
+		}
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/client/command/GenerateCommandTest.java
+++ b/src/test/java/jp/co/future/uroborosql/client/command/GenerateCommandTest.java
@@ -78,7 +78,7 @@ public class GenerateCommandTest extends ReaderTestSupport {
 		assertThat(command.execute(reader, "generate insert GEN_TEST".split("\\s+"), sqlConfig, new Properties()),
 				is(true));
 		assertThat(trimWhitespace(out.toString()), is(
-				"INSERT /* _SQL_ID_ */ INTO GEN_TEST ( /*IF id != null */  , \"ID\" /*END*/ /*IF SF.isNotEmpty(name) */  , \"NAME\" /*END*/ /*IF lockNo != null */  , \"LOCK_NO\" /*END*/ ) VALUES ( /*IF id != null */  , /*id*/'' /*END*/ /*IF SF.isNotEmpty(name) */  , /*name*/'' /*END*/ /*IF lockNo != null */  , /*lockNo*/'' /*END*/ )"));
+				"INSERT /* _SQL_ID_ */ INTO GEN_TEST ( /*IF id != null */  , \"ID\" /*END*/ /*IF name != null */  , \"NAME\" /*END*/ /*IF lockNo != null */  , \"LOCK_NO\" /*END*/ ) VALUES ( /*IF id != null */  , /*id*/'' /*END*/ /*IF name != null */  , /*name*/'' /*END*/ /*IF lockNo != null */  , /*lockNo*/'' /*END*/ )"));
 	}
 
 	private String trimWhitespace(final String str) {
@@ -110,7 +110,7 @@ public class GenerateCommandTest extends ReaderTestSupport {
 				"jp.co.future.uroborosql.mapping.FieldIncrementOptimisticLockSupplier");
 		command.execute(reader, "generate update GEN_TEST".split("\\s+"), sqlConfig, props);
 		assertThat(trimWhitespace(out.toString()), is(
-				"UPDATE /* _SQL_ID_ */ GEN_TEST SET /*IF SF.isNotEmpty(name) */  , \"NAME\" = /*name*/'' /*END*/  , \"LOCK_NO\" = /*SF.increment(lockNo)*/ WHERE   \"ID\" = /*id*/''  AND \"LOCK_NO\" = /*lockNo*/''"));
+				"UPDATE /* _SQL_ID_ */ GEN_TEST SET /*IF name != null */  , \"NAME\" = /*name*/'' /*END*/  , \"LOCK_NO\" = /*SF.increment(lockNo)*/ WHERE   \"ID\" = /*id*/''  AND \"LOCK_NO\" = /*lockNo*/''"));
 	}
 
 	@Test
@@ -119,7 +119,7 @@ public class GenerateCommandTest extends ReaderTestSupport {
 		Properties props = new Properties();
 		command.execute(reader, "generate update GEN_TEST".split("\\s+"), sqlConfig, props);
 		assertThat(trimWhitespace(out.toString()), is(
-				"UPDATE /* _SQL_ID_ */ GEN_TEST SET /*IF SF.isNotEmpty(name) */  , \"NAME\" = /*name*/'' /*END*/ /*IF lockNo != null */  , \"LOCK_NO\" = /*lockNo*/'' /*END*/ WHERE   \"ID\" = /*id*/''"));
+				"UPDATE /* _SQL_ID_ */ GEN_TEST SET /*IF name != null */  , \"NAME\" = /*name*/'' /*END*/ /*IF lockNo != null */  , \"LOCK_NO\" = /*lockNo*/'' /*END*/ WHERE   \"ID\" = /*id*/''"));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerMultiColumnCommentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerMultiColumnCommentTest.java
@@ -518,7 +518,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 			SqlContext ctx = handler.createSelectContext(agent, metadata, null, true);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			try (ResultSet rs = agent.query(ctx)) {
 				assertThat(rs.next(), is(true));
@@ -535,7 +535,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 			SqlContext ctx = handler.createInsertContext(agent, metadata, null);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			ctx.param("id", 1).param("name", "name1").param("age", 20)
 					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
@@ -578,7 +578,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 			SqlContext ctx = handler.createUpdateContext(agent, metadata, null, true);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			ctx.param("id", 1).param("name", "updatename");
 			assertThat(agent.update(ctx), is(1));

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -1755,7 +1755,7 @@ public class DefaultEntityHandlerTest {
 			SqlContext ctx = handler.createSelectContext(agent, metadata, null, true);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			try (ResultSet rs = agent.query(ctx)) {
 				assertThat(rs.next(), is(true));
@@ -1798,7 +1798,7 @@ public class DefaultEntityHandlerTest {
 			SqlContext ctx = handler.createInsertContext(agent, metadata, null);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			ctx.param("id", 1).param("name", "name1").param("age", 20)
 					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
@@ -1841,7 +1841,7 @@ public class DefaultEntityHandlerTest {
 			SqlContext ctx = handler.createUpdateContext(agent, metadata, null, true);
 
 			String sql = ctx.getSql();
-			assertThat(sql, containsString("SF.isNotEmpty"));
+			assertThat(sql, containsString("IF memo != null"));
 
 			ctx.param("id", 1).param("name", "updatename");
 			assertThat(agent.update(ctx), is(1));

--- a/src/test/java/jp/co/future/uroborosql/utils/StringFunctionTest.java
+++ b/src/test/java/jp/co/future/uroborosql/utils/StringFunctionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -46,6 +47,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.startsWith("a%bc"), is("a$%bc%"));
 		assertThat(expressionFunction.startsWith(""), is("%"));
 		assertThat(expressionFunction.startsWith(null), is("%"));
+		assertThat(expressionFunction.startsWith(123), is("123%"));
+		assertThat(expressionFunction.startsWith(Optional.empty()), is("%"));
+		assertThat(expressionFunction.startsWith(Optional.of("")), is("%"));
+		assertThat(expressionFunction.startsWith(Optional.of("abc")), is("abc%"));
+		assertThat(expressionFunction.startsWith(Optional.of(123)), is("123%"));
 
 		Map<Object, Object> root = new HashMap<>();
 		OgnlContext context = (OgnlContext) Ognl.createDefaultContext(root);
@@ -67,6 +73,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.contains("a%bc"), is("%a$%bc%"));
 		assertThat(expressionFunction.contains(""), is("%"));
 		assertThat(expressionFunction.contains(null), is("%"));
+		assertThat(expressionFunction.contains(123), is("%123%"));
+		assertThat(expressionFunction.contains(Optional.empty()), is("%"));
+		assertThat(expressionFunction.contains(Optional.of("")), is("%"));
+		assertThat(expressionFunction.contains(Optional.of("abc")), is("%abc%"));
+		assertThat(expressionFunction.contains(Optional.of(123)), is("%123%"));
 
 		Map<Object, Object> root = new HashMap<>();
 		OgnlContext context = (OgnlContext) Ognl.createDefaultContext(root);
@@ -88,6 +99,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.endsWith("a%bc"), is("%a$%bc"));
 		assertThat(expressionFunction.endsWith(""), is("%"));
 		assertThat(expressionFunction.endsWith(null), is("%"));
+		assertThat(expressionFunction.endsWith(123), is("%123"));
+		assertThat(expressionFunction.endsWith(Optional.empty()), is("%"));
+		assertThat(expressionFunction.endsWith(Optional.of("")), is("%"));
+		assertThat(expressionFunction.endsWith(Optional.of("abc")), is("%abc"));
+		assertThat(expressionFunction.endsWith(Optional.of(123)), is("%123"));
 
 		Map<Object, Object> root = new HashMap<>();
 		OgnlContext context = (OgnlContext) Ognl.createDefaultContext(root);
@@ -110,6 +126,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.isBlank("bob"), is(false));
 		assertThat(expressionFunction.isBlank("  bob  "), is(false));
 		assertThat(expressionFunction.isBlank(123), is(false));
+		assertThat(expressionFunction.isBlank(Optional.empty()), is(true));
+		assertThat(expressionFunction.isBlank(Optional.of("")), is(true));
+		assertThat(expressionFunction.isBlank(Optional.of(" ")), is(true));
+		assertThat(expressionFunction.isBlank(Optional.of("bob")), is(false));
+		assertThat(expressionFunction.isBlank(Optional.of(123)), is(false));
 	}
 
 	@Test
@@ -120,6 +141,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.isEmpty("bob"), is(false));
 		assertThat(expressionFunction.isEmpty("  bob  "), is(false));
 		assertThat(expressionFunction.isEmpty(123), is(false));
+		assertThat(expressionFunction.isEmpty(Optional.empty()), is(true));
+		assertThat(expressionFunction.isEmpty(Optional.of("")), is(true));
+		assertThat(expressionFunction.isEmpty(Optional.of(" ")), is(false));
+		assertThat(expressionFunction.isEmpty(Optional.of("bob")), is(false));
+		assertThat(expressionFunction.isEmpty(Optional.of(123)), is(false));
 	}
 
 	@Test
@@ -130,6 +156,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.isNotBlank("bob"), is(true));
 		assertThat(expressionFunction.isNotBlank("  bob  "), is(true));
 		assertThat(expressionFunction.isNotBlank(123), is(true));
+		assertThat(expressionFunction.isNotBlank(Optional.empty()), is(false));
+		assertThat(expressionFunction.isNotBlank(Optional.of("")), is(false));
+		assertThat(expressionFunction.isNotBlank(Optional.of(" ")), is(false));
+		assertThat(expressionFunction.isNotBlank(Optional.of("bob")), is(true));
+		assertThat(expressionFunction.isNotBlank(Optional.of(123)), is(true));
 	}
 
 	@Test
@@ -140,26 +171,41 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.isNotEmpty("bob"), is(true));
 		assertThat(expressionFunction.isNotEmpty("  bob  "), is(true));
 		assertThat(expressionFunction.isNotEmpty(123), is(true));
+		assertThat(expressionFunction.isNotEmpty(Optional.empty()), is(false));
+		assertThat(expressionFunction.isNotEmpty(Optional.of("")), is(false));
+		assertThat(expressionFunction.isNotEmpty(Optional.of(" ")), is(true));
+		assertThat(expressionFunction.isNotEmpty(Optional.of("bob")), is(true));
+		assertThat(expressionFunction.isNotEmpty(Optional.of(123)), is(true));
 	}
 
 	@Test
 	public void testTrim() throws Exception {
 		assertThat(expressionFunction.trim(null), nullValue());
 		assertThat(expressionFunction.trim(""), is(""));
-		assertThat(expressionFunction.trim(""), is(""));
 		assertThat(expressionFunction.trim("     "), is(""));
 		assertThat(expressionFunction.trim("abc"), is("abc"));
 		assertThat(expressionFunction.trim("    abc    "), is("abc"));
+		assertThat(expressionFunction.trim(Optional.empty()), is(nullValue()));
+		assertThat(expressionFunction.trim(Optional.of("")), is(""));
+		assertThat(expressionFunction.trim(Optional.of("    ")), is(""));
+		assertThat(expressionFunction.trim(Optional.of("abc")), is("abc"));
+		assertThat(expressionFunction.trim(Optional.of("   abc   ")), is("abc"));
+		assertThat(expressionFunction.trim(Optional.of(123)), is("123"));
 	}
 
 	@Test
 	public void testTrimToEmpty() throws Exception {
 		assertThat(expressionFunction.trimToEmpty(null), is(""));
 		assertThat(expressionFunction.trimToEmpty(""), is(""));
-		assertThat(expressionFunction.trimToEmpty(""), is(""));
 		assertThat(expressionFunction.trimToEmpty("     "), is(""));
 		assertThat(expressionFunction.trimToEmpty("abc"), is("abc"));
 		assertThat(expressionFunction.trimToEmpty("    abc    "), is("abc"));
+		assertThat(expressionFunction.trimToEmpty(Optional.empty()), is(""));
+		assertThat(expressionFunction.trimToEmpty(Optional.of("")), is(""));
+		assertThat(expressionFunction.trimToEmpty(Optional.of(" ")), is(""));
+		assertThat(expressionFunction.trimToEmpty(Optional.of("abc")), is("abc"));
+		assertThat(expressionFunction.trimToEmpty(Optional.of("   abc  ")), is("abc"));
+		assertThat(expressionFunction.trimToEmpty(Optional.of(123)), is("123"));
 	}
 
 	@Test
@@ -170,6 +216,13 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.left("abc", 0), is(""));
 		assertThat(expressionFunction.left("abc", 2), is("ab"));
 		assertThat(expressionFunction.left("abc", 4), is("abc"));
+		assertThat(expressionFunction.left(123, 4), is("123"));
+		assertThat(expressionFunction.left(Optional.empty(), 4), is(nullValue()));
+		assertThat(expressionFunction.left(Optional.of(""), 2), is(""));
+		assertThat(expressionFunction.left(Optional.of("abc"), 0), is(""));
+		assertThat(expressionFunction.left(Optional.of("abc"), 2), is("ab"));
+		assertThat(expressionFunction.left(Optional.of("abc"), 4), is("abc"));
+		assertThat(expressionFunction.left(Optional.of(123), 4), is("123"));
 	}
 
 	@Test
@@ -180,6 +233,13 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.right("abc", 0), is(""));
 		assertThat(expressionFunction.right("abc", 2), is("bc"));
 		assertThat(expressionFunction.right("abc", 4), is("abc"));
+		assertThat(expressionFunction.right(123, 4), is("123"));
+		assertThat(expressionFunction.right(Optional.empty(), 4), is(nullValue()));
+		assertThat(expressionFunction.right(Optional.of(""), 2), is(""));
+		assertThat(expressionFunction.right(Optional.of("abc"), 0), is(""));
+		assertThat(expressionFunction.right(Optional.of("abc"), 2), is("bc"));
+		assertThat(expressionFunction.right(Optional.of("abc"), 4), is("abc"));
+		assertThat(expressionFunction.right(Optional.of(123), 4), is("123"));
 	}
 
 	@Test
@@ -192,6 +252,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.mid("abc", 2, 4), is("c"));
 		assertThat(expressionFunction.mid("abc", 4, 2), is(""));
 		assertThat(expressionFunction.mid("abc", -2, 2), is("ab"));
+		assertThat(expressionFunction.mid(123, -2, 2), is("12"));
+		assertThat(expressionFunction.mid(Optional.empty(), 1, 2), is(nullValue()));
+		assertThat(expressionFunction.mid(Optional.of("abc"), 1, -1), is(""));
+		assertThat(expressionFunction.mid(Optional.of("abc"), 0, 4), is("abc"));
+		assertThat(expressionFunction.mid(Optional.of(123), 0, 4), is("123"));
 	}
 
 	@Test
@@ -202,6 +267,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.rightPad("bat", 5), is("bat  "));
 		assertThat(expressionFunction.rightPad("bat", 1), is("bat"));
 		assertThat(expressionFunction.rightPad("bat", -1), is("bat"));
+		assertThat(expressionFunction.rightPad(123, -1), is("123"));
+		assertThat(expressionFunction.rightPad(Optional.empty(), 3), is(nullValue()));
+		assertThat(expressionFunction.rightPad(Optional.of(""), 3), is("   "));
+		assertThat(expressionFunction.rightPad(Optional.of("bat"), 3), is("bat"));
+		assertThat(expressionFunction.rightPad(Optional.of(123), 5), is("123  "));
 	}
 
 	@Test
@@ -212,6 +282,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.rightPad("bat", 5, 'z'), is("batzz"));
 		assertThat(expressionFunction.rightPad("bat", 1, 'z'), is("bat"));
 		assertThat(expressionFunction.rightPad("bat", -1, 'z'), is("bat"));
+		assertThat(expressionFunction.rightPad(123, -1, 'z'), is("123"));
+		assertThat(expressionFunction.rightPad(Optional.empty(), 3, 'z'), is(nullValue()));
+		assertThat(expressionFunction.rightPad(Optional.of(""), 3, 'z'), is("zzz"));
+		assertThat(expressionFunction.rightPad(Optional.of("bat"), 3, 'z'), is("bat"));
+		assertThat(expressionFunction.rightPad(Optional.of(123), 5, 'z'), is("123zz"));
 	}
 
 	@Test
@@ -222,6 +297,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.leftPad("bat", 5), is("  bat"));
 		assertThat(expressionFunction.leftPad("bat", 1), is("bat"));
 		assertThat(expressionFunction.leftPad("bat", -1), is("bat"));
+		assertThat(expressionFunction.leftPad(123, -1), is("123"));
+		assertThat(expressionFunction.leftPad(Optional.empty(), 3), is(nullValue()));
+		assertThat(expressionFunction.leftPad(Optional.of(""), 3), is("   "));
+		assertThat(expressionFunction.leftPad(Optional.of("bat"), 3), is("bat"));
+		assertThat(expressionFunction.leftPad(Optional.of(123), 5), is("  123"));
 	}
 
 	@Test
@@ -232,6 +312,11 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.leftPad("bat", 5, 'z'), is("zzbat"));
 		assertThat(expressionFunction.leftPad("bat", 1, 'z'), is("bat"));
 		assertThat(expressionFunction.leftPad("bat", -1, 'z'), is("bat"));
+		assertThat(expressionFunction.leftPad(123, -1, 'z'), is("123"));
+		assertThat(expressionFunction.leftPad(Optional.empty(), 3, 'z'), is(nullValue()));
+		assertThat(expressionFunction.leftPad(Optional.of(""), 3, 'z'), is("zzz"));
+		assertThat(expressionFunction.leftPad(Optional.of("bat"), 3, 'z'), is("bat"));
+		assertThat(expressionFunction.leftPad(Optional.of(123), 5, 'z'), is("zz123"));
 	}
 
 	@Test
@@ -241,6 +326,13 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.split("abc def"), is(Matchers.arrayContaining("abc", "def")));
 		assertThat(expressionFunction.split("abc  def"), is(Matchers.arrayContaining("abc", "def")));
 		assertThat(expressionFunction.split(" abc "), is(Matchers.arrayContaining("abc")));
+		assertThat(expressionFunction.split(123), is(Matchers.arrayContaining("123")));
+		assertThat(expressionFunction.split(Optional.empty()), nullValue());
+		assertThat(expressionFunction.split(Optional.of("")), is(Matchers.emptyArray()));
+		assertThat(expressionFunction.split(Optional.of("abc def")), is(Matchers.arrayContaining("abc", "def")));
+		assertThat(expressionFunction.split(Optional.of("abc  def")), is(Matchers.arrayContaining("abc", "def")));
+		assertThat(expressionFunction.split(Optional.of(" abc ")), is(Matchers.arrayContaining("abc")));
+		assertThat(expressionFunction.split(Optional.of(123)), is(Matchers.arrayContaining("123")));
 	}
 
 	@Test
@@ -251,6 +343,12 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.split("a..b.c", '.'), is(Matchers.arrayContaining("a", "b", "c")));
 		assertThat(expressionFunction.split("a:b:c", '.'), is(Matchers.arrayContaining("a:b:c")));
 		assertThat(expressionFunction.split("a b c", ' '), is(Matchers.arrayContaining("a", "b", "c")));
+		assertThat(expressionFunction.split(Optional.empty(), '.'), nullValue());
+		assertThat(expressionFunction.split(Optional.of(""), '.'), is(Matchers.emptyArray()));
+		assertThat(expressionFunction.split(Optional.of("a.b.c"), '.'), is(Matchers.arrayContaining("a", "b", "c")));
+		assertThat(expressionFunction.split(Optional.of("a..b.c"), '.'), is(Matchers.arrayContaining("a", "b", "c")));
+		assertThat(expressionFunction.split(Optional.of("a:b:c"), '.'), is(Matchers.arrayContaining("a:b:c")));
+		assertThat(expressionFunction.split(Optional.of("a b c"), ' '), is(Matchers.arrayContaining("a", "b", "c")));
 	}
 
 	@Test
@@ -261,6 +359,16 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.split("ab   cd ef", null, 0), is(Matchers.arrayContaining("ab", "cd", "ef")));
 		assertThat(expressionFunction.split("ab:cd:ef", ":", 0), is(Matchers.arrayContaining("ab", "cd", "ef")));
 		assertThat(expressionFunction.split("ab:cd:ef", ":", 2), is(Matchers.arrayContaining("ab", "cd:ef")));
+		assertThat(expressionFunction.split(Optional.empty(), ".", 2), nullValue());
+		assertThat(expressionFunction.split(Optional.of(""), ".", 2), is(Matchers.emptyArray()));
+		assertThat(expressionFunction.split(Optional.of("ab cd ef"), null, 0),
+				is(Matchers.arrayContaining("ab", "cd", "ef")));
+		assertThat(expressionFunction.split(Optional.of("ab   cd ef"), null, 0),
+				is(Matchers.arrayContaining("ab", "cd", "ef")));
+		assertThat(expressionFunction.split(Optional.of("ab:cd:ef"), ":", 0),
+				is(Matchers.arrayContaining("ab", "cd", "ef")));
+		assertThat(expressionFunction.split(Optional.of("ab:cd:ef"), ":", 2),
+				is(Matchers.arrayContaining("ab", "cd:ef")));
 	}
 
 	@Test
@@ -269,6 +377,12 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.capitalize(""), is(""));
 		assertThat(expressionFunction.capitalize("cat"), is("Cat"));
 		assertThat(expressionFunction.capitalize("cAt"), is("CAt"));
+		assertThat(expressionFunction.capitalize(123), is("123"));
+		assertThat(expressionFunction.capitalize(Optional.empty()), nullValue());
+		assertThat(expressionFunction.capitalize(Optional.of("")), is(""));
+		assertThat(expressionFunction.capitalize(Optional.of("cat")), is("Cat"));
+		assertThat(expressionFunction.capitalize(Optional.of("cAt")), is("CAt"));
+		assertThat(expressionFunction.capitalize(Optional.of(123)), is("123"));
 	}
 
 	@Test
@@ -277,6 +391,12 @@ public class StringFunctionTest {
 		assertThat(expressionFunction.uncapitalize(""), is(""));
 		assertThat(expressionFunction.uncapitalize("Cat"), is("cat"));
 		assertThat(expressionFunction.uncapitalize("CAt"), is("cAt"));
+		assertThat(expressionFunction.uncapitalize(123), is("123"));
+		assertThat(expressionFunction.uncapitalize(Optional.empty()), nullValue());
+		assertThat(expressionFunction.uncapitalize(Optional.of("")), is(""));
+		assertThat(expressionFunction.uncapitalize(Optional.of("Cat")), is("cat"));
+		assertThat(expressionFunction.uncapitalize(Optional.of("CAt")), is("cAt"));
+		assertThat(expressionFunction.uncapitalize(Optional.of(123)), is("123"));
 	}
 
 	@Test


### PR DESCRIPTION
In SpEL, the argument of the method to be called is strictly determined, and if the type is different, the method call fails.  
In order to handle Optional type in StringFunction, the argument of each method of StringFunction was changed from String type to Object type, and it was modified to convert from Object type to String type in the method.