### PR TITLE
Fixed INSERT to apply default value if Entity field is null and a column default value is specified.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -650,7 +650,8 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				parts.append("\t").append("-- ").append(col.getRemarks());
 			}
 			parts.append(System.lineSeparator());
-			if (ignoreWhenEmpty && col.isNullable() || autoIncrementColumn) {
+			if (ignoreWhenEmpty && (col.isNullable() || StringUtils.isNotEmpty(col.getColumnDefault()))
+					|| autoIncrementColumn) {
 				wrapIfComment(sql, parts, col);
 			} else {
 				sql.append(parts);
@@ -707,7 +708,8 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 				sql.append(parts);
 			} else {
 				parts.append("/*").append(getParamName.apply(col)).append("*/''").append(System.lineSeparator());
-				if (ignoreWhenEmpty && col.isNullable() || autoIncrementColumn) {
+				if (ignoreWhenEmpty && (col.isNullable() || StringUtils.isNotEmpty(col.getColumnDefault()))
+						|| autoIncrementColumn) {
 					wrapIfComment(sql, parts, col);
 				} else {
 					sql.append(parts);

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
@@ -99,6 +99,13 @@ public interface TableMetadata {
 		String getRemarks();
 
 		/**
+		 * カラムのデフォルト値（文字列）取得
+		 *
+		 * @return カラムのデフォルト値（文字列）
+		 */
+		String getColumnDefault();
+
+		/**
 		 * NULLが許可されるかどうかを取得
 		 *
 		 * @return NULLが許可される場合<code>true</code>
@@ -291,6 +298,7 @@ public interface TableMetadata {
 					if (remarks != null) {
 						remarks = NEWLINE_CHARS_PATTERN.matcher(remarks).replaceAll(" ");
 					}
+					String columnDefault = rs.getString("COLUMN_DEF");
 					String isNullable = rs.getString("IS_NULLABLE");
 					String isAutoincrement = rs.getString("IS_AUTOINCREMENT");
 					boolean isVersion = columnName.equalsIgnoreCase(versionColumnName);
@@ -302,6 +310,7 @@ public interface TableMetadata {
 							sqlType,
 							columnSize,
 							remarks,
+							columnDefault,
 							isNullable,
 							isAutoincrement,
 							isVersion,

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadataImpl.java
@@ -32,6 +32,7 @@ public class TableMetadataImpl implements TableMetadata {
 		private Integer keySeq = null;
 		private final String identifierQuoteString;
 		private final String remarks;
+		private final String columnDefault;
 		private final boolean nullable;
 		private final boolean autoincrement;
 		private final boolean version;
@@ -45,6 +46,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param dataType データタイプ
 		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
+		 * @param columnDefault カラムのデフォルト値. nullの可能性もある
 		 * @param nullable NULL可かどうか
 		 * @param autoincrement 自動インクリメントされるかどうか
 		 * @param version バージョンカラムかどうか
@@ -56,14 +58,24 @@ public class TableMetadataImpl implements TableMetadata {
 				final SQLType dataType,
 				final int columnSize,
 				final String remarks,
+				final String columnDefault,
 				final String nullable,
 				final String autoincrement,
 				final boolean version,
 				final Class<? extends OptimisticLockSupplier> optimisticLockType,
 				final int ordinalPosition,
 				final String identifierQuoteString) {
-			this(columnName, dataType.getVendorTypeNumber(), columnSize, remarks, nullable, autoincrement, version,
-					optimisticLockType, ordinalPosition, identifierQuoteString);
+			this(columnName,
+					dataType.getVendorTypeNumber(),
+					columnSize,
+					remarks,
+					columnDefault,
+					nullable,
+					autoincrement,
+					version,
+					optimisticLockType,
+					ordinalPosition,
+					identifierQuoteString);
 		}
 
 		/**
@@ -73,6 +85,7 @@ public class TableMetadataImpl implements TableMetadata {
 		 * @param dataType データタイプ
 		 * @param columnSize カラムサイズ
 		 * @param remarks コメント文字列
+		 * @param columnDefault カラムのデフォルト値. nullの可能性もある
 		 * @param nullable NULL可かどうか
 		 * @param autoincrement 自動インクリメントされるかどうか
 		 * @param version バージョンカラムかどうか
@@ -84,6 +97,7 @@ public class TableMetadataImpl implements TableMetadata {
 				final int dataType,
 				final int columnSize,
 				final String remarks,
+				final String columnDefault,
 				final String nullable,
 				final String autoincrement,
 				final boolean version,
@@ -94,6 +108,7 @@ public class TableMetadataImpl implements TableMetadata {
 			this.dataType = dataType;
 			this.columnSize = columnSize;
 			this.remarks = remarks;
+			this.columnDefault = columnDefault;
 			this.nullable = "YES".equalsIgnoreCase(nullable);
 			this.autoincrement = "YES".equalsIgnoreCase(autoincrement);
 			this.version = version;
@@ -208,6 +223,16 @@ public class TableMetadataImpl implements TableMetadata {
 		@Override
 		public String getRemarks() {
 			return this.remarks;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * @see jp.co.future.uroborosql.mapping.TableMetadata.Column#getColumnDefault()
+		 */
+		@Override
+		public String getColumnDefault() {
+			return this.columnDefault;
 		}
 
 		/**

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierMultiByteTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierMultiByteTest.java
@@ -129,11 +129,11 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test1 = new TestEntity(1L, "name1");
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test2 = new TestEntity(2L, "name2");
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test3 = new TestEntity(3L, "name3");
 				agent.insert(test3);
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
 				assertThat(data, is(test1));
@@ -151,11 +151,11 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test1 = new TestEntity(1L, "name1");
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test2 = new TestEntity(2L, "name2");
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test3 = new TestEntity(3L, "name3");
 				agent.insert(test3);
 
 				List<TestEntity> list = agent.query(TestEntity.class).collect();
@@ -176,7 +176,7 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1");
+				TestEntity test = new TestEntity(1L, "name1");
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -194,7 +194,7 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1");
+				TestEntity test = new TestEntity(1L, "name1");
 				agent.insert(test);
 
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
@@ -213,9 +213,9 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
-				TestEntity test2 = new TestEntity(2, "name2");
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test1 = new TestEntity(1L, "name1");
+				TestEntity test2 = new TestEntity(2L, "name2");
+				TestEntity test3 = new TestEntity(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
 				assertThat(count, is(3));
@@ -236,9 +236,9 @@ public class DefaultEntityHandlerIdentifierMultiByteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
-				TestEntity test2 = new TestEntity(2, "name2");
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test1 = new TestEntity(1L, "name1");
+				TestEntity test2 = new TestEntity(2L, "name2");
+				TestEntity test3 = new TestEntity(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3));
 				assertThat(count, is(3));

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierPascalCaseTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierPascalCaseTest.java
@@ -149,11 +149,11 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test1 = new TestEntity(1L, "lastName1", "firstName1");
 	//				agent.insert(test1);
-	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				TestEntity test2 = new TestEntity(2L, "lastName2", "firstName2");
 	//				agent.insert(test2);
-	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				TestEntity test3 = new TestEntity(3L, "lastName3", "firstName3");
 	//				agent.insert(test3);
 	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
 	//				assertThat(data, is(test1));
@@ -190,11 +190,11 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test1 = new TestEntity(1L, "lastName1", "firstName1");
 	//				agent.insert(test1);
-	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
+	//				TestEntity test2 = new TestEntity(2L, "lastName2", "firstName2");
 	//				agent.insert(test2);
-	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				TestEntity test3 = new TestEntity(3L, "lastName3", "firstName3");
 	//				agent.insert(test3);
 	//
 	//				List<TestEntity> list = agent.query(TestEntity.class).collect();
@@ -215,7 +215,7 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test = new TestEntity(1L, "lastName1", "firstName1");
 	//				agent.insert(test);
 	//
 	//				test.setLastName("updatename");
@@ -233,7 +233,7 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test = new TestEntity(1, "lastName1", "firstName1");
+	//				TestEntity test = new TestEntity(1L, "lastName1", "firstName1");
 	//				agent.insert(test);
 	//
 	//				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
@@ -252,9 +252,9 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
-	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
-	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				TestEntity test1 = new TestEntity(1L, "lastName1", "firstName1");
+	//				TestEntity test2 = new TestEntity(2L, "lastName2", "firstName2");
+	//				TestEntity test3 = new TestEntity(3L, "lastName3", "firstName3");
 	//
 	//				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
 	//				assertThat(count, is(3));
@@ -275,9 +275,9 @@ public class DefaultEntityHandlerIdentifierPascalCaseTest {
 	//
 	//		try (SqlAgent agent = config.agent()) {
 	//			agent.required(() -> {
-	//				TestEntity test1 = new TestEntity(1, "lastName1", "firstName1");
-	//				TestEntity test2 = new TestEntity(2, "lastName2", "firstName2");
-	//				TestEntity test3 = new TestEntity(3, "lastName3", "firstName3");
+	//				TestEntity test1 = new TestEntity(1L, "lastName1", "firstName1");
+	//				TestEntity test2 = new TestEntity(2L, "lastName2", "firstName2");
+	//				TestEntity test3 = new TestEntity(3L, "lastName3", "firstName3");
 	//
 	//				int count = agent.inserts(Stream.of(test1, test2, test3));
 	//				assertThat(count, is(3));

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierQuoteTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerIdentifierQuoteTest.java
@@ -129,11 +129,11 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test1 = new TestEntity(1L, "name1");
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test2 = new TestEntity(2L, "name2");
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test3 = new TestEntity(3L, "name3");
 				agent.insert(test3);
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
 				assertThat(data, is(test1));
@@ -151,11 +151,11 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
+				TestEntity test1 = new TestEntity(1L, "name1");
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2");
+				TestEntity test2 = new TestEntity(2L, "name2");
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test3 = new TestEntity(3L, "name3");
 				agent.insert(test3);
 
 				List<TestEntity> list = agent.query(TestEntity.class).collect();
@@ -176,7 +176,7 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1");
+				TestEntity test = new TestEntity(1L, "name1");
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -194,7 +194,7 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1");
+				TestEntity test = new TestEntity(1L, "name1");
 				agent.insert(test);
 
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
@@ -213,9 +213,9 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
-				TestEntity test2 = new TestEntity(2, "name2");
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test1 = new TestEntity(1L, "name1");
+				TestEntity test2 = new TestEntity(2L, "name2");
+				TestEntity test3 = new TestEntity(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
 				assertThat(count, is(3));
@@ -236,9 +236,9 @@ public class DefaultEntityHandlerIdentifierQuoteTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1");
-				TestEntity test2 = new TestEntity(2, "name2");
-				TestEntity test3 = new TestEntity(3, "name3");
+				TestEntity test1 = new TestEntity(1L, "name1");
+				TestEntity test2 = new TestEntity(2L, "name2");
+				TestEntity test3 = new TestEntity(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3));
 				assertThat(count, is(3));

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerMultiColumnCommentTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerMultiColumnCommentTest.java
@@ -79,12 +79,13 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2), Optional.empty());
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						Optional.empty());
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3), Optional
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3), Optional
 						.of("memo3"));
 				agent.insert(test3);
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
@@ -103,13 +104,13 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1), Optional
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1), Optional
 						.of("memo2"));
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1), Optional.empty());
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1), Optional.empty());
 				agent.insert(test3);
 
 				List<TestEntity> list = agent.query(TestEntity.class).collect();
@@ -131,13 +132,13 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 22, LocalDate.of(1990, Month.APRIL, 1),
+				TestEntity test1 = new TestEntity(1L, "name1", 22, LocalDate.of(1990, Month.APRIL, 1),
 						Optional.of("memo"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1),
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1),
 						Optional.of("memo2"));
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 20, LocalDate.of(1990, Month.JUNE, 1), Optional.empty());
+				TestEntity test3 = new TestEntity(3L, "name3", 20, LocalDate.of(1990, Month.JUNE, 1), Optional.empty());
 				agent.insert(test3);
 
 				// Equal
@@ -411,7 +412,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test);
 
@@ -430,7 +431,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test);
 
@@ -450,13 +451,13 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -479,13 +480,13 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -506,7 +507,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 	@Test
 	public void testCreateSelectContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -566,7 +567,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 	@Test
 	public void testCreateUpdateContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -589,7 +590,7 @@ public class DefaultEntityHandlerMultiColumnCommentTest {
 	@Test
 	public void testCreateDeleteContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -61,6 +61,7 @@ public class DefaultEntityHandlerTest {
 				stmt.execute("comment on column test.\"Age\" is 'age'");
 				stmt.execute("comment on column test.birthday is 'birthday'");
 				stmt.execute("comment on column test.memo is 'memo'");
+				stmt.execute("comment on column test.lock_version is 'lockVersion'");
 
 				stmt.execute("drop table if exists test_data_no_key");
 				stmt.execute(
@@ -115,12 +116,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2), Optional.empty());
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+						Optional.empty());
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3), Optional
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3), Optional
 						.of("memo3"));
 				agent.insert(test3);
 				TestEntity data = agent.find(TestEntity.class, 1).orElse(null);
@@ -139,11 +141,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity2 test1 = new TestEntity2(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity2 test1 = new TestEntity2(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity2 test2 = new TestEntity2(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2));
+				TestEntity2 test2 = new TestEntity2(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2));
 				agent.insert(test2);
-				TestEntity2 test3 = new TestEntity2(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3));
+				TestEntity2 test3 = new TestEntity2(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3));
 				agent.insert(test3);
 				TestEntity2 data = agent.find(TestEntity2.class, 1).orElse(null);
 				assertThat(data, is(test1));
@@ -161,11 +163,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3));
 				agent.insert(test3);
 				assertThat(agent.find(TestEntity3.class, 1).orElse(null), is(test1));
 				assertThat(agent.find(TestEntity3.class, 2).orElse(null), is(test2));
@@ -179,13 +181,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1), Optional
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1), Optional
 						.of("memo2"));
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1), Optional.empty());
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1), Optional.empty());
 				agent.insert(test3);
 
 				List<TestEntity> list = agent.query(TestEntity.class).collect();
@@ -207,11 +209,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity2 test1 = new TestEntity2(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity2 test1 = new TestEntity2(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity2 test2 = new TestEntity2(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity2 test2 = new TestEntity2(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity2 test3 = new TestEntity2(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity2 test3 = new TestEntity2(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
 
 				List<TestEntity2> list = agent.query(TestEntity2.class).collect();
@@ -233,11 +235,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
 
 				List<TestEntity3> list = agent.query(TestEntity3.class).collect();
@@ -259,13 +261,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
-				TestEntity3 test4 = new TestEntity3(4, "name4", 23, null);
+				TestEntity3 test4 = new TestEntity3(4L, "name4", 23, null);
 				agent.insert(test4);
 
 				long count1 = agent.query(TestEntity3.class).count();
@@ -329,13 +331,13 @@ public class DefaultEntityHandlerTest {
 	public void testQueryCountUnmatchColumn() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
-				TestEntity3 test4 = new TestEntity3(4, "name4", 23, null);
+				TestEntity3 test4 = new TestEntity3(4L, "name4", 23, null);
 				agent.insert(test4);
 
 				agent.query(TestEntity3.class).count("unmatch");
@@ -347,13 +349,13 @@ public class DefaultEntityHandlerTest {
 	public void testQuerySumUnmatchColumn() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
-				TestEntity3 test4 = new TestEntity3(4, "name4", 23, null);
+				TestEntity3 test4 = new TestEntity3(4L, "name4", 23, null);
 				agent.insert(test4);
 
 				agent.query(TestEntity3.class).sum("unmatch");
@@ -365,13 +367,13 @@ public class DefaultEntityHandlerTest {
 	public void testQuerySumNoNumberColumn() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
-				TestEntity3 test4 = new TestEntity3(4, "name4", 23, null);
+				TestEntity3 test4 = new TestEntity3(4L, "name4", 23, null);
 				agent.insert(test4);
 
 				agent.query(TestEntity3.class).sum("birthday");
@@ -384,13 +386,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 22, LocalDate.of(1990, Month.APRIL, 1),
+				TestEntity test1 = new TestEntity(1L, "name1", 22, LocalDate.of(1990, Month.APRIL, 1),
 						Optional.of("memo"));
 				agent.insert(test1);
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1),
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1),
 						Optional.of("memo2"));
 				agent.insert(test2);
-				TestEntity test3 = new TestEntity(3, "name3", 20, LocalDate.of(1990, Month.JUNE, 1), Optional.empty());
+				TestEntity test3 = new TestEntity(3L, "name3", 20, LocalDate.of(1990, Month.JUNE, 1), Optional.empty());
 				agent.insert(test3);
 
 				// Equal
@@ -678,17 +680,17 @@ public class DefaultEntityHandlerTest {
 	public void testQueryWithBetweenColumns() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestHistoryEntity test1 = new TestHistoryEntity(1,
+				TestHistoryEntity test1 = new TestHistoryEntity(1L,
 						LocalDate.of(1990, Month.APRIL, 1),
 						LocalDate.of(1990, Month.APRIL, 28),
 						"name1");
 				agent.insert(test1);
-				TestHistoryEntity test2 = new TestHistoryEntity(2,
+				TestHistoryEntity test2 = new TestHistoryEntity(2L,
 						LocalDate.of(1990, Month.APRIL, 15),
 						LocalDate.of(1990, Month.MAY, 15),
 						"name2");
 				agent.insert(test2);
-				TestHistoryEntity test3 = new TestHistoryEntity(3,
+				TestHistoryEntity test3 = new TestHistoryEntity(3L,
 						LocalDate.of(1990, Month.MARCH, 1),
 						LocalDate.of(1990, Month.JUNE, 30),
 						"name3");
@@ -716,17 +718,17 @@ public class DefaultEntityHandlerTest {
 	public void testQueryWithNotBetweenColumns() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestHistoryEntity test1 = new TestHistoryEntity(1,
+				TestHistoryEntity test1 = new TestHistoryEntity(1L,
 						LocalDate.of(1990, Month.APRIL, 1),
 						LocalDate.of(1990, Month.APRIL, 28),
 						"name1");
 				agent.insert(test1);
-				TestHistoryEntity test2 = new TestHistoryEntity(2,
+				TestHistoryEntity test2 = new TestHistoryEntity(2L,
 						LocalDate.of(1990, Month.APRIL, 15),
 						LocalDate.of(1990, Month.MAY, 15),
 						"name2");
 				agent.insert(test2);
-				TestHistoryEntity test3 = new TestHistoryEntity(3,
+				TestHistoryEntity test3 = new TestHistoryEntity(3L,
 						LocalDate.of(1990, Month.MARCH, 1),
 						LocalDate.of(1990, Month.JUNE, 30),
 						"name3");
@@ -753,13 +755,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test1 = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test1 = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test1);
-				TestEntity3 test2 = new TestEntity3(2, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test2 = new TestEntity3(2L, "name2", 21, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test2);
-				TestEntity3 test3 = new TestEntity3(3, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
+				TestEntity3 test3 = new TestEntity3(3L, "name3", 22, LocalDate.of(1990, Month.MAY, 1));
 				agent.insert(test3);
-				TestEntity3 test4 = new TestEntity3(4, "name4", 23, null);
+				TestEntity3 test4 = new TestEntity3(4L, "name4", 23, null);
 				agent.insert(test4);
 
 				assertThat(config.getSqlAgentFactory().getDefaultForUpdateWaitSeconds(), is(10));
@@ -846,7 +848,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test);
 
@@ -880,7 +882,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity2 test = new TestEntity2(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity2 test = new TestEntity2(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -917,7 +919,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -935,7 +937,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity3 test = new TestEntity3(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity3 test = new TestEntity3(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				test.setLockVersion(1);
 				agent.insert(test);
 
@@ -1084,7 +1086,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
 				agent.insert(test);
 
@@ -1104,7 +1106,7 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity2 test = new TestEntity2(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
+				TestEntity2 test = new TestEntity2(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1));
 				agent.insert(test);
 
 				TestEntity2 data = agent.find(TestEntity2.class, 1).orElse(null);
@@ -1162,11 +1164,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
-				TestEntity test2 = new TestEntity(2, "name2", 30, LocalDate.of(1980, Month.MAY, 1), Optional
+				TestEntity test2 = new TestEntity(2L, "name2", 30, LocalDate.of(1980, Month.MAY, 1), Optional
 						.of("memo2"));
-				TestEntity test3 = new TestEntity(3, "name3", 40, LocalDate.of(1970, Month.JUNE, 1), Optional
+				TestEntity test3 = new TestEntity(3L, "name3", 40, LocalDate.of(1970, Month.JUNE, 1), Optional
 						.empty());
 				agent.insert(test1);
 				agent.insert(test2);
@@ -1233,11 +1235,11 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 						.of("memo1"));
-				TestEntity test2 = new TestEntity(2, "name2", 30, LocalDate.of(1980, Month.MAY, 1), Optional
+				TestEntity test2 = new TestEntity(2L, "name2", 30, LocalDate.of(1980, Month.MAY, 1), Optional
 						.of("memo2"));
-				TestEntity test3 = new TestEntity(3, "name3", 40, LocalDate.of(1970, Month.JUNE, 1), Optional
+				TestEntity test3 = new TestEntity(3L, "name3", 40, LocalDate.of(1970, Month.JUNE, 1), Optional
 						.empty());
 				agent.insert(test1);
 				agent.insert(test2);
@@ -1412,13 +1414,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1441,13 +1443,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1471,13 +1473,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1501,16 +1503,16 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
-				TestEntityForInserts test4 = new TestEntityForInserts(4, "name4", 23,
+				TestEntityForInserts test4 = new TestEntityForInserts(4L, "name4", 23,
 						LocalDate.of(1990, Month.APRIL, 4),
 						"memo4");
 
@@ -1536,13 +1538,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
 						Optional.of("memo1"));
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
 						Optional.empty());
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
 						Optional.of("memo3"));
-				TestEntity test4 = new TestEntity(4, "name4", 23, LocalDate.of(1990, Month.APRIL, 4),
+				TestEntity test4 = new TestEntity(4L, "name4", 23, LocalDate.of(1990, Month.APRIL, 4),
 						Optional.of("memo4"));
 
 				int count = agent.inserts(Stream.of(test1, test2, test3, test4), (ctx, cnt, r) -> cnt == 3,
@@ -1608,13 +1610,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1637,13 +1639,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1666,13 +1668,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
 
@@ -1695,16 +1697,16 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntityForInserts test1 = new TestEntityForInserts(1, "name1", 20,
+				TestEntityForInserts test1 = new TestEntityForInserts(1L, "name1", 20,
 						LocalDate.of(1990, Month.APRIL, 1),
 						"memo1");
-				TestEntityForInserts test2 = new TestEntityForInserts(2, "name2", 21,
+				TestEntityForInserts test2 = new TestEntityForInserts(2L, "name2", 21,
 						LocalDate.of(1990, Month.APRIL, 2),
 						null);
-				TestEntityForInserts test3 = new TestEntityForInserts(3, "name3", 22,
+				TestEntityForInserts test3 = new TestEntityForInserts(3L, "name3", 22,
 						LocalDate.of(1990, Month.APRIL, 3),
 						"memo3");
-				TestEntityForInserts test4 = new TestEntityForInserts(4, "name4", 23,
+				TestEntityForInserts test4 = new TestEntityForInserts(4L, "name4", 23,
 						LocalDate.of(1990, Month.APRIL, 4),
 						"memo4");
 
@@ -1729,13 +1731,13 @@ public class DefaultEntityHandlerTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity test1 = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
+				TestEntity test1 = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1),
 						Optional.of("memo1"));
-				TestEntity test2 = new TestEntity(2, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
+				TestEntity test2 = new TestEntity(2L, "name2", 21, LocalDate.of(1990, Month.APRIL, 2),
 						Optional.empty());
-				TestEntity test3 = new TestEntity(3, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
+				TestEntity test3 = new TestEntity(3L, "name3", 22, LocalDate.of(1990, Month.APRIL, 3),
 						Optional.of("memo3"));
-				TestEntity test4 = new TestEntity(4, "name4", 23, LocalDate.of(1990, Month.APRIL, 4),
+				TestEntity test4 = new TestEntity(4L, "name4", 23, LocalDate.of(1990, Month.APRIL, 4),
 						Optional.of("memo4"));
 
 				int count = agent.inserts(Stream.of(test1, test2, test3, test4), (ctx, cnt, r) -> cnt == 3);
@@ -1836,7 +1838,7 @@ public class DefaultEntityHandlerTest {
 	@Test
 	public void testCreateSelectContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -1859,7 +1861,7 @@ public class DefaultEntityHandlerTest {
 	@Test
 	public void testCreateSelectContextEmptyNotEqualsNull() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -1893,8 +1895,11 @@ public class DefaultEntityHandlerTest {
 			String sql = ctx.getSql();
 			assertThat(sql, containsString("IF memo != null"));
 
-			ctx.param("id", 1).param("name", "name1").param("age", 20)
-					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
+			ctx.param("id", 1)
+					.param("name", "name1")
+					.param("age", 20)
+					.param("birthday", LocalDate.of(1990, Month.APRIL, 1))
+					.param("memo", Optional.of("memo1"));
 			assertThat(agent.update(ctx), is(1));
 		}
 	}
@@ -1911,8 +1916,12 @@ public class DefaultEntityHandlerTest {
 			String sql = ctx.getSql();
 			assertThat(sql, not(containsString("SF.isNotEmpty")));
 
-			ctx.param("id", 1).param("name", "name1").param("age", 20)
-					.param("birthday", LocalDate.of(1990, Month.APRIL, 1)).param("memo", Optional.of("memo1"));
+			ctx.param("id", 1)
+					.param("name", "name1")
+					.param("age", 20)
+					.param("birthday", LocalDate.of(1990, Month.APRIL, 1))
+					.param("memo", Optional.of("memo1"))
+					.param("lockVersion", 1);
 			assertThat(agent.update(ctx), is(1));
 
 			handler.setEmptyStringEqualsNull(true);
@@ -1922,7 +1931,7 @@ public class DefaultEntityHandlerTest {
 	@Test
 	public void testCreateUpdateContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -1945,7 +1954,7 @@ public class DefaultEntityHandlerTest {
 	@Test
 	public void testCreateUpdateContextEmptyStringEqualsNull() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 
@@ -1971,7 +1980,7 @@ public class DefaultEntityHandlerTest {
 	@Test
 	public void testCreateDeleteContext() throws Exception {
 		try (SqlAgent agent = config.agent()) {
-			TestEntity test = new TestEntity(1, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
+			TestEntity test = new TestEntity(1L, "name1", 20, LocalDate.of(1990, Month.APRIL, 1), Optional
 					.of("memo1"));
 			agent.insert(test);
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
@@ -1,0 +1,142 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.exception.OptimisticLockException;
+import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+import jp.co.future.uroborosql.fluent.SqlEntityQuery.Nulls;
+import jp.co.future.uroborosql.mapping.mapper.PropertyMapper;
+import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
+import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
+
+public class DefaultEntityHandlerWithDefaultValueTest {
+
+	private static SqlConfig config;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:DefaultEntityHandlerWithDefaultValueTest;DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists test");
+				stmt.execute(
+						"create table if not exists test(id INTEGER auto_increment ,name VARCHAR(20) default 'default name',age NUMERIC(5) not null default 10,birthday DATE default '2000-01-01',memo VARCHAR(500), primary key(id))");
+				stmt.execute("comment on table test is 'test'");
+				stmt.execute("comment on column test.id is 'id'");
+				stmt.execute("comment on column test.name is 'name'");
+				stmt.execute("comment on column test.age is 'age'");
+				stmt.execute("comment on column test.birthday is 'birthday'");
+				stmt.execute("comment on column test.memo is 'memo'");
+
+			}
+		}
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from test").count();
+			agent.commit();
+		}
+	}
+
+	@Test
+	public void testInsert1() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityWithDefaultValue test1 = new TestEntityWithDefaultValue(1L,
+						Optional.of("name1"),
+						Optional.of(20),
+						Optional.of(LocalDate.of(1990, Month.APRIL, 1)),
+						Optional.of("memo1"));
+				agent.insert(test1);
+				TestEntityWithDefaultValue test2 = new TestEntityWithDefaultValue(2L,
+						null,
+						null,
+						null,
+						null);
+				agent.insert(test2);
+				TestEntityWithDefaultValue data = agent.find(TestEntityWithDefaultValue.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityWithDefaultValue.class, 2).orElse(null);
+				assertThat(data.getId(), is(2L));
+				assertThat(data.getName().get(), is("default name"));
+				assertThat(data.getAge().get(), is(10));
+				assertThat(data.getBirthday().get(), is(LocalDate.of(2000, Month.JANUARY, 1)));
+				assertThat(data.getMemo(), is(Optional.empty()));
+			});
+		}
+	}
+
+	@Test
+	public void testInsert2() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				TestEntityWithDefaultValue test1 = new TestEntityWithDefaultValue(null,
+						Optional.of("name1"),
+						Optional.of(20),
+						Optional.of(LocalDate.of(1990, Month.APRIL, 1)),
+						Optional.of("memo1"));
+				TestEntityWithDefaultValue result1 = agent.insertAndReturn(test1);
+				TestEntityWithDefaultValue test2 = new TestEntityWithDefaultValue(null,
+						null,
+						null,
+						null,
+						null);
+				TestEntityWithDefaultValue result2 = agent.insertAndReturn(test2);
+				TestEntityWithDefaultValue data = agent.find(TestEntityWithDefaultValue.class, result1.getId())
+						.orElse(null);
+				assertThat(data.getId(), is(result1.getId()));
+				assertThat(data.getName().get(), is("name1"));
+				assertThat(data.getAge().get(), is(20));
+				assertThat(data.getBirthday().get(), is(LocalDate.of(1990, Month.APRIL, 1)));
+				assertThat(data.getMemo(), is(Optional.of("memo1")));
+				data = agent.find(TestEntityWithDefaultValue.class, result2.getId()).orElse(null);
+				assertThat(data.getId(), is(result2.getId()));
+				assertThat(data.getName().get(), is("default name"));
+				assertThat(data.getAge().get(), is(10));
+				assertThat(data.getBirthday().get(), is(LocalDate.of(2000, Month.JANUARY, 1)));
+				assertThat(data.getMemo(), is(Optional.empty()));
+			});
+		}
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
@@ -2,22 +2,13 @@ package jp.co.future.uroborosql.mapping;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
-import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,17 +17,8 @@ import org.junit.Test;
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
-import jp.co.future.uroborosql.context.SqlContext;
-import jp.co.future.uroborosql.enums.InsertsType;
-import jp.co.future.uroborosql.exception.OptimisticLockException;
-import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
 import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
 import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
-import jp.co.future.uroborosql.fluent.SqlEntityQuery.Nulls;
-import jp.co.future.uroborosql.mapping.mapper.PropertyMapper;
-import jp.co.future.uroborosql.mapping.mapper.PropertyMapperManager;
-import jp.co.future.uroborosql.parameter.mapper.BindParameterMapper;
-import jp.co.future.uroborosql.parameter.mapper.BindParameterMapperManager;
 
 public class DefaultEntityHandlerWithDefaultValueTest {
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithMultiSchemaTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithMultiSchemaTest.java
@@ -314,11 +314,11 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test1 = new TestEntity1(1, "name1");
+				TestEntity1 test1 = new TestEntity1(1L, "name1");
 				agent.insert(test1);
-				TestEntity1 test2 = new TestEntity1(2, "name2");
+				TestEntity1 test2 = new TestEntity1(2L, "name2");
 				agent.insert(test2);
-				TestEntity1 test3 = new TestEntity1(3, "name3");
+				TestEntity1 test3 = new TestEntity1(3L, "name3");
 				agent.insert(test3);
 				TestEntity1 data = agent.find(TestEntity1.class, 1).orElse(null);
 				assertThat(data, is(test1));
@@ -338,11 +338,11 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity2 test1 = new TestEntity2(1, "name1");
+				TestEntity2 test1 = new TestEntity2(1L, "name1");
 				agent.insert(test1);
-				TestEntity2 test2 = new TestEntity2(2, "name2");
+				TestEntity2 test2 = new TestEntity2(2L, "name2");
 				agent.insert(test2);
-				TestEntity2 test3 = new TestEntity2(3, "name3");
+				TestEntity2 test3 = new TestEntity2(3L, "name3");
 				agent.insert(test3);
 				TestEntity2 data = agent.find(TestEntity2.class, 1).orElse(null);
 				assertThat(data, is(test1));
@@ -362,11 +362,11 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test1 = new TestEntity1(1, "name1");
+				TestEntity1 test1 = new TestEntity1(1L, "name1");
 				agent.insert(test1);
-				TestEntity1 test2 = new TestEntity1(2, "name2");
+				TestEntity1 test2 = new TestEntity1(2L, "name2");
 				agent.insert(test2);
-				TestEntity1 test3 = new TestEntity1(3, "name3");
+				TestEntity1 test3 = new TestEntity1(3L, "name3");
 				agent.insert(test3);
 
 				List<TestEntity1> list = agent.query(TestEntity1.class).collect();
@@ -387,7 +387,7 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test = new TestEntity1(1, "name1");
+				TestEntity1 test = new TestEntity1(1L, "name1");
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -405,7 +405,7 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test = new TestEntity1(1, "name1");
+				TestEntity1 test = new TestEntity1(1L, "name1");
 				agent.insert(test);
 
 				test.setName("updatename");
@@ -426,7 +426,7 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test = new TestEntity1(1, "name1");
+				TestEntity1 test = new TestEntity1(1L, "name1");
 				agent.insert(test);
 
 				TestEntity1 data = agent.find(TestEntity1.class, 1).orElse(null);
@@ -445,9 +445,9 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test1 = new TestEntity1(1, "name1");
-				TestEntity1 test2 = new TestEntity1(2, "name2");
-				TestEntity1 test3 = new TestEntity1(3, "name3");
+				TestEntity1 test1 = new TestEntity1(1L, "name1");
+				TestEntity1 test2 = new TestEntity1(2L, "name2");
+				TestEntity1 test3 = new TestEntity1(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
 				assertThat(count, is(3));
@@ -468,9 +468,9 @@ public class DefaultEntityHandlerWithMultiSchemaTest {
 
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				TestEntity1 test1 = new TestEntity1(1, "name1");
-				TestEntity1 test2 = new TestEntity1(2, "name2");
-				TestEntity1 test3 = new TestEntity1(3, "name3");
+				TestEntity1 test1 = new TestEntity1(1L, "name1");
+				TestEntity1 test2 = new TestEntity1(2L, "name2");
+				TestEntity1 test3 = new TestEntity1(3L, "name3");
 
 				int count = agent.inserts(Stream.of(test1, test2, test3));
 				assertThat(count, is(3));

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntity2.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntity2.java
@@ -6,23 +6,23 @@ import jp.co.future.uroborosql.mapping.annotations.Table;
 
 @Table(name = "TEST")
 public class TestEntity2 {
-	private long id;
+	private Long id;
 	private String name;
-	private int age;
+	private Integer age;
 	private LocalDate birthday;
-	private int lockVersion = 0;
+	private Integer lockVersion = 0;
 
 	public TestEntity2() {
 	}
 
-	public TestEntity2(final long id, final String name, final int age, final LocalDate birthday) {
+	public TestEntity2(final Long id, final String name, final Integer age, final LocalDate birthday) {
 		this.id = id;
 		this.name = name;
 		this.age = age;
 		this.birthday = birthday;
 	}
 
-	public long getId() {
+	public Long getId() {
 		return this.id;
 	}
 
@@ -30,7 +30,7 @@ public class TestEntity2 {
 		return this.name;
 	}
 
-	public int getAge() {
+	public Integer getAge() {
 		return this.age;
 	}
 
@@ -38,7 +38,7 @@ public class TestEntity2 {
 		return this.birthday;
 	}
 
-	public void setId(final long id) {
+	public void setId(final Long id) {
 		this.id = id;
 	}
 
@@ -46,7 +46,7 @@ public class TestEntity2 {
 		this.name = name;
 	}
 
-	public void setAge(final int age) {
+	public void setAge(final Integer age) {
 		this.age = age;
 	}
 
@@ -54,11 +54,11 @@ public class TestEntity2 {
 		this.birthday = birthday;
 	}
 
-	public int getLockVersion() {
+	public Integer getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final int lockVersion) {
+	public void setLockVersion(final Integer lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntity3.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntity3.java
@@ -7,17 +7,17 @@ import jp.co.future.uroborosql.mapping.annotations.Version;
 
 @Table(name = "TEST")
 public class TestEntity3 {
-	private long id;
+	private Long id;
 	private String name;
-	private int age;
+	private Integer age;
 	private LocalDate birthday;
 	@Version
-	private int lockVersion = 0;
+	private Integer lockVersion = 0;
 
 	public TestEntity3() {
 	}
 
-	public TestEntity3(final long id, final String name, final int age, final LocalDate birthday) {
+	public TestEntity3(final Long id, final String name, final Integer age, final LocalDate birthday) {
 		this.id = id;
 		this.name = name;
 		this.age = age;
@@ -38,7 +38,7 @@ public class TestEntity3 {
 		String Birthday = "birthday";
 	}
 
-	public long getId() {
+	public Long getId() {
 		return this.id;
 	}
 
@@ -46,7 +46,7 @@ public class TestEntity3 {
 		return this.name;
 	}
 
-	public int getAge() {
+	public Integer getAge() {
 		return this.age;
 	}
 
@@ -54,7 +54,7 @@ public class TestEntity3 {
 		return this.birthday;
 	}
 
-	public void setId(final long id) {
+	public void setId(final Long id) {
 		this.id = id;
 	}
 
@@ -62,7 +62,7 @@ public class TestEntity3 {
 		this.name = name;
 	}
 
-	public void setAge(final int age) {
+	public void setAge(final Integer age) {
 		this.age = age;
 	}
 
@@ -70,11 +70,11 @@ public class TestEntity3 {
 		this.birthday = birthday;
 	}
 
-	public int getLockVersion() {
+	public Integer getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final int lockVersion) {
+	public void setLockVersion(final Integer lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCustomLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCustomLockVersion.java
@@ -8,7 +8,7 @@ public class TestEntityCustomLockVersion {
 	private Long id;
 	private String name;
 	@Version(supplier = CustomOptimisticLockSupplier.class)
-	private long lockVersion = 0;
+	private Long lockVersion = 0L;
 
 	public TestEntityCustomLockVersion() {
 	}
@@ -44,11 +44,11 @@ public class TestEntityCustomLockVersion {
 		this.name = name;
 	}
 
-	public long getLockVersion() {
+	public Long getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final long lockVersion) {
+	public void setLockVersion(final Long lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCyclicLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityCyclicLockVersion.java
@@ -8,7 +8,7 @@ public class TestEntityCyclicLockVersion {
 	private Long id;
 	private String name;
 	@Version(supplier = CyclicLockVersionOptimisticLockSupplier.class)
-	private int lockVersion = 0;
+	private Integer lockVersion = 0;
 
 	public TestEntityCyclicLockVersion() {
 	}
@@ -44,11 +44,11 @@ public class TestEntityCyclicLockVersion {
 		this.name = name;
 	}
 
-	public int getLockVersion() {
+	public Integer getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final int lockVersion) {
+	public void setLockVersion(final Integer lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityForInserts.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityForInserts.java
@@ -6,16 +6,16 @@ import jp.co.future.uroborosql.mapping.annotations.Table;
 
 @Table(name = "TEST")
 public class TestEntityForInserts {
-	private long id;
+	private Long id;
 	private String name;
-	private int age;
+	private Integer age;
 	private LocalDate birthday;
 	private String memo;
 
 	public TestEntityForInserts() {
 	}
 
-	public TestEntityForInserts(final long id, final String name, final int age, final LocalDate birthday,
+	public TestEntityForInserts(final Long id, final String name, final Integer age, final LocalDate birthday,
 			final String memo) {
 		this.id = id;
 		this.name = name;
@@ -24,7 +24,7 @@ public class TestEntityForInserts {
 		this.memo = memo;
 	}
 
-	public long getId() {
+	public Long getId() {
 		return this.id;
 	}
 
@@ -32,7 +32,7 @@ public class TestEntityForInserts {
 		return this.name;
 	}
 
-	public int getAge() {
+	public Integer getAge() {
 		return this.age;
 	}
 
@@ -44,7 +44,7 @@ public class TestEntityForInserts {
 		return this.memo;
 	}
 
-	public void setId(final long id) {
+	public void setId(final Long id) {
 		this.id = id;
 	}
 
@@ -52,7 +52,7 @@ public class TestEntityForInserts {
 		this.name = name;
 	}
 
-	public void setAge(final int age) {
+	public void setAge(final Integer age) {
 		this.age = age;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityLockVersion.java
@@ -8,7 +8,7 @@ public class TestEntityLockVersion {
 	private Long id;
 	private String name;
 	@Version
-	private int lockVersion = 0;
+	private Integer lockVersion = 0;
 
 	public TestEntityLockVersion() {
 	}
@@ -44,11 +44,11 @@ public class TestEntityLockVersion {
 		this.name = name;
 	}
 
-	public int getLockVersion() {
+	public Integer getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final int lockVersion) {
+	public void setLockVersion(final Integer lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestampLockVersion.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestampLockVersion.java
@@ -8,7 +8,7 @@ public class TestEntityTimestampLockVersion {
 	private Long id;
 	private String name;
 	@Version(supplier = TimestampOptimisticLockSupplier.class)
-	private long lockVersion = 0;
+	private Long lockVersion = 0L;
 
 	public TestEntityTimestampLockVersion() {
 	}
@@ -44,11 +44,11 @@ public class TestEntityTimestampLockVersion {
 		this.name = name;
 	}
 
-	public long getLockVersion() {
+	public Long getLockVersion() {
 		return lockVersion;
 	}
 
-	public void setLockVersion(final long lockVersion) {
+	public void setLockVersion(final Long lockVersion) {
 		this.lockVersion = lockVersion;
 	}
 
@@ -81,7 +81,7 @@ public class TestEntityTimestampLockVersion {
 		} else if (!id.equals(other.id)) {
 			return false;
 		}
-		if (lockVersion != other.lockVersion) {
+		if (!lockVersion.equals(other.lockVersion)) {
 			return false;
 		}
 		if (name == null) {

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityWithDefaultValue.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityWithDefaultValue.java
@@ -3,73 +3,72 @@ package jp.co.future.uroborosql.mapping;
 import java.time.LocalDate;
 import java.util.Optional;
 
-public class TestEntity {
-	private Long id;
-	private String name;
-	private Integer age;
-	private LocalDate birthday;
-	private Optional<String> memo;
-	private Integer lockVersion;
+import jp.co.future.uroborosql.enums.GenerationType;
+import jp.co.future.uroborosql.mapping.annotations.GeneratedValue;
+import jp.co.future.uroborosql.mapping.annotations.Id;
+import jp.co.future.uroborosql.mapping.annotations.Table;
 
-	public TestEntity() {
+@Table(name = "TEST")
+public class TestEntityWithDefaultValue {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private Optional<String> name;
+	private Optional<Integer> age;
+	private Optional<LocalDate> birthday;
+	private Optional<String> memo;
+
+	public TestEntityWithDefaultValue() {
 	}
 
-	public TestEntity(final Long id, final String name, final Integer age, final LocalDate birthday,
-			final Optional<String> memo) {
+	public TestEntityWithDefaultValue(Long id, Optional<String> name, Optional<Integer> age,
+			Optional<LocalDate> birthday, Optional<String> memo) {
+		super();
 		this.id = id;
 		this.name = name;
 		this.age = age;
 		this.birthday = birthday;
 		this.memo = memo;
-		this.lockVersion = 0;
 	}
 
 	public Long getId() {
-		return this.id;
+		return id;
 	}
 
-	public String getName() {
-		return this.name;
-	}
-
-	public Integer getAge() {
-		return this.age;
-	}
-
-	public LocalDate getBirthday() {
-		return this.birthday;
-	}
-
-	public Optional<String> getMemo() {
-		return this.memo;
-	}
-
-	public Integer getLockVersion() {
-		return this.lockVersion;
-	}
-
-	public void setId(final Long id) {
+	public void setId(Long id) {
 		this.id = id;
 	}
 
-	public void setName(final String name) {
+	public Optional<String> getName() {
+		return name;
+	}
+
+	public void setName(Optional<String> name) {
 		this.name = name;
 	}
 
-	public void setAge(final Integer age) {
+	public Optional<Integer> getAge() {
+		return age;
+	}
+
+	public void setAge(Optional<Integer> age) {
 		this.age = age;
 	}
 
-	public void setBirthday(final LocalDate birthday) {
+	public Optional<LocalDate> getBirthday() {
+		return birthday;
+	}
+
+	public void setBirthday(Optional<LocalDate> birthday) {
 		this.birthday = birthday;
 	}
 
-	public void setMemo(final Optional<String> memo) {
-		this.memo = memo;
+	public Optional<String> getMemo() {
+		return memo;
 	}
 
-	public void setLockVersion(final Integer lockVersion) {
-		this.lockVersion = lockVersion;
+	public void setMemo(Optional<String> memo) {
+		this.memo = memo;
 	}
 
 	@Override
@@ -79,7 +78,6 @@ public class TestEntity {
 		result = prime * result + ((age == null) ? 0 : age.hashCode());
 		result = prime * result + ((birthday == null) ? 0 : birthday.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + ((lockVersion == null) ? 0 : lockVersion.hashCode());
 		result = prime * result + ((memo == null) ? 0 : memo.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		return result;
@@ -93,7 +91,7 @@ public class TestEntity {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		TestEntity other = (TestEntity) obj;
+		TestEntityWithDefaultValue other = (TestEntityWithDefaultValue) obj;
 		if (age == null) {
 			if (other.age != null)
 				return false;
@@ -108,11 +106,6 @@ public class TestEntity {
 			if (other.id != null)
 				return false;
 		} else if (!id.equals(other.id))
-			return false;
-		if (lockVersion == null) {
-			if (other.lockVersion != null)
-				return false;
-		} else if (!lockVersion.equals(other.lockVersion))
 			return false;
 		if (memo == null) {
 			if (other.memo != null)
@@ -129,8 +122,8 @@ public class TestEntity {
 
 	@Override
 	public String toString() {
-		return "TestEntity [id=" + id + ", name=" + name + ", age=" + age + ", birthday=" + birthday + ", memo=" + memo
-				+ ", lockVersion=" + lockVersion + "]";
+		return "TestEntityWithDefaultValue [id=" + id + ", name=" + name + ", age=" + age + ", birthday=" + birthday
+				+ ", memo=" + memo + "]";
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestHistoryEntity.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestHistoryEntity.java
@@ -3,7 +3,7 @@ package jp.co.future.uroborosql.mapping;
 import java.time.LocalDate;
 
 public class TestHistoryEntity {
-	private long id;
+	private Long id;
 	private LocalDate startAt;
 	private LocalDate finishAt;
 	private String name;
@@ -11,18 +11,18 @@ public class TestHistoryEntity {
 	public TestHistoryEntity() {
 	}
 
-	public TestHistoryEntity(final long id, final LocalDate startAt, final LocalDate finishAt, final String name) {
+	public TestHistoryEntity(final Long id, final LocalDate startAt, final LocalDate finishAt, final String name) {
 		this.id = id;
 		this.startAt = startAt;
 		this.finishAt = finishAt;
 		this.name = name;
 	}
 
-	public long getId() {
+	public Long getId() {
 		return id;
 	}
 
-	public void setId(final long id) {
+	public void setId(final Long id) {
 		this.id = id;
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/store/SqlManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/store/SqlManagerTest.java
@@ -160,7 +160,7 @@ public class SqlManagerTest {
 		SqlManagerImpl manager = new SqlManagerImpl(loadPaths);
 		manager.initialize();
 
-		assertThat(manager.getSqlPathList().size(), is(37));
+		assertThat(manager.getSqlPathList().size(), is(36));
 	}
 
 	@Test


### PR DESCRIPTION
Previously, even if a default value was specified for a column that was NOT NULL, if NULL was specified in the Entity field, NULL was specified in the generated SQL, resulting in an SQL error.

With this modification, for columns for which a default value is specified, if the field of Entity is NULL, SQL is issued in which the default value is valid.


The field type of the Entity class for testing has been changed accordingly, so the amount of modification has increased.