### PR TITLE
add sqlId() api to SqlEntity interfaces.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlEntityDeleteImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityDeleteImpl.java
@@ -45,6 +45,38 @@ final class SqlEntityDeleteImpl<E> extends AbstractExtractionCondition<SqlEntity
 		this.entityType = entityType;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityDelete#sqlId(java.lang.String)
+	 */
+	@Override
+	public SqlEntityDelete<E> sqlId(final String sqlId) {
+		context().setSqlId(sqlId);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityDelete#retry(int)
+	 */
+	@Override
+	public SqlEntityDelete<E> retry(final int count) {
+		return retry(count, 0);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityDelete#retry(int, int)
+	 */
+	@Override
+	public SqlEntityDelete<E> retry(final int count, final int waitTime) {
+		context().setMaxRetryCount(count).setRetryWaitTime(waitTime);
+		return this;
+	}
+
 	@Override
 	public int count() {
 		try {

--- a/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
@@ -83,6 +83,38 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityQuery#sqlId(java.lang.String)
+	 */
+	@Override
+	public SqlEntityQuery<E> sqlId(final String sqlId) {
+		context().setSqlId(sqlId);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityQuery#retry(int)
+	 */
+	@Override
+	public SqlEntityQuery<E> retry(final int count) {
+		return retry(count, 0);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityQuery#retry(int, int)
+	 */
+	@Override
+	public SqlEntityQuery<E> retry(final int count, final int waitTime) {
+		context().setMaxRetryCount(count).setRetryWaitTime(waitTime);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlEntityQuery#collect()
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityUpdateImpl.java
@@ -51,6 +51,38 @@ final class SqlEntityUpdateImpl<E> extends AbstractExtractionCondition<SqlEntity
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#sqlId(java.lang.String)
+	 */
+	@Override
+	public SqlEntityUpdate<E> sqlId(final String sqlId) {
+		context().setSqlId(sqlId);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#retry(int)
+	 */
+	@Override
+	public SqlEntityUpdate<E> retry(final int count) {
+		return retry(count, 0);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#retry(int, int)
+	 */
+	@Override
+	public SqlEntityUpdate<E> retry(final int count, final int waitTime) {
+		context().setMaxRetryCount(count).setRetryWaitTime(waitTime);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.fluent.SqlEntityUpdate#count()
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityDelete.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityDelete.java
@@ -14,6 +14,31 @@ package jp.co.future.uroborosql.fluent;
  */
 public interface SqlEntityDelete<E> extends ExtractionCondition<SqlEntityDelete<E>> {
 	/**
+	 * 発行するSQLに付与するSQL_IDを設定する
+	 *
+	 * @param sqlId SQL_ID文字列
+	 * @return SqlEntityDelete
+	 */
+	SqlEntityDelete<E> sqlId(String sqlId);
+
+	/**
+	 * リトライ回数を設定する。 リトライ待機時間は0msが設定される
+	 *
+	 * @param count リトライ回数
+	 * @return SqlEntityDelete
+	 */
+	SqlEntityDelete<E> retry(int count);
+
+	/**
+	 * リトライ回数を設定する
+	 *
+	 * @param count リトライ回数
+	 * @param waitTime リトライ待機時間（ms）
+	 * @return SqlEntityDelete
+	 */
+	SqlEntityDelete<E> retry(int count, int waitTime);
+
+	/**
 	 * 削除結果の取得（終端処理）
 	 *
 	 * @return 削除件数

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityQuery.java
@@ -53,6 +53,31 @@ public interface SqlEntityQuery<E> extends ExtractionCondition<SqlEntityQuery<E>
 	}
 
 	/**
+	 * 発行するSQLに付与するSQL_IDを設定する
+	 *
+	 * @param sqlId SQL_ID文字列
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> sqlId(String sqlId);
+
+	/**
+	 * リトライ回数を設定する。 リトライ待機時間は0msが設定される
+	 *
+	 * @param count リトライ回数
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> retry(int count);
+
+	/**
+	 * リトライ回数を設定する
+	 *
+	 * @param count リトライ回数
+	 * @param waitTime リトライ待機時間（ms）
+	 * @return SqlEntityQuery
+	 */
+	SqlEntityQuery<E> retry(int count, int waitTime);
+
+	/**
 	 * 検索結果の取得（終端処理）
 	 *
 	 * @return 検索結果のEntityリスト.

--- a/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityUpdate.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/SqlEntityUpdate.java
@@ -17,6 +17,31 @@ import java.util.function.Supplier;
  */
 public interface SqlEntityUpdate<E> extends ExtractionCondition<SqlEntityUpdate<E>> {
 	/**
+	 * 発行するSQLに付与するSQL_IDを設定する
+	 *
+	 * @param sqlId SQL_ID文字列
+	 * @return SqlEntityUpdate
+	 */
+	SqlEntityUpdate<E> sqlId(String sqlId);
+
+	/**
+	 * リトライ回数を設定する。 リトライ待機時間は0msが設定される
+	 *
+	 * @param count リトライ回数
+	 * @return SqlEntityUpdate
+	 */
+	SqlEntityUpdate<E> retry(int count);
+
+	/**
+	 * リトライ回数を設定する
+	 *
+	 * @param count リトライ回数
+	 * @param waitTime リトライ待機時間（ms）
+	 * @return SqlEntityUpdate
+	 */
+	SqlEntityUpdate<E> retry(int count, int waitTime);
+
+	/**
 	 * 更新結果の取得（終端処理）
 	 *
 	 * @return 更新件数


### PR DESCRIPTION
sqlId() and retry() are no longer available due to the removal of the SqlFluent interface from the SqlEntity interfaces (SqlEntityQuery, SqlEntityUpdate, SqlEntityDelete).
 sqlId() and retry() are also used in the SqlEntity interface, so they were added to SqlEntityQuery, SqlEntityUpdate, and SqlEntityDelete respectively