### PR TITLE
Fixed to check for differences in setting values before setting connection properties.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/connection/DataSourceConnectionSupplierImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/DataSourceConnectionSupplierImpl.java
@@ -98,10 +98,14 @@ public class DataSourceConnectionSupplierImpl implements ConnectionSupplier {
 			synchronized (ds) {
 				connection = ds.getConnection();
 			}
-			connection.setAutoCommit(ctx.autoCommit());
-			connection.setReadOnly(ctx.readOnly());
+			if (ctx.autoCommit() != connection.getAutoCommit()) {
+				connection.setAutoCommit(ctx.autoCommit());
+			}
+			if (ctx.readOnly() != connection.isReadOnly()) {
+				connection.setReadOnly(ctx.readOnly());
+			}
 			int transactionIsolation = ctx.transactionIsolation();
-			if (transactionIsolation > 0) {
+			if (transactionIsolation > 0 && transactionIsolation != connection.getTransactionIsolation()) {
 				connection.setTransactionIsolation(transactionIsolation);
 			}
 			return connection;

--- a/src/main/java/jp/co/future/uroborosql/connection/JdbcConnectionSupplierImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/JdbcConnectionSupplierImpl.java
@@ -103,10 +103,14 @@ public class JdbcConnectionSupplierImpl implements ConnectionSupplier {
 			if (schema != null && !Objects.equals(connection.getSchema(), schema)) {
 				connection.setSchema(schema);
 			}
-			connection.setAutoCommit(jdbcCtx.autoCommit());
-			connection.setReadOnly(jdbcCtx.readOnly());
+			if (jdbcCtx.autoCommit() != connection.getAutoCommit()) {
+				connection.setAutoCommit(jdbcCtx.autoCommit());
+			}
+			if (jdbcCtx.readOnly() != connection.isReadOnly()) {
+				connection.setReadOnly(jdbcCtx.readOnly());
+			}
 			int transactionIsolation = jdbcCtx.transactionIsolation();
-			if (transactionIsolation > 0) {
+			if (transactionIsolation > 0 && transactionIsolation != connection.getTransactionIsolation()) {
 				connection.setTransactionIsolation(transactionIsolation);
 			}
 			return connection;


### PR DESCRIPTION
Fixed to make sure that the settings are different before setting the connection properties.

- autoCommit
- readOnly
- transactionIsolation
