### PR TITLE
Remove entityhandler configuration API from uroboroSQL.builder interface

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
+++ b/src/main/java/jp/co/future/uroborosql/UroboroSQL.java
@@ -112,7 +112,6 @@ public final class UroboroSQL {
 		private EventListenerHolder eventListenerHolder;
 		private ExecutionContextProvider executionContextProvider;
 		private SqlAgentProvider sqlAgentProvider;
-		private EntityHandler<?> entityHandler;
 		private Clock clock;
 		private Dialect dialect;
 		private ExpressionParser expressionParser;
@@ -123,7 +122,6 @@ public final class UroboroSQL {
 			this.eventListenerHolder = new EventListenerHolder();
 			this.executionContextProvider = new ExecutionContextProviderImpl();
 			this.sqlAgentProvider = new SqlAgentProviderImpl();
-			this.entityHandler = new DefaultEntityHandler();
 			this.clock = null;
 			this.dialect = null;
 			this.expressionParser = null;
@@ -185,17 +183,6 @@ public final class UroboroSQL {
 		}
 
 		/**
-		 * EntityHandlerの設定.
-		 *
-		 * @param entityHandler entityHandler
-		 * @return UroboroSQLBuilder
-		 */
-		public UroboroSQLBuilder setEntityHandler(final EntityHandler<?> entityHandler) {
-			this.entityHandler = entityHandler;
-			return this;
-		}
-
-		/**
 		 * Clockの設定.
 		 *
 		 * @param clock clock
@@ -244,7 +231,6 @@ public final class UroboroSQL {
 					this.executionContextProvider,
 					this.sqlAgentProvider,
 					this.eventListenerHolder,
-					this.entityHandler,
 					this.clock,
 					this.dialect,
 					this.expressionParser);
@@ -303,7 +289,6 @@ public final class UroboroSQL {
 				final ExecutionContextProvider executionContextProvider,
 				final SqlAgentProvider sqlAgentProvider,
 				final EventListenerHolder eventListenerHolder,
-				final EntityHandler<?> entityHandler,
 				final Clock clock,
 				final Dialect dialect,
 				final ExpressionParser expressionParser) {
@@ -312,7 +297,7 @@ public final class UroboroSQL {
 			this.executionContextProvider = executionContextProvider;
 			this.sqlAgentProvider = sqlAgentProvider;
 			this.eventListenerHolder = eventListenerHolder;
-			this.entityHandler = entityHandler;
+			this.entityHandler = new DefaultEntityHandler();
 			if (clock == null) {
 				this.clock = Clock.systemDefaultZone();
 				if (SETTING_LOG.isWarnEnabled()) {

--- a/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
+++ b/src/test/java/jp/co/future/uroborosql/UroboroSQLTest.java
@@ -36,7 +36,6 @@ import jp.co.future.uroborosql.connection.DefaultConnectionSupplierImpl;
 import jp.co.future.uroborosql.dialect.H2Dialect;
 import jp.co.future.uroborosql.enums.InsertsType;
 import jp.co.future.uroborosql.event.EventListenerHolder;
-import jp.co.future.uroborosql.mapping.DefaultEntityHandler;
 import jp.co.future.uroborosql.store.SqlResourceManagerImpl;
 import jp.co.future.uroborosql.utils.CaseFormat;
 import jp.co.future.uroborosql.utils.ObjectUtils;
@@ -171,26 +170,6 @@ public class UroboroSQLTest {
 	void builderSetSqlResourceManager() throws Exception {
 		var config = UroboroSQL.builder("jdbc:h2:mem:" + this.getClass().getSimpleName(), "", "", null)
 				.setSqlResourceManager(new SqlResourceManagerImpl(false)).build();
-		try (var agent = config.agent()) {
-			var sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/ddl/create_tables.sql")),
-					StandardCharsets.UTF_8).split(";");
-			for (var sql : sqls) {
-				if (ObjectUtils.isNotBlank(sql)) {
-					agent.updateWith(sql.trim()).count();
-				}
-			}
-
-			insert(agent, Paths.get("src/test/resources/data/setup", "testExecuteQuery.ltsv"));
-			agent.rollback();
-		}
-
-		assertEquals(true, config.getSqlResourceManager().existSql("ddl/create_tables"));
-	}
-
-	@Test
-	void builderSetEntityHandler() throws Exception {
-		var config = UroboroSQL.builder("jdbc:h2:mem:" + this.getClass().getSimpleName(), "", "", null)
-				.setEntityHandler(new DefaultEntityHandler()).build();
 		try (var agent = config.agent()) {
 			var sqls = new String(Files.readAllBytes(Paths.get("src/test/resources/sql/ddl/create_tables.sql")),
 					StandardCharsets.UTF_8).split(";");


### PR DESCRIPTION
Removed the addition of EntityHandler from the UroboroSQL.builder interface because the addition of the Event API eliminated the need to add its own EventHandler extension.