### PR TITLE
Fixed a bug in AbstractSecretColumnSqlFilter that prevented encryption when an Optional value was set for the column to be encrypted.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/filter/AbstractSecretColumnSqlFilter.java
+++ b/src/main/java/jp/co/future/uroborosql/filter/AbstractSecretColumnSqlFilter.java
@@ -22,6 +22,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import javax.crypto.Cipher;
@@ -177,8 +178,15 @@ public abstract class AbstractSecretColumnSqlFilter extends AbstractSqlFilter {
 			String key = parameter.getParameterName();
 			if (getCryptParamKeys().contains(CaseFormat.CAMEL_CASE.convert(key))) {
 				Object obj = parameter.getValue();
-				if (obj != null && obj instanceof String) {
-					String objStr = obj.toString();
+				if (obj != null) {
+					String objStr = null;
+					if (obj instanceof Optional) {
+						objStr = ((Optional<?>) obj)
+								.map(Object::toString)
+								.orElse(null);
+					} else {
+						objStr = obj.toString();
+					}
 					if (StringUtils.isNotEmpty(objStr)) {
 						try {
 							synchronized (encryptCipher) {
@@ -263,7 +271,7 @@ public abstract class AbstractSecretColumnSqlFilter extends AbstractSqlFilter {
 			}
 
 			String secretStr = secret.toString();
-			if (!secretStr.isEmpty()) {
+			if (StringUtils.isNotEmpty(secretStr)) {
 				synchronized (cipher) {
 					try {
 						return decrypt(cipher, secretKey, secretStr);

--- a/src/main/java/jp/co/future/uroborosql/filter/SecretResultSet.java
+++ b/src/main/java/jp/co/future/uroborosql/filter/SecretResultSet.java
@@ -23,7 +23,7 @@ import jp.co.future.uroborosql.utils.CaseFormat;
  */
 public class SecretResultSet extends AbstractResultSetWrapper {
 
-	private Function<Object, String> decode;
+	private final Function<Object, String> decode;
 
 	/**
 	 * キャラクタセット（デフォルトUTF-8）

--- a/src/test/java/jp/co/future/uroborosql/store/SqlManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/store/SqlManagerTest.java
@@ -160,7 +160,7 @@ public class SqlManagerTest {
 		SqlManagerImpl manager = new SqlManagerImpl(loadPaths);
 		manager.initialize();
 
-		assertThat(manager.getSqlPathList().size(), is(36));
+		assertThat(manager.getSqlPathList().size(), is(37));
 	}
 
 	@Test

--- a/src/test/resources/sql/example/insert_product_for_optional.sql
+++ b/src/test/resources/sql/example/insert_product_for_optional.sql
@@ -1,0 +1,38 @@
+INSERT
+INTO
+	PRODUCT
+(
+	PRODUCT_ID
+/*IF product_name != null */
+,	PRODUCT_NAME
+/*END*/
+/*IF product_kana_name != null */
+,	PRODUCT_KANA_NAME
+/*END*/
+/*IF jan_code != null */
+,	JAN_CODE
+/*END*/
+/*IF product_description != null */
+,	PRODUCT_DESCRIPTION
+/*END*/
+,	INS_DATETIME
+,	UPD_DATETIME
+,	VERSION_NO
+) VALUES (
+	/*product_id*/
+/*IF product_name != null */
+,	/*product_name*/
+/*END*/
+/*IF product_kana_name != null */
+,	/*product_kana_name*/
+/*END*/
+/*IF jan_code != null */
+,	/*jan_code*/
+/*END*/
+/*IF product_description != null */
+,	/*product_description*/
+/*END*/
+,	/*ins_datetime*/
+,	/*upd_datetime*/
+,	/*version_no*/
+)


### PR DESCRIPTION
AbstractSecretColumnSqlFilter sets the value of Optional for the column to be encrypted,  
and if the Optional holds a value, it should be encrypted, but the existing implementation does not allow encryption if it is of type Optional.

This fix makes it so that the case where the Optional type holds a value is also subject to encryption.