### PR TITLE
Improved the performance of ResultSetConverter by caching JavaType and columnLabel in memory.

### DIFF
--- a/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
@@ -244,6 +244,31 @@ public class SqlQueryTest extends AbstractDbTest {
 	 * クエリ実行処理のテストケース(Fluent API)。
 	 */
 	@Test
+	public void testQueryFluentCollectWithPerformance() throws Exception {
+		// 事前条件
+		// 事前条件
+		truncateTable("PRODUCT");
+		int rowsize = 1000000;
+		agent.required(() -> {
+			agent.insertsAndReturn(IntStream.range(1, rowsize)
+					.mapToObj(i -> new Product(i, "商品" + i, "ショウヒン" + i, "1111-" + i, "商品-" + i, new Date(), new Date(),
+							1)));
+		});
+
+		Instant startTime = Instant.now();
+
+		agent.query("example/select_product").collect();
+
+		Instant finishTime = Instant.now();
+		Duration elapsedTime = Duration.between(startTime, finishTime);
+		System.out.println(rowsize + " records read time. time=" +
+				elapsedTime.getSeconds() + "." + elapsedTime.getNano());
+	}
+
+	/**
+	 * クエリ実行処理のテストケース(Fluent API)。
+	 */
+	@Test
 	public void testQueryFluentCollectCaseFormat() throws Exception {
 		// 事前条件
 		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));

--- a/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
@@ -246,9 +246,8 @@ public class SqlQueryTest extends AbstractDbTest {
 	@Test
 	public void testQueryFluentCollectWithPerformance() throws Exception {
 		// 事前条件
-		// 事前条件
 		truncateTable("PRODUCT");
-		int rowsize = 1000000;
+		int rowsize = 500000;
 		agent.required(() -> {
 			agent.insertsAndReturn(IntStream.range(1, rowsize)
 					.mapToObj(i -> new Product(i, "商品" + i, "ショウヒン" + i, "1111-" + i, "商品-" + i, new Date(), new Date(),
@@ -311,7 +310,7 @@ public class SqlQueryTest extends AbstractDbTest {
 	public void testQueryFluentCollectEntityWithPerformance() throws Exception {
 		// 事前条件
 		truncateTable("PRODUCT");
-		int rowsize = 1000000;
+		int rowsize = 500000;
 		agent.required(() -> {
 			agent.insertsAndReturn(IntStream.range(1, rowsize)
 					.mapToObj(i -> new Product(i, "商品" + i, "ショウヒン" + i, "1111-" + i, "商品-" + i, new Date(), new Date(),


### PR DESCRIPTION
Performance tuning of MapResultSetConverter and EntityResultSetConverter by caching the objects required for value conversion.

Reference)  
Measurements on my local PC.

- EntityResultSetConverter  
  select 500,000 record.  (SqlQueryTest#testQueryFluentCollectEntityWithPerformance())
  - before : 3.85s , after : 1.81s

- MapResultSetConverter  
  select 500,000 record.  (SqlQueryTest#testQueryFluentCollectWithPerformance())
  - before : 3.21s , after : 1.54s

