### PR TITLE
fix remove first comma regexp

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -75,12 +75,13 @@ public class SqlContextImpl implements SqlContext {
 
 	/** where句の直後にくるANDやORを除外するための正規表現 */
 	protected static final Pattern WHERE_CLAUSE_PATTERN = Pattern
-			.compile("(?i)(?<clause>(^|\\s+)(WHERE\\s+(--.*|/\\*.*\\*/\\s*)*\\s*))(AND\\s+|OR\\s+)");
+			.compile("(?i)(?<clause>(^|\\s+)(WHERE\\s+(--.*|/\\*[^(/\\*|\\*/)]+?\\*/\\s*)*\\s*))(AND\\s+|OR\\s+)");
 
 	/** 各句の最初に現れるカンマを除去するための正規表現 */
 	protected static final Pattern REMOVE_FIRST_COMMA_PATTERN = Pattern
 			.compile(
-					"(?i)(?<keyword>((^|\\s+)(SELECT|ORDER\\s+BY|GROUP\\s+BY|SET)\\s+|\\(\\s*)(--.*|/\\*.*\\*/\\s*)*\\s*)(,)");
+					"(?i)(?<keyword>((^|\\s+)(SELECT|ORDER\\s+BY|GROUP\\s+BY|SET)\\s+|\\(\\s*)(--.*|/\\*[^(/\\*|\\*/)]+?\\*/\\s*)*\\s*)(,)");
+
 	/** 不要な空白、改行を除去するための正規表現 */
 	protected static final Pattern CLEAR_BLANK_PATTERN = Pattern.compile("(?m)^\\s*(\\r\\n|\\r|\\n)");
 

--- a/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/SqlContextImplTest.java
@@ -120,6 +120,12 @@ public class SqlContextImplTest {
 		assertEquals(replaceLineSep(
 				"with dummy as ( select * from dummy )[LF]select -- /* comment */ [LF] aaa[LF], bbb[LF], ccc from test"),
 				ctx7.getExecutableSql());
+
+		SqlContext ctx8 = getSqlContext(
+				"with dummy as ( select * from dummy )[LF]select /* コメント:japanese comment */ [LF], aaa[LF], bbb[LF], ccc from test");
+		assertEquals(replaceLineSep(
+				"with dummy as ( select * from dummy )[LF]select /* コメント:japanese comment */ [LF] aaa[LF], bbb[LF], ccc from test"),
+				ctx8.getExecutableSql());
 	}
 
 	@Test
@@ -301,6 +307,19 @@ public class SqlContextImplTest {
 				"select[LF], aaa,[LF]code_set,[LF]bbb,[LF]ccc[LF]from[LF]test[LF]where[LF]1 = 1");
 		assertEquals(replaceLineSep("select[LF] aaa,[LF]code_set,[LF]bbb,[LF]ccc[LF]from[LF]test[LF]where[LF]1 = 1"),
 				ctx63.getExecutableSql());
+	}
+
+	@Test
+	public void dontRemoveFirstComma() throws Exception {
+		SqlContext ctx11 = getSqlContext("SELECT /* _SQL_ID_ */ setval(/*sequenceName*/'', /*initialValue*/1, false)");
+		assertEquals("SELECT /* _SQL_ID_ */ setval(/*sequenceName*/'', /*initialValue*/1, false)",
+				ctx11.getExecutableSql());
+
+		SqlContext ctx12 = getSqlContext(
+				"SELECT /* _SQL_ID_ */ test.col1, TO_CHAR(FNC_ADD_MONTHS(TO_DATE(/*BIND_0*/'M', 'YYYYMMDD'), - 3), 'YYYYMMDD') AS ymd FROM test WHERE test.month = /*BIND_1*/'M'");
+		assertEquals(
+				"SELECT /* _SQL_ID_ */ test.col1, TO_CHAR(FNC_ADD_MONTHS(TO_DATE(/*BIND_0*/'M', 'YYYYMMDD'), - 3), 'YYYYMMDD') AS ymd FROM test WHERE test.month = /*BIND_1*/'M'",
+				ctx12.getExecutableSql());
 	}
 
 	@Test

--- a/src/test/java/jp/co/future/uroborosql/parser/SqlParserTest.java
+++ b/src/test/java/jp/co/future/uroborosql/parser/SqlParserTest.java
@@ -1162,4 +1162,36 @@ public class SqlParserTest {
 		assertEquals("aaa WHERE ORDER = 1 bbb", ctx.getExecutableSql());
 	}
 
+	@Test
+	public void testParseDontRemoveComma1() throws Exception {
+		String sql = "SELECT /* _SQL_ID_ */ setval(/*sequenceName*/'', /*initialValue*/1, false)";
+
+		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
+				sqlConfig.getDialect().isRemoveTerminator(), true);
+		SqlContext ctx = sqlConfig.context();
+		ctx.param("sequenceName", "test_seq");
+		ctx.param("initialValue", "1");
+
+		ContextTransformer transformer = parser.parse();
+		transformer.transform(ctx);
+		assertEquals("SELECT /* _SQL_ID_ */ setval(?/*sequenceName*/, ?/*initialValue*/, false)",
+				ctx.getExecutableSql());
+	}
+
+	@Test
+	public void testParseDontRemoveComma2() throws Exception {
+		String sql = "SELECT /* _SQL_ID_ */ TO_CHAR(FNC_ADD_MONTHS(TO_DATE(/*BIND_0*/'M', 'YYYYMMDD'), - 3), 'YYYYMMDD') AS ymd FROM test";
+
+		SqlParser parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
+				sqlConfig.getDialect().isRemoveTerminator(), true);
+		SqlContext ctx = sqlConfig.context();
+		ctx.param("BIND_0", "M");
+
+		ContextTransformer transformer = parser.parse();
+		transformer.transform(ctx);
+		assertEquals(
+				"SELECT /* _SQL_ID_ */ TO_CHAR(FNC_ADD_MONTHS(TO_DATE(?/*BIND_0*/, 'YYYYMMDD'), - 3), 'YYYYMMDD') AS ymd FROM test",
+				ctx.getExecutableSql());
+	}
+
 }


### PR DESCRIPTION
Fixed a bug that the regular expression to remove the comma that appears at the beginning of each SQL clause  
was removed even to the comma that should not be deleted in the case of SQL without line breaks.

The cause is that the regular expression that identifies the multi-line comment matched in a wider range than the expected value.