### PR TITLE
Improved SQL Batch insert performance issues.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
@@ -11,7 +11,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Savepoint;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -107,7 +106,7 @@ class LocalTransactionContext implements AutoCloseable {
 				if (sqlContext.hasGeneratedKeyColumns()) {
 					stmt = conn.prepareStatement(sqlContext.getExecutableSql(), sqlContext.getGeneratedKeyColumns());
 				} else {
-					stmt = conn.prepareStatement(sqlContext.getExecutableSql(), Statement.RETURN_GENERATED_KEYS);
+					stmt = conn.prepareStatement(sqlContext.getExecutableSql());
 				}
 			} else {
 				throw new UroborosqlTransactionException("Transaction not started.");


### PR DESCRIPTION
When generating PreparedStatement in postgresql, it was found that if autoGeneratedKeys argument is specified as Statement.RETURN_GENERATED_KEYS, it takes a lot of time to generate PreparedStatement.

Therefore, if there is no auto-generated keys, the autoGeneratedKeys argument should not be specified.

----

postgresqlでPreparedStatementを生成する際、  autoGeneratedKeys 引数に Statement.RETURN_GENERATED_KEYS を指定するとPreparedStatementの生成に時間がかかるため、自動採番キーがない場合は指定しないように修正