### PR TITLE
Add timestamp/LocalDateTime/OffsetDateTime/ZonedDateTime OptimisticLocking

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -926,8 +926,12 @@ public class SqlContextImpl implements SqlContext {
 	 */
 	@Override
 	public void bindBatchParams(final PreparedStatement preparedStatement) throws SQLException {
+		// parameterMap に設定されている共通のパラメータ（ESCAPE_CHARなど）を引き継ぐため、退避しておく
+		Map<String, Parameter> tempParamMap = new HashMap<>(parameterMap);
 		for (Map<String, Parameter> paramMap : batchParameters) {
-			parameterMap = paramMap;
+			Map<String, Parameter> batchParamMap = new HashMap<>(tempParamMap);
+			batchParamMap.putAll(paramMap);
+			parameterMap = batchParamMap;
 			bindParams(preparedStatement);
 			preparedStatement.addBatch();
 		}

--- a/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
@@ -6,6 +6,8 @@
  */
 package jp.co.future.uroborosql.mapping;
 
+import java.sql.Types;
+
 import jp.co.future.uroborosql.config.SqlConfig;
 
 /**
@@ -22,7 +24,13 @@ public class TimestampOptimisticLockSupplier extends OptimisticLockSupplier {
 	 */
 	@Override
 	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
-		return versionColumn.getColumnIdentifier() + " = " + System.currentTimeMillis();
+		if (Types.TIMESTAMP == versionColumn.getDataType()) {
+			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestamp(_zoneId)*/";
+		} else if (Types.TIMESTAMP_WITH_TIMEZONE == versionColumn.getDataType()) {
+			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestampWithZone(_zoneId)*/";
+		} else {
+			return versionColumn.getColumnIdentifier() + " = " + System.currentTimeMillis();
+		}
 	}
 
 }

--- a/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
+++ b/src/main/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplier.java
@@ -16,6 +16,10 @@ import jp.co.future.uroborosql.config.SqlConfig;
  * @author H.Sugimoto
  */
 public class TimestampOptimisticLockSupplier extends OptimisticLockSupplier {
+	/**
+	 * バージョンカラムの値生成時にZoneIdを渡す場合に設定するパラメータキー名 : {@value}
+	 */
+	public static final String PARAM_KEY_ZONE_ID = "_zoneId";
 
 	/**
 	 * {@inheritDoc}
@@ -25,9 +29,9 @@ public class TimestampOptimisticLockSupplier extends OptimisticLockSupplier {
 	@Override
 	public String getPart(final TableMetadata.Column versionColumn, final SqlConfig sqlConfig) {
 		if (Types.TIMESTAMP == versionColumn.getDataType()) {
-			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestamp(_zoneId)*/";
+			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestamp(" + PARAM_KEY_ZONE_ID + ")*/";
 		} else if (Types.TIMESTAMP_WITH_TIMEZONE == versionColumn.getDataType()) {
-			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestampWithZone(_zoneId)*/";
+			return versionColumn.getColumnIdentifier() + " = /*SF.nowTimestampWithZone(" + PARAM_KEY_ZONE_ID + ")*/";
 		} else {
 			return versionColumn.getColumnIdentifier() + " = " + System.currentTimeMillis();
 		}

