### PR TITLE
Fixed retries can be turned off by specifying 0 in the retry method of SqlQuery/SqlUpdate/SqlBatch/Procedure

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -131,7 +131,7 @@ public class SqlAgentImpl extends AbstractAgent {
 		try {
 			// デフォルト最大リトライ回数を取得し、個別指定（SqlContextの値）があれば上書き
 			int maxRetryCount = getMaxRetryCount();
-			if (sqlContext.getMaxRetryCount() > 0) {
+			if (sqlContext.getMaxRetryCount() >= 0) {
 				maxRetryCount = sqlContext.getMaxRetryCount();
 			}
 
@@ -308,7 +308,7 @@ public class SqlAgentImpl extends AbstractAgent {
 
 			// デフォルト最大リトライ回数を取得し、個別指定（SqlContextの値）があれば上書き
 			int maxRetryCount = getMaxRetryCount();
-			if (sqlContext.getMaxRetryCount() > 0) {
+			if (sqlContext.getMaxRetryCount() >= 0) {
 				maxRetryCount = sqlContext.getMaxRetryCount();
 			}
 
@@ -441,7 +441,7 @@ public class SqlAgentImpl extends AbstractAgent {
 
 			// デフォルト最大リトライ回数を取得し、個別指定（SqlContextの値）があれば上書き
 			int maxRetryCount = getMaxRetryCount();
-			if (sqlContext.getMaxRetryCount() > 0) {
+			if (sqlContext.getMaxRetryCount() >= 0) {
 				maxRetryCount = sqlContext.getMaxRetryCount();
 			}
 
@@ -572,7 +572,7 @@ public class SqlAgentImpl extends AbstractAgent {
 
 			// デフォルト最大リトライ回数を取得し、個別指定（SqlContextの値）があれば上書き
 			int maxRetryCount = getMaxRetryCount();
-			if (sqlContext.getMaxRetryCount() > 0) {
+			if (sqlContext.getMaxRetryCount() >= 0) {
 				maxRetryCount = sqlContext.getMaxRetryCount();
 			}
 

--- a/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/SqlContextImpl.java
@@ -108,7 +108,7 @@ public class SqlContextImpl implements SqlContext {
 	private String schema;
 
 	/** SQL実行の最大リトライ数 */
-	private int maxRetryCount = 0;
+	private int maxRetryCount = -1;
 
 	/** リトライを行う場合の待機時間（ms） */
 	private int retryWaitTime = 0;


### PR DESCRIPTION
Fixed a bug that DefaultMaxRetryCount was enabled when SqlQuery#retry(0) was used to turn off DefaultMaxRetryCount set at the time of SqlConfig construction when individual SQL was issued, but individual specification was not applied.

----

SqlConfig構築時に設定したDefaultMaxRetryCountを個別のSQL発行時にOFFにする目的で
SqlQuery#retry(0) としても、個別指定が適用されずDefaultMaxRetryCountが有効になっていた不具合を修正。