### PR TITLE
Add includeColumns and excludeColumns for SqlEntityQuery

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
@@ -136,15 +136,15 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 				selectClause = selectClause.replaceAll(tableMetadata.getColumns().stream()
 						.filter(col -> !includeColumns.contains(col.getCamelColumnName()))
 						.map(TableMetadata.Column::getColumnIdentifier)
-						.collect(Collectors.joining("|", "(?m)^,*\\s+(", ").+$")), "");
+						.collect(Collectors.joining("|", "(?m)\\s*,*\\s+(", ").+\\s")), "");
 			} else if (!excludeColumns.isEmpty()) {
 				selectClause = selectClause.replaceAll(tableMetadata.getColumns().stream()
 						.filter(col -> excludeColumns.contains(col.getCamelColumnName()))
 						.map(TableMetadata.Column::getColumnIdentifier)
-						.collect(Collectors.joining("|", "(?m)^,*\\s+(", ").+$")), "");
+						.collect(Collectors.joining("|", "(?m)\\s*,*\\s+(", ").+\\s")), "");
 			}
 			if (!includeColumns.isEmpty() || !excludeColumns.isEmpty()) {
-				selectClause = selectClause.replaceFirst("(?m)(SELECT.+\\s*)(,)", "$1");
+				selectClause = selectClause.replaceFirst("(?m)(SELECT.+\\s*)(,)", "$1 ");
 			}
 			StringBuilder sql = new StringBuilder(selectClause).append(getWhereClause())
 					.append(getOrderByClause());

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
@@ -232,4 +232,22 @@ public interface SqlEntityQuery<E> extends ExtractionCondition<SqlEntityQuery<E>
 	 */
 	SqlEntityQuery<E> hint(String hint);
 
+	/**
+	 * 検索時に取得するカラムを指定.<br>
+	 * 指定しない場合は全カラムが取得対象となる.
+	 *
+	 * @param cols 取得するカラム名（複数指定可）
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> includeColumns(String... cols);
+
+	/**
+	 * 検索時に除外するカラムを指定.<br>
+	 * 指定しない場合は全カラムが取得対象となる.
+	 *
+	 * @param cols 除外するカラム名（複数指定可）
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> excludeColumns(String... cols);
+
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import jp.co.future.uroborosql.exception.DataNonUniqueException;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.exception.UroborosqlSQLException;
 
 public class SqlEntityQueryTest extends AbstractDbTest {
 
@@ -180,6 +181,149 @@ public class SqlEntityQueryTest extends AbstractDbTest {
 		} catch (Exception ex) {
 			fail();
 		}
+	}
+
+	@Test
+	public void testIncludeColumns() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		// camel case
+		Product product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(1));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getProductKanaName(), is("ショウヒンメイイチ"));
+		assertThat(product.getJanCode(), is("1234567890124"));
+		assertThat(product.getProductDescription(), is("1番目の商品"));
+		assertThat(product.getInsDatetime(), not(nullValue()));
+		assertThat(product.getUpdDatetime(), not(nullValue()));
+		assertThat(product.getVersionNo(), is(0));
+
+		// productIdのみ
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.includeColumns("productId")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(1));
+		assertThat(product.getProductName(), is(nullValue()));
+		assertThat(product.getJanCode(), nullValue());
+		assertThat(product.getProductDescription(), nullValue());
+		assertThat(product.getInsDatetime(), nullValue());
+		assertThat(product.getUpdDatetime(), nullValue());
+		assertThat(product.getVersionNo(), is(0));
+
+		// productId, productName
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.includeColumns("productId", "productName")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(1));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getJanCode(), nullValue());
+		assertThat(product.getProductDescription(), nullValue());
+		assertThat(product.getInsDatetime(), nullValue());
+		assertThat(product.getUpdDatetime(), nullValue());
+		assertThat(product.getVersionNo(), is(0));
+
+		// productName (先頭カラムを含まない)
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.includeColumns("productName")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(0));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getJanCode(), nullValue());
+		assertThat(product.getProductDescription(), nullValue());
+		assertThat(product.getInsDatetime(), nullValue());
+		assertThat(product.getUpdDatetime(), nullValue());
+		assertThat(product.getVersionNo(), is(0));
+	}
+
+	@Test
+	public void testExcludeColumns() {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
+
+		// camel case
+		Product product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(1));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getProductKanaName(), is("ショウヒンメイイチ"));
+		assertThat(product.getJanCode(), is("1234567890124"));
+		assertThat(product.getProductDescription(), is("1番目の商品"));
+		assertThat(product.getInsDatetime(), not(nullValue()));
+		assertThat(product.getUpdDatetime(), not(nullValue()));
+		assertThat(product.getVersionNo(), is(0));
+
+		// janCodeのみ
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.excludeColumns("janCode")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(1));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getProductKanaName(), is("ショウヒンメイイチ"));
+		assertThat(product.getJanCode(), is(nullValue()));
+		assertThat(product.getProductDescription(), is("1番目の商品"));
+		assertThat(product.getInsDatetime(), not(nullValue()));
+		assertThat(product.getUpdDatetime(), not(nullValue()));
+		assertThat(product.getVersionNo(), is(0));
+
+		// productId, productName
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.excludeColumns("productId", "productName")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(0));
+		assertThat(product.getProductName(), is(nullValue()));
+		assertThat(product.getProductKanaName(), is("ショウヒンメイイチ"));
+		assertThat(product.getJanCode(), is("1234567890124"));
+		assertThat(product.getProductDescription(), is("1番目の商品"));
+		assertThat(product.getInsDatetime(), not(nullValue()));
+		assertThat(product.getUpdDatetime(), not(nullValue()));
+		assertThat(product.getVersionNo(), is(0));
+
+		// productId (先頭カラム)
+		product = agent.query(Product.class)
+				.equal("product_id", 1)
+				.excludeColumns("productId")
+				.first()
+				.orElseThrow(UroborosqlSQLException::new);
+
+		assertThat(product, not(nullValue()));
+		assertThat(product.getProductId(), is(0));
+		assertThat(product.getProductName(), is("商品名1"));
+		assertThat(product.getProductKanaName(), is("ショウヒンメイイチ"));
+		assertThat(product.getJanCode(), is("1234567890124"));
+		assertThat(product.getProductDescription(), is("1番目の商品"));
+		assertThat(product.getInsDatetime(), not(nullValue()));
+		assertThat(product.getUpdDatetime(), not(nullValue()));
+		assertThat(product.getVersionNo(), is(0));
 	}
 
 	@Test


### PR DESCRIPTION
Added method to specify columns to include or exclude when selecting entities.

ex)
- full column
```java
var product = agent.query(Product.class)
		.equal("product_id", 1)
		.first()
		.orElseThrow(UroborosqlSQLException::new);
```
```sql
SELECT /* _SQL_ID_ */
	 "PRODUCT_ID"	AS	"PRODUCT_ID"
