### PR TITLE
Added API to specify Mock action for SQL update/batch process

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -274,6 +274,11 @@ public class SqlAgentImpl extends AbstractAgent {
 	 */
 	@Override
 	public int update(final SqlContext sqlContext) throws SQLException {
+		if (sqlContext.getUpdateMockAction() != null) {
+			LOG.debug("Performs Mock action of update process");
+			return sqlContext.getUpdateMockAction().apply(sqlContext);
+		}
+
 		// パラメータログを出力する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.FALSE.toString());
 
@@ -400,6 +405,10 @@ public class SqlAgentImpl extends AbstractAgent {
 	 */
 	@Override
 	public int[] batch(final SqlContext sqlContext) throws SQLException {
+		if (sqlContext.getUpdateMockAction() != null) {
+			LOG.debug("Performs Mock action of batch process");
+			return new int[] { sqlContext.getUpdateMockAction().apply(sqlContext) };
+		}
 		// バッチ処理の場合大量のログが出力されるため、パラメータログの出力を抑止する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.TRUE.toString());
 

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -274,11 +274,6 @@ public class SqlAgentImpl extends AbstractAgent {
 	 */
 	@Override
 	public int update(final SqlContext sqlContext) throws SQLException {
-		if (sqlContext.getUpdateMockAction() != null) {
-			LOG.debug("Performs Mock action of update process");
-			return sqlContext.getUpdateMockAction().apply(sqlContext);
-		}
-
 		// パラメータログを出力する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.FALSE.toString());
 
@@ -288,6 +283,13 @@ public class SqlAgentImpl extends AbstractAgent {
 
 		// コンテキスト変換
 		transformContext(sqlContext, false);
+
+		// 更新移譲処理の指定がある場合は移譲処理を実行し結果を返却
+		if (sqlContext.getUpdateDelegate() != null) {
+			MDC.remove(SUPPRESS_PARAMETER_LOG_OUTPUT);
+			LOG.debug("Performs update delegate of update process");
+			return sqlContext.getUpdateDelegate().apply(sqlContext);
+		}
 
 		Instant startTime = null;
 
@@ -405,10 +407,6 @@ public class SqlAgentImpl extends AbstractAgent {
 	 */
 	@Override
 	public int[] batch(final SqlContext sqlContext) throws SQLException {
-		if (sqlContext.getUpdateMockAction() != null) {
-			LOG.debug("Performs Mock action of batch process");
-			return new int[] { sqlContext.getUpdateMockAction().apply(sqlContext) };
-		}
 		// バッチ処理の場合大量のログが出力されるため、パラメータログの出力を抑止する
 		MDC.put(SUPPRESS_PARAMETER_LOG_OUTPUT, Boolean.TRUE.toString());
 
@@ -418,6 +416,13 @@ public class SqlAgentImpl extends AbstractAgent {
 
 		// コンテキスト変換
 		transformContext(sqlContext, false);
+
+		// 更新移譲処理の指定がある場合は移譲処理を実行し結果を返却
+		if (sqlContext.getUpdateDelegate() != null) {
+			MDC.remove(SUPPRESS_PARAMETER_LOG_OUTPUT);
+			LOG.debug("Performs update delegate of batch process");
+			return new int[] { sqlContext.getUpdateDelegate().apply(sqlContext) };
+		}
 
 		Instant startTime = null;
 

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
@@ -290,21 +290,21 @@ public interface SqlContext extends TransformContext, SqlFluent<SqlContext>, Pro
 	void setGeneratedKeyValues(Object[] generatedKeyValues);
 
 	/**
-	 * 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理を取得する.<br>
+	 * 更新処理実行時に通常の更新SQL発行の代わりに移譲する処理を取得する.<br>
 	 * デフォルト実装は<code>null</code> を返却する. 必要に応じて子クラスでオーバーライドすること.
 	 *
 	 * @return 通常の更新SQL発行の代わりに行う疑似動作. <code>null</code> が返る場合は通常の更新処理を行う.
 	 */
-	default Function<SqlContext, Integer> getUpdateMockAction() {
+	default Function<SqlContext, Integer> getUpdateDelegate() {
 		return null;
 	}
 
 	/**
-	 * 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理を設定する.
+	 * 更新処理実行時に通常の更新SQL発行の代わりに移譲する処理を設定する.
 	 *
-	 * @param updateMockAction 通常の更新SQL発行の代わりに行う疑似動作. <code>null</code> を設定した場合は通常の更新処理を行う.
+	 * @param updateDelegate 通常の更新SQL発行の代わりに移譲する処理. <code>null</code> を設定した場合は通常の更新処理を行う.
 	 * @return 自身のSqlContext
 	 */
-	SqlContext setUpdateMockAction(Function<SqlContext, Integer> updateMockAction);
+	SqlContext setUpdateDelegate(Function<SqlContext, Integer> updateDelegate);
 
 }

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContext.java
@@ -12,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLType;
 import java.util.Map;
+import java.util.function.Function;
 
 import jp.co.future.uroborosql.enums.SqlKind;
 import jp.co.future.uroborosql.fluent.ProcedureFluent;
@@ -287,4 +288,23 @@ public interface SqlContext extends TransformContext, SqlFluent<SqlContext>, Pro
 	 * @param generatedKeyValues 自動採番するキーカラム値の配列
 	 */
 	void setGeneratedKeyValues(Object[] generatedKeyValues);
+
+	/**
+	 * 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理を取得する.<br>
+	 * デフォルト実装は<code>null</code> を返却する. 必要に応じて子クラスでオーバーライドすること.
+	 *
+	 * @return 通常の更新SQL発行の代わりに行う疑似動作. <code>null</code> が返る場合は通常の更新処理を行う.
+	 */
+	default Function<SqlContext, Integer> getUpdateMockAction() {
+		return null;
+	}
+
+	/**
+	 * 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理を設定する.
+	 *
+	 * @param updateMockAction 通常の更新SQL発行の代わりに行う疑似動作. <code>null</code> を設定した場合は通常の更新処理を行う.
+	 * @return 自身のSqlContext
+	 */
+	SqlContext setUpdateMockAction(Function<SqlContext, Integer> updateMockAction);
+
 }

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -167,8 +167,8 @@ public class SqlContextImpl implements SqlContext {
 	/** パラメータ名Set */
 	private ParameterNames parameterNames;
 
-	/** 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理. */
-	private Function<SqlContext, Integer> updateMockAction;
+	/** 更新処理実行時に通常の更新SQL発行の代わりに移譲する処理. */
+	private Function<SqlContext, Integer> updateDelegate;
 
 	/**
 	 * コンストラクタ。
@@ -1237,21 +1237,21 @@ public class SqlContextImpl implements SqlContext {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.context.SqlContext#getUpdateMockAction()
+	 * @see jp.co.future.uroborosql.context.SqlContext#getUpdateDelegate()
 	 */
 	@Override
-	public Function<SqlContext, Integer> getUpdateMockAction() {
-		return this.updateMockAction;
+	public Function<SqlContext, Integer> getUpdateDelegate() {
+		return this.updateDelegate;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see jp.co.future.uroborosql.context.SqlContext#setUpdateMockAction(java.util.function.Function)
+	 * @see jp.co.future.uroborosql.context.SqlContext#setUpdateDelegate(java.util.function.Function)
 	 */
 	@Override
-	public SqlContext setUpdateMockAction(Function<SqlContext, Integer> updateMockAction) {
-		this.updateMockAction = updateMockAction;
+	public SqlContext setUpdateDelegate(Function<SqlContext, Integer> updateDelegate) {
+		this.updateDelegate = updateDelegate;
 		return this;
 	}
 

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -163,7 +164,11 @@ public class SqlContextImpl implements SqlContext {
 	/** パラメータ変換マネージャ */
 	private BindParameterMapperManager parameterMapperManager;
 
+	/** パラメータ名Set */
 	private ParameterNames parameterNames;
+
+	/** 更新処理実行時に通常の更新SQL発行の代わりに疑似的に実行する処理. */
+	private Function<SqlContext, Integer> updateMockAction;
 
 	/**
 	 * コンストラクタ。
@@ -1227,6 +1232,27 @@ public class SqlContextImpl implements SqlContext {
 	@Override
 	public boolean hasGeneratedKeyColumns() {
 		return getGeneratedKeyColumns() != null && getGeneratedKeyColumns().length > 0;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.context.SqlContext#getUpdateMockAction()
+	 */
+	@Override
+	public Function<SqlContext, Integer> getUpdateMockAction() {
+		return this.updateMockAction;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.context.SqlContext#setUpdateMockAction(java.util.function.Function)
+	 */
+	@Override
+	public SqlContext setUpdateMockAction(Function<SqlContext, Integer> updateMockAction) {
+		this.updateMockAction = updateMockAction;
+		return this;
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
@@ -1,6 +1,9 @@
 package jp.co.future.uroborosql;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.nio.file.Paths;
@@ -19,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.MapResultSetConverter;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.fluent.SqlBatch;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
 public class SqlBatchTest extends AbstractDbTest {
@@ -374,6 +378,34 @@ public class SqlBatchTest extends AbstractDbTest {
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
+	}
+
+	/**
+	 * updateMockActionが指定された場合のテストケース。
+	 */
+	@Test
+	public void testUpdateMockAction() throws Exception {
+		Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (int i = 1; i <= 1000; i++) {
+			Map<String, Object> row = new HashMap<>();
+			row.put("product_id", i);
+			row.put("product_name", "商品名" + i);
+			row.put("product_kana_name", "ショウヒンメイ" + i);
+			row.put("jan_code", "1234567890124");
+			row.put("product_description", i + "番目の商品");
+			row.put("ins_datetime", currentDatetime);
+			row.put("upd_datetime", currentDatetime);
+			row.put("version_no", 1);
+			rows.add(row);
+		}
+		// 処理実行
+		SqlBatch batch = agent.batch("example/insert_product")
+				.paramStream(rows.stream());
+		SqlContext ctx = batch.context();
+		ctx.setUpdateMockAction(context -> 2);
+
+		assertThat(batch.count(), is(4));
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlBatchTest.java
@@ -381,10 +381,10 @@ public class SqlBatchTest extends AbstractDbTest {
 	}
 
 	/**
-	 * updateMockActionが指定された場合のテストケース。
+	 * updateDelegateが指定された場合のテストケース。
 	 */
 	@Test
-	public void testUpdateMockAction() throws Exception {
+	public void testUpdateDelegate() throws Exception {
 		Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
 		List<Map<String, Object>> rows = new ArrayList<>();
 		for (int i = 1; i <= 1000; i++) {
@@ -403,7 +403,7 @@ public class SqlBatchTest extends AbstractDbTest {
 		SqlBatch batch = agent.batch("example/insert_product")
 				.paramStream(rows.stream());
 		SqlContext ctx = batch.context();
-		ctx.setUpdateMockAction(context -> 2);
+		ctx.setUpdateDelegate(context -> 2);
 
 		assertThat(batch.count(), is(4));
 	}

--- a/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
@@ -113,18 +113,17 @@ public class SqlUpdateTest extends AbstractDbTest {
 	}
 
 	/**
-	 * updateMockActionが指定された場合のテストケース。
+	 * updateDelegateが指定された場合のテストケース。
 	 */
 	@Test
-	public void testUpdateMockAction() throws Exception {
+	public void testUpdateDelegate() throws Exception {
 		SqlUpdate update = agent.update("example/selectinsert_product")
 				.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
 				.param("jan_code", "1234567890123", Types.CHAR);
 		SqlContext ctx = update.context();
-		ctx.setUpdateMockAction(context -> 2);
+		ctx.setUpdateDelegate(context -> 2);
 
 		assertThat(update.count(), is(2));
-
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
@@ -1,6 +1,10 @@
 package jp.co.future.uroborosql;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.nio.file.Paths;
@@ -16,6 +20,7 @@ import org.junit.Test;
 import jp.co.future.uroborosql.context.SqlContext;
 import jp.co.future.uroborosql.converter.MapResultSetConverter;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.fluent.SqlUpdate;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
 public class SqlUpdateTest extends AbstractDbTest {
@@ -106,4 +111,20 @@ public class SqlUpdateTest extends AbstractDbTest {
 			fail(e.getMessage());
 		}
 	}
+
+	/**
+	 * updateMockActionが指定された場合のテストケース。
+	 */
+	@Test
+	public void testUpdateMockAction() throws Exception {
+		SqlUpdate update = agent.update("example/selectinsert_product")
+				.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
+				.param("jan_code", "1234567890123", Types.CHAR);
+		SqlContext ctx = update.context();
+		ctx.setUpdateMockAction(context -> 2);
+
+		assertThat(update.count(), is(2));
+
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/UpdateDelegateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/UpdateDelegateTest.java
@@ -1,0 +1,73 @@
+package jp.co.future.uroborosql;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.sql.DriverManager;
+import java.sql.JDBCType;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContextFactoryImpl;
+
+public class UpdateDelegateTest {
+	protected SqlConfig config;
+
+	@Before
+	public void setUp() throws Exception {
+		config = UroboroSQL.builder(DriverManager.getConnection("jdbc:h2:mem:" + this.getClass().getSimpleName()))
+				.setSqlContextFactory(new SqlContextFactoryImpl()
+						.addUpdateAutoParameterBinder(ctx -> ctx.setUpdateDelegate(context -> 2)))
+				.build();
+	}
+
+	/**
+	 * updateDelegateが指定されたupdateメソッドのテストケース。
+	 */
+	@Test
+	public void testUpdateDelegate() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			assertThat(agent.update("example/selectinsert_product")
+					.param("product_id", new BigDecimal("0"), JDBCType.DECIMAL)
+					.param("jan_code", "1234567890123", Types.CHAR).count(), is(2));
+		}
+	}
+
+	/**
+	 * updateDelegateが指定されたbatchメソッドのテストケース。
+	 */
+	@Test
+	public void testBatchUpdateDelegate() throws Exception {
+		Timestamp currentDatetime = Timestamp.valueOf("2005-12-12 10:10:10.000000000");
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (int i = 1; i <= 1000; i++) {
+			Map<String, Object> row = new HashMap<>();
+			row.put("product_id", i);
+			row.put("product_name", "商品名" + i);
+			row.put("product_kana_name", "ショウヒンメイ" + i);
+			row.put("jan_code", "1234567890124");
+			row.put("product_description", i + "番目の商品");
+			row.put("ins_datetime", currentDatetime);
+			row.put("upd_datetime", currentDatetime);
+			row.put("version_no", 1);
+			rows.add(row);
+		}
+
+		try (SqlAgent agent = config.agent()) {
+			// 処理実行
+			assertThat(agent.batch("example/insert_product")
+					.paramStream(rows.stream())
+					.count(), is(4));
+		}
+	}
+
+}


### PR DESCRIPTION
Added API to SqlContext to specify update delegate when there is a need to avoid SQL update process under certain conditions.

ex)
```java
SqlUpdate update = agent.update("example/insert_product");
SqlContext ctx = update.context();
ctx.setUpdateDelegate(context -> 1);
ctx.count(); // return 1

```