### PR TITLE
Fixed to not call close() method if the connection is already closed

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -1567,7 +1567,9 @@ public class SqlAgentImpl extends AbstractAgent {
 		public boolean tryAdvance(final Consumer<? super T> action) {
 			try {
 				if (finished || !rs.next()) {
-					rs.close();
+					if (!rs.isClosed()) {
+						rs.close();
+					}
 					finished = true;
 					return false;
 				}

--- a/src/main/java/jp/co/future/uroborosql/connection/ConnectionSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/ConnectionSupplier.java
@@ -47,7 +47,7 @@ public interface ConnectionSupplier {
 			throw new UroborosqlSQLException(ex);
 		} finally {
 			try {
-				if (conn != null) {
+				if (conn != null && !conn.isClosed()) {
 					conn.close();
 				}
 			} catch (SQLException ex) {

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
@@ -17,6 +17,9 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jp.co.future.uroborosql.config.SqlConfig;
 import jp.co.future.uroborosql.connection.ConnectionContext;
 import jp.co.future.uroborosql.context.SqlContext;
@@ -29,6 +32,8 @@ import jp.co.future.uroborosql.exception.UroborosqlTransactionException;
  * @author ota
  */
 class LocalTransactionContext implements AutoCloseable {
+	/** ロガー */
+	private static final Logger LOG = LoggerFactory.getLogger(LocalTransactionContext.class);
 
 	/** セーブポイント名リスト */
 	private final List<String> savepointNames = new ArrayList<>();
@@ -239,12 +244,12 @@ class LocalTransactionContext implements AutoCloseable {
 	 * @throws SQLException SQL例外. トランザクションのコミットに失敗した場合
 	 */
 	void commit() {
-		if (connection != null) {
-			try {
+		try {
+			if (connection != null && !connection.isClosed() && !connection.getAutoCommit()) {
 				connection.commit();
-			} catch (SQLException e) {
-				throw new UroborosqlSQLException(e);
 			}
+		} catch (SQLException e) {
+			throw new UroborosqlSQLException(e);
 		}
 		clearState();
 	}
@@ -255,12 +260,12 @@ class LocalTransactionContext implements AutoCloseable {
 	 * @throws SQLException SQL例外. トランザクションのロールバックに失敗した場合
 	 */
 	void rollback() {
-		if (connection != null) {
-			try {
+		try {
+			if (connection != null && !connection.isClosed() && !connection.getAutoCommit()) {
 				connection.rollback();
-			} catch (SQLException e) {
-				throw new UroborosqlSQLException(e);
 			}
+		} catch (SQLException e) {
+			throw new UroborosqlSQLException(e);
 		}
 		clearState();
 	}
@@ -272,19 +277,21 @@ class LocalTransactionContext implements AutoCloseable {
 	 */
 	@Override
 	public void close() {
-		if (connection != null) {
-			try {
-				if (!isRollbackOnly()) {
-					commit();
-				} else {
-					rollback();
-				}
-				connection.close();
-			} catch (SQLException e) {
-				throw new UroborosqlSQLException(e);
+		try {
+			if (!isRollbackOnly()) {
+				commit();
+			} else {
+				rollback();
 			}
-			connection = null;
+			if (connection != null && !connection.isClosed()) {
+				connection.close();
+			} else {
+				LOG.trace("Connection close was skipped because the connection was already closed.");
+			}
+		} catch (SQLException e) {
+			throw new UroborosqlSQLException(e);
 		}
+		connection = null;
 	}
 
 	/**


### PR DESCRIPTION
When connection#close() is called on a connection which is closed for some reason, SQLException will be thrown.   
To avoid this problem, we added a process to check if the connection has been closed or not.

----

何かの原因によってクローズされたコネクションに対してconnection#close()を呼び出すとSQLExceptionがスローされてしまう。  
これを回避するため、クローズ処理を行う際、そのコネクションがクローズ済みかどうかを判定する処理を追加した。