### PR TITLE
Add Cache Clear API for DefaultEntityHandler and MappingUtils

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/DefaultEntityHandler.java
@@ -870,4 +870,11 @@ public class DefaultEntityHandler implements EntityHandler<Object> {
 		return this.sqlConfig;
 	}
 
+	/**
+	 * TableMetadataのLRUキャッシュをクリアします.
+	 */
+	public static void clearCache() {
+		CACHE.clear();
+	}
+
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/MappingUtils.java
@@ -455,6 +455,13 @@ public final class MappingUtils {
 				.findFirst();
 	}
 
+	/**
+	 * MappingColumnのキャッシュをクリアします.
+	 */
+	public static void clearCache() {
+		CACHE.clear();
+	}
+
 	private static void walkFields(final Class<?> type, final JavaType.ImplementClass implementClass,
 			final Map<SqlKind, Map<String, MappingColumn>> fieldsMap) {
 		if (type.equals(Object.class)) {

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerTest.java
@@ -1,8 +1,11 @@
 package jp.co.future.uroborosql.mapping;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
@@ -2018,6 +2021,18 @@ public class DefaultEntityHandlerTest {
 		handler.removePropertyMapper(customMapper);
 
 		assertThat(instance.contains(customMapper), is(false));
+
+	}
+
+	@Test
+	public void testClearCache() throws Exception {
+		EntityHandler<?> handler = config.getEntityHandler();
+
+		if (handler instanceof DefaultEntityHandler) {
+			DefaultEntityHandler.clearCache();
+		} else {
+			fail();
+		}
 
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/mapping/MappingUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/MappingUtilsTest.java
@@ -198,6 +198,11 @@ public class MappingUtilsTest {
 		}
 	}
 
+	@Test
+	public void testClearCache() throws Exception {
+		MappingUtils.clearCache();
+	}
+
 	@Table(name = "TEST")
 	public static class Test1 {
 		@Id


### PR DESCRIPTION
When dynamically reloaded by Spring dev tools, the caches held inside DefaultEntityHandler and MappingUtils were not cleared, resulting in unexpected behavior in some cases. cache can be cleared when reloading.

---

Spring dev tools で動的リロードされる場合、DefaultEntityHandlerとMappingUtilsの内部で保持するキャッシュがクリアされず、予期しない動作となるケースがあったため、明示的にキャッシュをクリアするAPIを追加し、リロード時にキャッシュをクリアできるようにした。
