### PR TITLE
add Dialect#supportsEntityBulkUpdateOptimisticLock

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -1342,11 +1342,9 @@ public class SqlAgentImpl extends AbstractAgent {
 			SqlContext context = handler.createBatchUpdateContext(this, metadata, entityType);
 			context.setSqlKind(SqlKind.BATCH_UPDATE);
 
-			Optional<MappingColumn> versionColumn = updatedEntities != null
-					? MappingUtils.getVersionMappingColumn(entityType)
-					: null;
-
-			int count = 0;
+			Optional<MappingColumn> versionColumn = MappingUtils.getVersionMappingColumn(entityType);
+			int entityCount = 0;
+			int updateCount = 0;
 			List<E> entityList = new ArrayList<>();
 			for (Iterator<E> iterator = entities.iterator(); iterator.hasNext();) {
 				E entity = iterator.next();
@@ -1359,16 +1357,17 @@ public class SqlAgentImpl extends AbstractAgent {
 				if (updatedEntities != null) {
 					updatedEntities.add(entity);
 				}
+				entityCount++;
 
 				handler.setUpdateParams(context, entity);
 				context.addBatch();
 
 				if (condition.test(context, context.batchCount(), entity)) {
-					count += Arrays.stream(handler.doBatchUpdate(this, context)).sum();
+					updateCount += Arrays.stream(handler.doBatchUpdate(this, context)).sum();
 					entityList.clear();
 				}
 			}
-			count = count + (context.batchCount() != 0
+			updateCount = updateCount + (context.batchCount() != 0
 					? Arrays.stream(handler.doBatchUpdate(this, context)).sum()
 					: 0);
 
@@ -1414,7 +1413,14 @@ public class SqlAgentImpl extends AbstractAgent {
 							}).count();
 				}
 			}
-			return count;
+			if (versionColumn.isPresent()) {
+				if (getSqlConfig().getDialect().supportsEntityBulkUpdateOptimisticLock()
+						&& updateCount != entityCount) {
+					// バージョンカラムの指定があり、更新件数と更新対象Entityの件数が不一致の場合は楽観ロックエラーとする
+					throw new OptimisticLockException(context);
+				}
+			}
+			return updateCount;
 		} catch (SQLException e) {
 			throw new EntitySqlRuntimeException(SqlKind.BATCH_UPDATE, e);
 		}

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -1417,7 +1417,9 @@ public class SqlAgentImpl extends AbstractAgent {
 				if (getSqlConfig().getDialect().supportsEntityBulkUpdateOptimisticLock()
 						&& updateCount != entityCount) {
 					// バージョンカラムの指定があり、更新件数と更新対象Entityの件数が不一致の場合は楽観ロックエラーとする
-					throw new OptimisticLockException(context);
+					throw new OptimisticLockException(String.format(
+							"An error occurred due to optimistic locking.\nExecuted SQL [\n%s]\nBatch Entity Count: %d, Update Count: %d.",
+							context.getExecutableSql(), entityCount, updateCount));
 				}
 			}
 			return updateCount;

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -141,6 +141,15 @@ public interface Dialect {
 		return true;
 	}
 
+	/**
+	 * Entityバルクアップデートでの楽観ロックチェックをサポートしているか.
+	 *
+	 * @return Entityバルクアップデートでの楽観ロックチェックをサポートしている場合<code>true</code>
+	 */
+	default boolean supportsEntityBulkUpdateOptimisticLock() {
+		return true;
+	}
+
 	String getSequenceNextValSql(String sequenceName);
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/dialect/Oracle10Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Oracle10Dialect.java
@@ -29,4 +29,14 @@ public class Oracle10Dialect extends OracleDialect {
 		return majorVersion < 11;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsEntityBulkUpdateOptimisticLock()
+	 */
+	@Override
+	public boolean supportsEntityBulkUpdateOptimisticLock() {
+		return false;
+	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/dialect/Oracle11Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Oracle11Dialect.java
@@ -30,4 +30,14 @@ public class Oracle11Dialect extends OracleDialect {
 		return majorVersion == 11;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsEntityBulkUpdateOptimisticLock()
+	 */
+	@Override
+	public boolean supportsEntityBulkUpdateOptimisticLock() {
+		return false;
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -354,6 +354,30 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 	}
 
 	/**
+	 * Entityを使った一括更新処理で楽観ロックエラーが発生するケース
+	 */
+	@Test(expected = OptimisticLockException.class)
+	public void testEntityUpdatesOptimisticLockException() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteBatch.ltsv"));
+
+		agent.required(() -> {
+
+			List<Product> products = agent.query(Product.class).stream().map(p -> {
+				p.setProductName(p.getProductName() + "_new");
+				p.setProductKanaName(null);
+				return p;
+			}).collect(Collectors.toList());
+
+			// ロック番号を加算し、更新されないようにする
+			Product product1 = products.get(0);
+			product1.setVersionNo(product1.getVersionNo() + 1);
+
+			agent.updates(Product.class, products.stream());
+		});
+	}
+
+	/**
 	 * Entityを使った一括更新処理(IN句の上限を超える場合)のテストケース。
 	 */
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -84,6 +84,7 @@ public class DefaultDialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(false));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/H2DialectTest.java
@@ -92,6 +92,7 @@ public class H2DialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(false));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -92,6 +92,7 @@ public class MsSqlDialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MySqlDialectTest.java
@@ -93,6 +93,7 @@ public class MySqlDialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle10DialectTest.java
@@ -145,6 +145,7 @@ public class Oracle10DialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(true));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(false));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -145,6 +145,7 @@ public class Oracle11DialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(true));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(false));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle12DialectTest.java
@@ -145,6 +145,7 @@ public class Oracle12DialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(true));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/PostgresqlDialectTest.java
@@ -90,6 +90,7 @@ public class PostgresqlDialectTest {
 		assertThat(dialect.supportsForUpdate(), is(true));
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
+		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 	}
 
 	@Test


### PR DESCRIPTION
When performing Entity bulk update  
Added optimistic lock check to judge whether Entity has updated all records by the number of records.

Depending on the database, the number of updates  
during batch processing may not be returned correctly,  
so Dialect is used for control.