### PR TITLE
unmanagedConnection can not use savepoint.

### DIFF
--- a/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
+++ b/src/test/java/jp/co/future/uroborosql/tx/LocalTxManagerTest.java
@@ -377,6 +377,19 @@ public class LocalTxManagerTest {
 	}
 
 	@Test
+	void testSavepointScopeWithUnmanagedConnection() {
+		try (var agent = config.agent()) {
+			try {
+				agent.savepointScope(() -> {
+					throw new IllegalAccessError();
+				});
+			} catch (UroborosqlRuntimeException ex) {
+				assertThat(ex.getMessage(), is("UnmanagedConnection cannot use savepoint."));
+			}
+		}
+	}
+
+	@Test
 	void testagentEx01() {
 
 		try (var agent = config.agent()) {


### PR DESCRIPTION
Fixed to throw an exception so that savepointScope cannot be started explicitly because Transaction is not started in the UnmanagedConnection state.