--- a/src/main/java/jp/co/future/uroborosql/utils/StringFunction.java
+++ b/src/main/java/jp/co/future/uroborosql/utils/StringFunction.java
@@ -6,6 +6,10 @@
  */
 package jp.co.future.uroborosql.utils;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -561,6 +565,34 @@ public final class StringFunction {
 	 */
 	public Long incrementLong(final Long num) {
 		return num + 1L;
+	}
+
+	/**
+	 * 現在時刻のTimestampを取得する.
+	 *
+	 * @param zoneId ZoneId. <code>null</code> の場合はシステムクロックが利用される.
+	 * @return 現在時刻のTimestamp
+	 */
+	public Timestamp nowTimestamp(String zoneId) {
+		if (zoneId == null) {
+			return Timestamp.valueOf(LocalDateTime.now());
+		} else {
+			return Timestamp.valueOf(LocalDateTime.now(ZoneId.of(zoneId)));
+		}
+	}
+
+	/**
+	 * 現在時刻のTimestampを取得する（ゾーン計算あり）.
+	 *
+	 * @param zoneId ZoneId. <code>null</code> の場合はシステムクロックが利用される.
+	 * @return 現在時刻のTimestamp
+	 */
+	public Timestamp nowTimestampWithZone(String zoneId) {
+		if (zoneId == null) {
+			return new Timestamp(ZonedDateTime.now().toInstant().toEpochMilli());
+		} else {
+			return new Timestamp(ZonedDateTime.now(ZoneId.of(zoneId)).toInstant().toEpochMilli());
+		}
 	}
 
 	/**

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityLocalDateTime.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityLocalDateTime.java
@@ -1,0 +1,99 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.time.LocalDateTime;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_TIMESTAMP")
+public class TestEntityLocalDateTime {
+	private Long id;
+	private String name;
+	@Version(supplier = TimestampOptimisticLockSupplier.class)
+	private LocalDateTime updDatetime;
+
+	public TestEntityLocalDateTime() {
+	}
+
+	public TestEntityLocalDateTime(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public LocalDateTime getUpdDatetime() {
+		return updDatetime;
+	}
+
+	public void setUpdDatetime(final LocalDateTime updDatetime) {
+		this.updDatetime = updDatetime;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((updDatetime == null) ? 0 : updDatetime.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TestEntityLocalDateTime other = (TestEntityLocalDateTime) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (updDatetime == null) {
+			if (other.updDatetime != null)
+				return false;
+		} else if (!updDatetime.equals(other.updDatetime))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "TestEntityLocalDateTime [id=" + id + ", name=" + name + ", updDatetime=" + updDatetime + "]";
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityOffsetDateTime.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityOffsetDateTime.java
@@ -1,0 +1,99 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.time.OffsetDateTime;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_TIMESTAMPTZ")
+public class TestEntityOffsetDateTime {
+	private Long id;
+	private String name;
+	@Version(supplier = TimestampOptimisticLockSupplier.class)
+	private OffsetDateTime updDatetime;
+
+	public TestEntityOffsetDateTime() {
+	}
+
+	public TestEntityOffsetDateTime(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public OffsetDateTime getUpdDatetime() {
+		return updDatetime;
+	}
+
+	public void setUpdDatetime(final OffsetDateTime updDatetime) {
+		this.updDatetime = updDatetime;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((updDatetime == null) ? 0 : updDatetime.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TestEntityOffsetDateTime other = (TestEntityOffsetDateTime) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (updDatetime == null) {
+			if (other.updDatetime != null)
+				return false;
+		} else if (!updDatetime.equals(other.updDatetime))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "TestEntityOffsetDateTime [id=" + id + ", name=" + name + ", updDatetime=" + updDatetime + "]";
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestamp.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityTimestamp.java
@@ -1,0 +1,99 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.sql.Timestamp;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_TIMESTAMP")
+public class TestEntityTimestamp {
+	private Long id;
+	private String name;
+	@Version(supplier = TimestampOptimisticLockSupplier.class)
+	private Timestamp updDatetime;
+
+	public TestEntityTimestamp() {
+	}
+
+	public TestEntityTimestamp(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public Timestamp getUpdDatetime() {
+		return updDatetime;
+	}
+
+	public void setUpdDatetime(final Timestamp updDatetime) {
+		this.updDatetime = updDatetime;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((updDatetime == null) ? 0 : updDatetime.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TestEntityTimestamp other = (TestEntityTimestamp) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (updDatetime == null) {
+			if (other.updDatetime != null)
+				return false;
+		} else if (!updDatetime.equals(other.updDatetime))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "TestEntityTimestamp [id=" + id + ", name=" + name + ", updDatetime=" + updDatetime + "]";
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TestEntityZonedDateTime.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TestEntityZonedDateTime.java
@@ -1,0 +1,99 @@
+package jp.co.future.uroborosql.mapping;
+
+import java.time.ZonedDateTime;
+
+import jp.co.future.uroborosql.mapping.annotations.Table;
+import jp.co.future.uroborosql.mapping.annotations.Version;
+
+@Table(name = "TEST_TIMESTAMPTZ")
+public class TestEntityZonedDateTime {
+	private Long id;
+	private String name;
+	@Version(supplier = TimestampOptimisticLockSupplier.class)
+	private ZonedDateTime updDatetime;
+
+	public TestEntityZonedDateTime() {
+	}
+
+	public TestEntityZonedDateTime(final Long id, final String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * name を取得します。
+	 *
+	 * @return name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * name を設定します。
+	 *
+	 * @param name name
+	 */
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public ZonedDateTime getUpdDatetime() {
+		return updDatetime;
+	}
+
+	public void setUpdDatetime(final ZonedDateTime updDatetime) {
+		this.updDatetime = updDatetime;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((updDatetime == null) ? 0 : updDatetime.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TestEntityZonedDateTime other = (TestEntityZonedDateTime) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (updDatetime == null) {
+			if (other.updDatetime != null)
+				return false;
+		} else if (!updDatetime.equals(other.updDatetime))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "TestEntityZonedDateTime [id=" + id + ", name=" + name + ", updDatetime=" + updDatetime + "]";
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
@@ -135,7 +135,7 @@ public class TimestampOptimisticLockSupplierTest {
 	@Test
 	public void testUpdateTimestampWithTimezone() throws Exception {
 		ZoneId zoneId = ZoneId.of("Asia/Singapore");
-		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param(TimestampOptimisticLockSupplier.PARAM_KEY_ZONE_ID, zoneId);
 		try (SqlAgent agent = config.agent()) {
 			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
 			agent.required(() -> {
@@ -350,7 +350,7 @@ public class TimestampOptimisticLockSupplierTest {
 	@Test
 	public void testUpdateZonedDateTimeWithTimezone() throws Exception {
 		ZoneId zoneId = ZoneId.of("Asia/Singapore");
-		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param(TimestampOptimisticLockSupplier.PARAM_KEY_ZONE_ID, zoneId);
 		try (SqlAgent agent = config.agent()) {
 			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
 			agent.required(() -> {
@@ -565,7 +565,7 @@ public class TimestampOptimisticLockSupplierTest {
 	@Test
 	public void testUpdateLocalDateTimeWithTimezone() throws Exception {
 		ZoneId zoneId = ZoneId.of("Asia/Singapore");
-		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param(TimestampOptimisticLockSupplier.PARAM_KEY_ZONE_ID, zoneId);
 		try (SqlAgent agent = config.agent()) {
 			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
 			agent.required(() -> {
@@ -780,7 +780,7 @@ public class TimestampOptimisticLockSupplierTest {
 	@Test
 	public void testUpdateOffsetDateTimeWithTimezone() throws Exception {
 		ZoneId zoneId = ZoneId.of("Asia/Singapore");
-		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param(TimestampOptimisticLockSupplier.PARAM_KEY_ZONE_ID, zoneId);
 		try (SqlAgent agent = config.agent()) {
 			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
 			agent.required(() -> {

--- a/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
@@ -164,6 +164,12 @@ public class TimestampOptimisticLockSupplierTest {
 				test.setUpdDatetime(Timestamp.valueOf(now));
 				agent.insert(test);
 
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+
 				test.setName("updatename");
 				test.setUpdDatetime(Timestamp.valueOf(LocalDateTime.now()));
 				agent.update(test);
@@ -372,6 +378,12 @@ public class TimestampOptimisticLockSupplierTest {
 				TestEntityZonedDateTime test = new TestEntityZonedDateTime(1L, "name1");
 				test.setUpdDatetime(now);
 				agent.insert(test);
+
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
 
 				test.setName("updatename");
 				test.setUpdDatetime(ZonedDateTime.now());
@@ -582,6 +594,12 @@ public class TimestampOptimisticLockSupplierTest {
 				test.setUpdDatetime(now);
 				agent.insert(test);
 
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+
 				test.setName("updatename");
 				test.setUpdDatetime(LocalDateTime.now());
 				agent.update(test);
@@ -790,6 +808,12 @@ public class TimestampOptimisticLockSupplierTest {
 				TestEntityOffsetDateTime test = new TestEntityOffsetDateTime(1L, "name1");
 				test.setUpdDatetime(now);
 				agent.insert(test);
+
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
 
 				test.setName("updatename");
 				test.setUpdDatetime(OffsetDateTime.now());

--- a/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/TimestampOptimisticLockSupplierTest.java
@@ -1,0 +1,903 @@
+package jp.co.future.uroborosql.mapping;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jp.co.future.uroborosql.SqlAgent;
+import jp.co.future.uroborosql.UroboroSQL;
+import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.context.SqlContext;
+import jp.co.future.uroborosql.enums.InsertsType;
+import jp.co.future.uroborosql.exception.OptimisticLockException;
+import jp.co.future.uroborosql.filter.AuditLogSqlFilter;
+import jp.co.future.uroborosql.filter.SqlFilterManagerImpl;
+
+public class TimestampOptimisticLockSupplierTest {
+
+	private static SqlConfig config;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String url = "jdbc:h2:mem:TimestampOptimisticLockSupplierTest;DB_CLOSE_DELAY=-1";
+		String user = null;
+		String password = null;
+
+		try (Connection conn = DriverManager.getConnection(url, user, password)) {
+			conn.setAutoCommit(false);
+			// テーブル作成
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("drop table if exists test_timestamp");
+				stmt.execute(
+						"create table if not exists test_timestamp( id NUMERIC(4) not null,name VARCHAR(10) not null, upd_datetime TIMESTAMP not null, primary key(id))");
+				stmt.execute("drop table if exists test_timestamptz");
+				stmt.execute(
+						"create table if not exists test_timestamptz( id NUMERIC(4) not null,name VARCHAR(10) not null, upd_datetime TIMESTAMP WITH TIME ZONE not null, primary key(id))");
+			}
+		}
+
+		config = UroboroSQL.builder(url, user, password)
+				.setSqlFilterManager(new SqlFilterManagerImpl().addSqlFilter(new AuditLogSqlFilter()))
+				.build();
+	}
+
+	@Before
+	public void setUpBefore() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.updateWith("delete from test_timestamp").count();
+			agent.updateWith("delete from test_timestamptz").count();
+			agent.commit();
+		}
+	}
+
+	@Test
+	public void testInsertTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test1 = new TestEntityTimestamp(1L, "name1");
+				test1.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test1);
+				TestEntityTimestamp test2 = new TestEntityTimestamp(2L, "name2");
+				test2.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test2);
+				TestEntityTimestamp test3 = new TestEntityTimestamp(3L, "name3");
+				test3.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test3);
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityTimestamp.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityTimestamp.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testQueryTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test1 = new TestEntityTimestamp(1L, "name1");
+				test1.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test1);
+				TestEntityTimestamp test2 = new TestEntityTimestamp(2L, "name2");
+				test2.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test2);
+				TestEntityTimestamp test3 = new TestEntityTimestamp(3L, "name3");
+				test3.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test3);
+
+				List<TestEntityTimestamp> list = agent.query(TestEntityTimestamp.class).collect();
+				assertThat(list.get(0), is(test1));
+				assertThat(list.get(1), is(test2));
+				assertThat(list.get(2), is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test = new TestEntityTimestamp(1L, "name1");
+				test.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateTimestampWithTimezone() throws Exception {
+		ZoneId zoneId = ZoneId.of("Asia/Singapore");
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		try (SqlAgent agent = config.agent()) {
+			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test = new TestEntityTimestamp(1L, "name1");
+				test.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		} finally {
+			config.getSqlContextFactory().removeUpdateAutoParameterBinder(autoBinder);
+		}
+	}
+
+	@Test(expected = OptimisticLockException.class)
+	public void testUpdateTimestampLockVersionError() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test = new TestEntityTimestamp(1L, "name1");
+				test.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test);
+
+				test.setName("updatename");
+				test.setUpdDatetime(Timestamp.valueOf(LocalDateTime.now()));
+				agent.update(test);
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test = new TestEntityTimestamp(1L, "name1");
+				test.setUpdDatetime(Timestamp.valueOf(now));
+				agent.insert(test);
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test));
+
+				agent.delete(test);
+
+				data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test1 = new TestEntityTimestamp(1L, "name1");
+				test1.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test2 = new TestEntityTimestamp(2L, "name2");
+				test2.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test3 = new TestEntityTimestamp(3L, "name3");
+				test3.setUpdDatetime(Timestamp.valueOf(now));
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityTimestamp.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityTimestamp.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test1 = new TestEntityTimestamp(1L, "name1");
+				test1.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test2 = new TestEntityTimestamp(2L, "name2");
+				test2.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test3 = new TestEntityTimestamp(3L, "name3");
+				test3.setUpdDatetime(Timestamp.valueOf(now));
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				test1.setName("name1_upd");
+				test2.setName("name2_upd");
+				test3.setName("name3_upd");
+
+				List<TestEntityTimestamp> updateEntities = agent.updatesAndReturn(Stream.of(test1, test2, test3))
+						.collect(Collectors.toList());
+				assertThat(updateEntities.size(), is(3));
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(updateEntities.get(0)));
+				data = agent.find(TestEntityTimestamp.class, 2).orElse(null);
+				assertThat(data, is(updateEntities.get(1)));
+				data = agent.find(TestEntityTimestamp.class, 3).orElse(null);
+				assertThat(data, is(updateEntities.get(2)));
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsertTimestamp() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityTimestamp test1 = new TestEntityTimestamp(1L, "name1");
+				test1.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test2 = new TestEntityTimestamp(2L, "name2");
+				test2.setUpdDatetime(Timestamp.valueOf(now));
+				TestEntityTimestamp test3 = new TestEntityTimestamp(3L, "name3");
+				test3.setUpdDatetime(Timestamp.valueOf(now));
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BULK);
+				assertThat(count, is(3));
+
+				TestEntityTimestamp data = agent.find(TestEntityTimestamp.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityTimestamp.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityTimestamp.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	// ZonedDateTime
+
+	@Test
+	public void testInsertZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test1 = new TestEntityZonedDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityZonedDateTime test2 = new TestEntityZonedDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityZonedDateTime test3 = new TestEntityZonedDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityZonedDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityZonedDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testQueryZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test1 = new TestEntityZonedDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityZonedDateTime test2 = new TestEntityZonedDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityZonedDateTime test3 = new TestEntityZonedDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+
+				List<TestEntityZonedDateTime> list = agent.query(TestEntityZonedDateTime.class).collect();
+				assertThat(list.get(0), is(test1));
+				assertThat(list.get(1), is(test2));
+				assertThat(list.get(2), is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test = new TestEntityZonedDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateZonedDateTimeWithTimezone() throws Exception {
+		ZoneId zoneId = ZoneId.of("Asia/Singapore");
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		try (SqlAgent agent = config.agent()) {
+			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test = new TestEntityZonedDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		} finally {
+			config.getSqlContextFactory().removeUpdateAutoParameterBinder(autoBinder);
+		}
+	}
+
+	@Test(expected = OptimisticLockException.class)
+	public void testUpdateZonedDateTimeLockVersionError() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test = new TestEntityZonedDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				test.setUpdDatetime(ZonedDateTime.now());
+				agent.update(test);
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test = new TestEntityZonedDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+
+				agent.delete(test);
+
+				data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test1 = new TestEntityZonedDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityZonedDateTime test2 = new TestEntityZonedDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityZonedDateTime test3 = new TestEntityZonedDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityZonedDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityZonedDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test1 = new TestEntityZonedDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityZonedDateTime test2 = new TestEntityZonedDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityZonedDateTime test3 = new TestEntityZonedDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				test1.setName("name1_upd");
+				test2.setName("name2_upd");
+				test3.setName("name3_upd");
+
+				List<TestEntityZonedDateTime> updateEntities = agent.updatesAndReturn(Stream.of(test1, test2, test3))
+						.collect(Collectors.toList());
+				assertThat(updateEntities.size(), is(3));
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(updateEntities.get(0)));
+				data = agent.find(TestEntityZonedDateTime.class, 2).orElse(null);
+				assertThat(data, is(updateEntities.get(1)));
+				data = agent.find(TestEntityZonedDateTime.class, 3).orElse(null);
+				assertThat(data, is(updateEntities.get(2)));
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsertZonedDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				ZonedDateTime now = ZonedDateTime.now();
+				TestEntityZonedDateTime test1 = new TestEntityZonedDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityZonedDateTime test2 = new TestEntityZonedDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityZonedDateTime test3 = new TestEntityZonedDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BULK);
+				assertThat(count, is(3));
+
+				TestEntityZonedDateTime data = agent.find(TestEntityZonedDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityZonedDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityZonedDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	// LocalDateTime
+
+	@Test
+	public void testInsertLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test1 = new TestEntityLocalDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityLocalDateTime test2 = new TestEntityLocalDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityLocalDateTime test3 = new TestEntityLocalDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityLocalDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityLocalDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testQueryLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test1 = new TestEntityLocalDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityLocalDateTime test2 = new TestEntityLocalDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityLocalDateTime test3 = new TestEntityLocalDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+
+				List<TestEntityLocalDateTime> list = agent.query(TestEntityLocalDateTime.class).collect();
+				assertThat(list.get(0), is(test1));
+				assertThat(list.get(1), is(test2));
+				assertThat(list.get(2), is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test = new TestEntityLocalDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateLocalDateTimeWithTimezone() throws Exception {
+		ZoneId zoneId = ZoneId.of("Asia/Singapore");
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		try (SqlAgent agent = config.agent()) {
+			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test = new TestEntityLocalDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		} finally {
+			config.getSqlContextFactory().removeUpdateAutoParameterBinder(autoBinder);
+		}
+	}
+
+	@Test(expected = OptimisticLockException.class)
+	public void testUpdateLocalDateTimeLockVersionError() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test = new TestEntityLocalDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				test.setUpdDatetime(LocalDateTime.now());
+				agent.update(test);
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test = new TestEntityLocalDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+
+				agent.delete(test);
+
+				data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test1 = new TestEntityLocalDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityLocalDateTime test2 = new TestEntityLocalDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityLocalDateTime test3 = new TestEntityLocalDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityLocalDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityLocalDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test1 = new TestEntityLocalDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityLocalDateTime test2 = new TestEntityLocalDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityLocalDateTime test3 = new TestEntityLocalDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				test1.setName("name1_upd");
+				test2.setName("name2_upd");
+				test3.setName("name3_upd");
+
+				List<TestEntityLocalDateTime> updateEntities = agent.updatesAndReturn(Stream.of(test1, test2, test3))
+						.collect(Collectors.toList());
+				assertThat(updateEntities.size(), is(3));
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(updateEntities.get(0)));
+				data = agent.find(TestEntityLocalDateTime.class, 2).orElse(null);
+				assertThat(data, is(updateEntities.get(1)));
+				data = agent.find(TestEntityLocalDateTime.class, 3).orElse(null);
+				assertThat(data, is(updateEntities.get(2)));
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsertLocalDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				LocalDateTime now = LocalDateTime.now();
+				TestEntityLocalDateTime test1 = new TestEntityLocalDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityLocalDateTime test2 = new TestEntityLocalDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityLocalDateTime test3 = new TestEntityLocalDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BULK);
+				assertThat(count, is(3));
+
+				TestEntityLocalDateTime data = agent.find(TestEntityLocalDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityLocalDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityLocalDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	// OffsetDateTime
+
+	@Test
+	public void testInsertOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test1 = new TestEntityOffsetDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityOffsetDateTime test2 = new TestEntityOffsetDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityOffsetDateTime test3 = new TestEntityOffsetDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityOffsetDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityOffsetDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testQueryOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test1 = new TestEntityOffsetDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				agent.insert(test1);
+				TestEntityOffsetDateTime test2 = new TestEntityOffsetDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				agent.insert(test2);
+				TestEntityOffsetDateTime test3 = new TestEntityOffsetDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+				agent.insert(test3);
+
+				List<TestEntityOffsetDateTime> list = agent.query(TestEntityOffsetDateTime.class).collect();
+				assertThat(list.get(0), is(test1));
+				assertThat(list.get(1), is(test2));
+				assertThat(list.get(2), is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test = new TestEntityOffsetDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		}
+	}
+
+	@Test
+	public void testUpdateOffsetDateTimeWithTimezone() throws Exception {
+		ZoneId zoneId = ZoneId.of("Asia/Singapore");
+		Consumer<SqlContext> autoBinder = ctx -> ctx.param("_zoneId", zoneId);
+		try (SqlAgent agent = config.agent()) {
+			config.getSqlContextFactory().addUpdateAutoParameterBinder(autoBinder);
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test = new TestEntityOffsetDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				agent.update(test);
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+			});
+		} finally {
+			config.getSqlContextFactory().removeUpdateAutoParameterBinder(autoBinder);
+		}
+	}
+
+	@Test(expected = OptimisticLockException.class)
+	public void testUpdateOffsetDateTimeLockVersionError() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test = new TestEntityOffsetDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				test.setName("updatename");
+				test.setUpdDatetime(OffsetDateTime.now());
+				agent.update(test);
+			});
+		}
+	}
+
+	@Test
+	public void testDeleteOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test = new TestEntityOffsetDateTime(1L, "name1");
+				test.setUpdDatetime(now);
+				agent.insert(test);
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test));
+
+				agent.delete(test);
+
+				data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(nullValue()));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchInsertOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test1 = new TestEntityOffsetDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityOffsetDateTime test2 = new TestEntityOffsetDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityOffsetDateTime test3 = new TestEntityOffsetDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityOffsetDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityOffsetDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+
+	@Test
+	public void testBatchUpdateOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test1 = new TestEntityOffsetDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityOffsetDateTime test2 = new TestEntityOffsetDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityOffsetDateTime test3 = new TestEntityOffsetDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BATCH);
+				assertThat(count, is(3));
+
+				test1.setName("name1_upd");
+				test2.setName("name2_upd");
+				test3.setName("name3_upd");
+
+				List<TestEntityOffsetDateTime> updateEntities = agent.updatesAndReturn(Stream.of(test1, test2, test3))
+						.collect(Collectors.toList());
+				assertThat(updateEntities.size(), is(3));
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(updateEntities.get(0)));
+				data = agent.find(TestEntityOffsetDateTime.class, 2).orElse(null);
+				assertThat(data, is(updateEntities.get(1)));
+				data = agent.find(TestEntityOffsetDateTime.class, 3).orElse(null);
+				assertThat(data, is(updateEntities.get(2)));
+			});
+		}
+	}
+
+	@Test
+	public void testBulkInsertOffsetDateTime() throws Exception {
+		try (SqlAgent agent = config.agent()) {
+			agent.required(() -> {
+				OffsetDateTime now = OffsetDateTime.now();
+				TestEntityOffsetDateTime test1 = new TestEntityOffsetDateTime(1L, "name1");
+				test1.setUpdDatetime(now);
+				TestEntityOffsetDateTime test2 = new TestEntityOffsetDateTime(2L, "name2");
+				test2.setUpdDatetime(now);
+				TestEntityOffsetDateTime test3 = new TestEntityOffsetDateTime(3L, "name3");
+				test3.setUpdDatetime(now);
+
+				int count = agent.inserts(Stream.of(test1, test2, test3), InsertsType.BULK);
+				assertThat(count, is(3));
+
+				TestEntityOffsetDateTime data = agent.find(TestEntityOffsetDateTime.class, 1).orElse(null);
+				assertThat(data, is(test1));
+				data = agent.find(TestEntityOffsetDateTime.class, 2).orElse(null);
+				assertThat(data, is(test2));
+				data = agent.find(TestEntityOffsetDateTime.class, 3).orElse(null);
+				assertThat(data, is(test3));
+			});
+		}
+	}
+}


### PR DESCRIPTION
The Entity API now supports optimistic locking with columns of type timestamp or timestamp with timezone.  
Entity now allows fields of the following types to be annotated with the @Version annotation.

- Timestamp
- LocalDateTime
- OffsetDateTime
- ZonedDateTime

To add the @Version annotation, specify TimestampOptimisticLockSupplier as the OptimisticLockSupplier
```java
@Version(supplier = TimestampOptimisticLockSupplier.class)
private ZonedDateTime updDatetime;
```

----

Entity APIで timestamp型、または timestamp with timezone型のカラムを使った楽観ロックに対応しました。  
Entityで以下の型のフィールドに@Versionアノテーションを付与することができるようになりまる。  

- Timestamp
- LocalDateTime
- OffsetDateTime
- ZonedDateTime

@Versionアノテーションを付与する場合は、OptimisticLockSupplierとして TimestampOptimisticLockSupplierを指定してください
```java
@Version(supplier = TimestampOptimisticLockSupplier.class)
private ZonedDateTime updDatetime;
```