,	 "PRODUCT_NAME"	AS	"PRODUCT_NAME"
,	 "PRODUCT_KANA_NAME"	AS	"PRODUCT_KANA_NAME"
,	 "JAN_CODE"	AS	"JAN_CODE"
,	 "PRODUCT_DESCRIPTION"	AS	"PRODUCT_DESCRIPTION"
,	 "INS_DATETIME"	AS	"INS_DATETIME"
,	 "UPD_DATETIME"	AS	"UPD_DATETIME"
,	 "VERSION_NO"	AS	"VERSION_NO"
FROM PRODUCT
```

- includeColumns
```java
var product = agent.query(Product.class)
		.equal("product_id", 1)
		.includeColumns("productId")
		.first()
		.orElseThrow(UroborosqlSQLException::new);
```
```sql
SELECT /* _SQL_ID_ */
	 "PRODUCT_ID"	AS	"PRODUCT_ID"
FROM PRODUCT
```

- excludeColumns
```java
var product = agent.query(Product.class)
		.equal("product_id", 1)
		.excludeColumns("productId")
		.first()
		.orElseThrow(UroborosqlSQLException::new);
```
```sql
SELECT /* _SQL_ID_ */
	 "PRODUCT_NAME"	AS	"PRODUCT_NAME"
,	 "PRODUCT_KANA_NAME"	AS	"PRODUCT_KANA_NAME"
,	 "JAN_CODE"	AS	"JAN_CODE"
,	 "PRODUCT_DESCRIPTION"	AS	"PRODUCT_DESCRIPTION"
,	 "INS_DATETIME"	AS	"INS_DATETIME"
,	 "UPD_DATETIME"	AS	"UPD_DATETIME"
,	 "VERSION_NO"	AS	"VERSION_NO"
FROM PRODUCT
```
