### PR TITLE
change EvnetSubscriber implementation class log level.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,19 +156,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<configuration>

--- a/src/main/java/jp/co/future/uroborosql/event/subscriber/AbstractSecretColumnEventSubscriber.java
+++ b/src/main/java/jp/co/future/uroborosql/event/subscriber/AbstractSecretColumnEventSubscriber.java
@@ -29,8 +29,8 @@ import javax.crypto.spec.IvParameterSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jp.co.future.uroborosql.event.BeforeSetParameterEvent;
 import jp.co.future.uroborosql.event.AfterSqlQueryEvent;
+import jp.co.future.uroborosql.event.BeforeSetParameterEvent;
 import jp.co.future.uroborosql.parameter.Parameter;
 import jp.co.future.uroborosql.utils.CaseFormat;
 import jp.co.future.uroborosql.utils.ObjectUtils;
@@ -47,7 +47,7 @@ import jp.co.future.uroborosql.utils.ObjectUtils;
  */
 public abstract class AbstractSecretColumnEventSubscriber<T> extends EventSubscriber {
 	/** イベントロガー */
-	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event");
+	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event.secretcolumn");
 
 	/** 設定ロガー */
 	private static final Logger SETTING_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.setting");

--- a/src/main/java/jp/co/future/uroborosql/event/subscriber/AuditLogEventSubscriber.java
+++ b/src/main/java/jp/co/future/uroborosql/event/subscriber/AuditLogEventSubscriber.java
@@ -26,7 +26,7 @@ import jp.co.future.uroborosql.event.AfterSqlUpdateEvent;
  */
 public class AuditLogEventSubscriber extends EventSubscriber {
 	/** イベントロガー */
-	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event");
+	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event.auditlog");
 
 	/** 機能名取得用のパラメータキー名 */
 	private String funcIdKey = "_funcId";

--- a/src/main/java/jp/co/future/uroborosql/event/subscriber/DebugEventSubscriber.java
+++ b/src/main/java/jp/co/future/uroborosql/event/subscriber/DebugEventSubscriber.java
@@ -13,11 +13,11 @@ import org.slf4j.LoggerFactory;
 
 import jp.co.future.uroborosql.event.AfterBeginTransactionEvent;
 import jp.co.future.uroborosql.event.AfterGetOutParameterEvent;
-import jp.co.future.uroborosql.event.BeforeEndTransactionEvent;
-import jp.co.future.uroborosql.event.BeforeSetParameterEvent;
 import jp.co.future.uroborosql.event.AfterSqlBatchEvent;
 import jp.co.future.uroborosql.event.AfterSqlQueryEvent;
 import jp.co.future.uroborosql.event.AfterSqlUpdateEvent;
+import jp.co.future.uroborosql.event.BeforeEndTransactionEvent;
+import jp.co.future.uroborosql.event.BeforeSetParameterEvent;
 
 /**
  * デバッグログを出力するEventSubscriber
@@ -27,7 +27,7 @@ import jp.co.future.uroborosql.event.AfterSqlUpdateEvent;
  */
 public class DebugEventSubscriber extends EventSubscriber {
 	/** ロガー */
-	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event");
+	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event.debug");
 
 	@Override
 	public void initialize() {

--- a/src/main/java/jp/co/future/uroborosql/event/subscriber/DumpResultEventSubscriber.java
+++ b/src/main/java/jp/co/future/uroborosql/event/subscriber/DumpResultEventSubscriber.java
@@ -38,7 +38,7 @@ import jp.co.future.uroborosql.utils.ObjectUtils;
  */
 public class DumpResultEventSubscriber extends EventSubscriber {
 	/** ロガー */
-	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event");
+	private static final Logger EVENT_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.event.dumpresult");
 
 	/** 文字数計算用のエンコーディング */
 	private static final String ENCODING_SHIFT_JIS = "Shift-JIS";

--- a/src/main/java/jp/co/future/uroborosql/store/SqlResourceManagerImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/store/SqlResourceManagerImpl.java
@@ -97,10 +97,10 @@ public class SqlResourceManagerImpl implements SqlResourceManager {
 	private ExecutorService es;
 
 	/** sqlNameとそれに対するSqlInfoの紐付きを持つMap */
-	private final ConcurrentHashMap<String, SqlInfo> sqlInfos = new ConcurrentHashMap<>();
+	protected final ConcurrentHashMap<String, SqlInfo> sqlInfos = new ConcurrentHashMap<>();
 
 	/** WatchKeyに対するディレクトリPathを取得するためのMap */
-	private final ConcurrentHashMap<WatchKey, Path> watchDirs = new ConcurrentHashMap<>();
+	protected final ConcurrentHashMap<WatchKey, Path> watchDirs = new ConcurrentHashMap<>();
 
 	/**
 	 * コンストラクタ


### PR DESCRIPTION
Changed log level so that log output settings can be changed for each event subscriber implementation class.

|class|loglevel|
|:--|:--|
|SecretColumnEventSubscriber|jp.co.future.uroborosql.event.secretcolumn|
|AuditLogEventSubscriber|jp.co.future.uroborosql.event.auditlog|
|DebugEventSubscriber|jp.co.future.uroborosql.event.debug|
|DumpResultEventSubscriber|jp.co.future.uroborosql.event.dumpresult|

And, change the visibility of SqlResourceManagerImpl#sqlInfos from private to protected