### PR TITLE
add uroborosql.use.qualified.table.name option

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -38,10 +38,15 @@ import jp.co.future.uroborosql.utils.StringUtils;
  * @author ota
  */
 public class DefaultEntityHandler implements EntityHandler<Object> {
+	/** TableMetadataのキャッシュサイズ. */
 	protected static final int CACHE_SIZE = Integer.valueOf(System.getProperty("uroborosql.entity.cache.size", "30"));
+	/** TableMetadataのLRUキャッシュ. */
 	protected static final ConcurrentLruCache<String, TableMetadata> CACHE = new ConcurrentLruCache<>(CACHE_SIZE);
+	/** プロパティマッパーマネージャー. */
 	protected PropertyMapperManager propertyMapperManager;
+	/** 空文字をNULLとして扱うか. */
 	protected boolean emptyStringEqualsNull = true;
+	/** SQLコンフィグ. */
 	protected SqlConfig sqlConfig = null;
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TableMetadata.java
@@ -34,6 +34,10 @@ public interface TableMetadata {
 	/** remark中の改行文字を除外するためのパターン */
 	Pattern NEWLINE_CHARS_PATTERN = Pattern.compile("\r\n|\r|\n");
 
+	/** SQL文構築時、スキーマ名で修飾されたテーブル名を使用するかどうか. */
+	boolean USE_QUALIFIED_TABLE_NAME = Boolean
+			.valueOf(System.getProperty("uroborosql.use.qualified.table.name", "true"));
+
 	/**
 	 * カラム情報
 	 */
@@ -197,7 +201,7 @@ public interface TableMetadata {
 		if (StringUtils.isEmpty(identifierQuoteString)) {
 			identifierQuoteString = "";
 		}
-		if (StringUtils.isEmpty(getSchema())) {
+		if (!USE_QUALIFIED_TABLE_NAME || StringUtils.isEmpty(getSchema())) {
 			return identifierQuoteString + getTableName() + identifierQuoteString;
 		} else {
 			return identifierQuoteString + getSchema() + identifierQuoteString + "." + identifierQuoteString

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerNoUseQualifiedTableNameTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerNoUseQualifiedTableNameTest.java
@@ -1,0 +1,180 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+
+/**
+ * DefaultEntityHandler の "uroborosql.use.qualified.table.name=false" オプションのテスト.<br>
+ * クラスロード時に設定されるため、単一のテストでは成功するが一括実行では失敗してしまう。そのためIgnoreを指定している
+ *
+ * @author H.Sugimoto
+ */
+@Ignore
+public class DefaultEntityHandlerNoUseQualifiedTableNameTest {
+
+	private static SqlConfig config;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:DefaultEntityHandlerWithDefaultValueTest;DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists test");
+				stmt.execute(
+						"create table if not exists test(id INTEGER auto_increment ,name VARCHAR(20) default 'default name',age NUMERIC(5) not null default 10,birthday DATE default '2000-01-01',memo VARCHAR(500),lock_version INTEGER, primary key(id))");
+				stmt.execute("comment on table test is 'test'");
+				stmt.execute("comment on column test.id is 'id'");
+				stmt.execute("comment on column test.name is 'name'");
+				stmt.execute("comment on column test.age is 'age'");
+				stmt.execute("comment on column test.birthday is 'birthday'");
+				stmt.execute("comment on column test.memo is 'memo'");
+				stmt.execute("comment on column test.lock_version is 'lock version'");
+			}
+		}
+
+		System.setProperty("uroborosql.use.qualified.table.name", "false");
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from test").count();
+			agent.commit();
+		}
+	}
+
+	@Test
+	public void testSelectContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createSelectContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testInsertContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createInsertContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createUpdateContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createDeleteContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createBatchInsertContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createBatchUpdateContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), not(containsString("PUBLIC")));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testTruncateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				// SQL文が取得できないので、成功することで確認とする
+				agent.truncate(TestEntity.class);
+			});
+		}
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerUseQualifiedTableNameTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerUseQualifiedTableNameTest.java
@@ -1,0 +1,176 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+
+/**
+ * DefaultEntityHandler の "uroborosql.use.qualified.table.name=true" オプションのテスト.<br>
+ *
+ * @author H.Sugimoto
+ */
+public class DefaultEntityHandlerUseQualifiedTableNameTest {
+
+	private static SqlConfig config;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:DefaultEntityHandlerWithDefaultValueTest;DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists test");
+				stmt.execute(
+						"create table if not exists test(id INTEGER auto_increment ,name VARCHAR(20) default 'default name',age NUMERIC(5) not null default 10,birthday DATE default '2000-01-01',memo VARCHAR(500),lock_version INTEGER, primary key(id))");
+				stmt.execute("comment on table test is 'test'");
+				stmt.execute("comment on column test.id is 'id'");
+				stmt.execute("comment on column test.name is 'name'");
+				stmt.execute("comment on column test.age is 'age'");
+				stmt.execute("comment on column test.birthday is 'birthday'");
+				stmt.execute("comment on column test.memo is 'memo'");
+				stmt.execute("comment on column test.lock_version is 'lock version'");
+			}
+		}
+
+		System.setProperty("uroborosql.use.qualified.table.name", "true");
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from test").count();
+			agent.commit();
+		}
+	}
+
+	@Test
+	public void testSelectContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createSelectContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testInsertContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createInsertContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createUpdateContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createDeleteContext(agent, metadata, TestEntity.class, false);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createBatchInsertContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				try {
+					DefaultEntityHandler handler = (DefaultEntityHandler) config.getEntityHandler();
+					TableMetadata metadata = handler.getMetadata(agent, TestEntity.class);
+					SqlContext context = handler.createBatchUpdateContext(agent, metadata, TestEntity.class);
+					assertThat(context.getSql(), containsString("PUBLIC"));
+				} catch (SQLException e) {
+					Assert.fail(e.getMessage());
+				}
+			});
+		}
+	}
+
+	@Test
+	public void testTruncateContext() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				// SQL文が取得できないので、成功することで確認とする
+				agent.truncate(TestEntity.class);
+			});
+		}
+	}
+
+}


### PR DESCRIPTION
Added option to specify whether to output only table names or table names qualified by schema names in the SQL generated by the DAO interface.

The "uroborosql.use.qualified.table.name" system property is specified before the EntityHandler (concrete class) is loaded into the JVM.
- true: schema name-qualified table name
- false: table name only

ex)
```java
System.setProperty("uroborosql.use.qualified.table.name", "true");
config = UroboroSQL.builder(url, user, password).build();
```


----
DAOインタフェースで生成するSQLにテーブル名のみを出力するか、スキーマ名で修飾したテーブル名を出力するかを指定するオプションを追加した。

"uroborosql.use.qualified.table.name"システムプロパティをEntityHandler（の具象クラス）がJVMにロードされる前に指定する。
- true: スキーマ名で修飾したテーブル名
- false: テーブル名のみ
