### PR TITLE
Fixed to use Optional#orElseThrow() instead of Optional#get()

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -59,6 +59,10 @@ import jp.co.future.uroborosql.event.AfterEntityDeleteEvent;
 import jp.co.future.uroborosql.event.AfterEntityInsertEvent;
 import jp.co.future.uroborosql.event.AfterEntityQueryEvent;
 import jp.co.future.uroborosql.event.AfterEntityUpdateEvent;
+import jp.co.future.uroborosql.event.AfterProcedureEvent;
+import jp.co.future.uroborosql.event.AfterSqlBatchEvent;
+import jp.co.future.uroborosql.event.AfterSqlQueryEvent;
+import jp.co.future.uroborosql.event.AfterSqlUpdateEvent;
 import jp.co.future.uroborosql.event.BeforeEntityBatchInsertEvent;
 import jp.co.future.uroborosql.event.BeforeEntityBatchUpdateEvent;
 import jp.co.future.uroborosql.event.BeforeEntityBulkInsertEvent;
@@ -67,10 +71,6 @@ import jp.co.future.uroborosql.event.BeforeEntityInsertEvent;
 import jp.co.future.uroborosql.event.BeforeEntityQueryEvent;
 import jp.co.future.uroborosql.event.BeforeEntityUpdateEvent;
 import jp.co.future.uroborosql.event.BeforeParseSqlEvent;
-import jp.co.future.uroborosql.event.AfterProcedureEvent;
-import jp.co.future.uroborosql.event.AfterSqlBatchEvent;
-import jp.co.future.uroborosql.event.AfterSqlQueryEvent;
-import jp.co.future.uroborosql.event.AfterSqlUpdateEvent;
 import jp.co.future.uroborosql.event.BeforeTransformSqlEvent;
 import jp.co.future.uroborosql.exception.EntitySqlRuntimeException;
 import jp.co.future.uroborosql.exception.OptimisticLockException;
@@ -1269,7 +1269,7 @@ public class SqlAgentImpl implements SqlAgent {
 					: 0);
 
 			if (updatedEntities != null && versionColumn.isPresent()) {
-				var vColumn = versionColumn.get();
+				var vColumn = versionColumn.orElseThrow();
 				var keyColumns = metadata.getColumns().stream()
 						.filter(TableMetadata.Column::isKey)
 						.sorted(Comparator.comparingInt(TableMetadata.Column::getKeySeq))
@@ -1816,7 +1816,8 @@ public class SqlAgentImpl implements SqlAgent {
 					var result = callableStatement.execute();
 					// Procedure実行後イベント発行
 					if (getSqlConfig().getEventListenerHolder().hasAfterProcedureListener()) {
-						var eventObj = new AfterProcedureEvent(executionContext, result, callableStatement.getConnection(),
+						var eventObj = new AfterProcedureEvent(executionContext, result,
+								callableStatement.getConnection(),
 								callableStatement);
 						for (var listener : getSqlConfig().getEventListenerHolder().getAfterProcedureListeners()) {
 							listener.accept(eventObj);

--- a/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlEntityQueryImpl.java
@@ -318,7 +318,9 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 		context().setSql(sql.toString());
 		try {
 			return (T) mappingColumn
-					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType).findFirst().get());
+					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType)
+							.findFirst()
+							.orElseThrow());
 		} catch (final SQLException ex) {
 			throw new EntitySqlRuntimeException(context().getSqlKind(), ex);
 		}
@@ -344,7 +346,9 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 		context().setSql(sql.toString());
 		try {
 			return (T) mappingColumn
-					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType).findFirst().get());
+					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType)
+							.findFirst()
+							.orElseThrow());
 		} catch (SQLException ex) {
 			throw new EntitySqlRuntimeException(context().getSqlKind(), ex);
 		}
@@ -370,7 +374,9 @@ final class SqlEntityQueryImpl<E> extends AbstractExtractionCondition<SqlEntityQ
 		context().setSql(sql.toString());
 		try {
 			return (T) mappingColumn
-					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType).findFirst().get());
+					.getValue(this.entityHandler.doSelect(agent(), context(), this.entityType)
+							.findFirst()
+							.orElseThrow());
 		} catch (SQLException ex) {
 			throw new EntitySqlRuntimeException(context().getSqlKind(), ex);
 		}

--- a/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
@@ -333,13 +333,14 @@ public class SqlREPL {
 		}
 
 		var parts = SqlParamUtils.parseLine(line);
-		var command = commands.stream().filter(c -> c.is(parts[0])).findFirst();
-		if (command.isPresent()) {
-			return command.get().execute(reader, parts, sqlConfig, props);
-		} else {
-			showHelp(reader.getTerminal());
-			return true;
-		}
+		return commands.stream()
+				.filter(c -> c.is(parts[0]))
+				.findFirst()
+				.map(cmd -> cmd.execute(reader, parts, sqlConfig, props))
+				.orElseGet(() -> {
+					showHelp(reader.getTerminal());
+					return true;
+				});
 	}
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/client/command/ParseCommand.java
+++ b/src/main/java/jp/co/future/uroborosql/client/command/ParseCommand.java
@@ -53,60 +53,60 @@ public class ParseCommand extends ReplCommand {
 		writer.println("PARSE:");
 
 		if (parts.length > 1) {
-			var path = sqlConfig.getSqlResourceManager().getSqlPathList().stream()
+			sqlConfig.getSqlResourceManager().getSqlPathList().stream()
 					.filter(p -> p.equalsIgnoreCase(parts[1]))
-					.findFirst();
-			if (path.isPresent()) {
-				var sql = sqlConfig.getSqlResourceManager().getSql(path.get());
+					.findFirst()
+					.ifPresentOrElse(path -> {
+						var sql = sqlConfig.getSqlResourceManager().getSql(path);
 
-				// 対象SQLの出力
-				writer.println("");
-				writer.println("SQL :");
-				var sqlLines = sql.split("\\r\\n|\\r|\\n");
-				for (var sqlLine : sqlLines) {
-					writer.println(sqlLine);
-				}
+						// 対象SQLの出力
+						writer.println("");
+						writer.println("SQL :");
+						var sqlLines = sql.split("\\r\\n|\\r|\\n");
+						for (var sqlLine : sqlLines) {
+							writer.println(sqlLine);
+						}
 
-				// IF分岐の出力
-				writer.println("");
-				writer.println("BRANCHES :");
-				var parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
-						sqlConfig.getDialect().isRemoveTerminator(), true);
-				var transformer = parser.parse();
-				var rootNode = transformer.getRoot();
-				Set<String> bindParams = new LinkedHashSet<>();
-				traverseNode(writer, 0, sqlConfig.getExpressionParser(), rootNode, bindParams);
+						// IF分岐の出力
+						writer.println("");
+						writer.println("BRANCHES :");
+						var parser = new SqlParserImpl(sql, sqlConfig.getExpressionParser(),
+								sqlConfig.getDialect().isRemoveTerminator(), true);
+						var transformer = parser.parse();
+						var rootNode = transformer.getRoot();
+						Set<String> bindParams = new LinkedHashSet<>();
+						traverseNode(writer, 0, sqlConfig.getExpressionParser(), rootNode, bindParams);
 
-				// 利用されているバインドパラメータの出力
-				writer.println("");
-				var constPrefix = sqlConfig.getExecutionContextProvider().getConstParamPrefix();
-				var ctx = sqlConfig.getExecutionContextProvider().createExecutionContext();
-				writer.println("BIND_PARAMS :");
-				// 定数以外のバインドパラメータ
-				bindParams.stream().filter(param -> !param.startsWith(constPrefix))
-						.sorted()
-						.forEach(param -> write(writer, 1, null, param, null));
-				// 定数バインドパラメータ
-				bindParams.stream().filter(param -> param.startsWith(constPrefix))
-						.sorted().forEach(param -> {
-							// 定数についてはバインド値が取得できるので、実際の値を追加で表示
-							var parameter = ctx.getParam(param);
-							if (parameter != null) {
-								var value = parameter.getValue();
-								String suffix = null;
-								if (value instanceof String) {
-									suffix = String.format(" ('%s')", value);
-								} else {
-									suffix = String.format(" (%s)", value);
-								}
-								write(writer, 1, null, param, suffix);
-							} else {
-								write(writer, 1, null, param, " (not found)");
-							}
-						});
-			} else {
-				writer.println("sqlName : " + parts[1] + " not found.");
-			}
+						// 利用されているバインドパラメータの出力
+						writer.println("");
+						var constPrefix = sqlConfig.getExecutionContextProvider().getConstParamPrefix();
+						var ctx = sqlConfig.getExecutionContextProvider().createExecutionContext();
+						writer.println("BIND_PARAMS :");
+						// 定数以外のバインドパラメータ
+						bindParams.stream().filter(param -> !param.startsWith(constPrefix))
+								.sorted()
+								.forEach(param -> write(writer, 1, null, param, null));
+						// 定数バインドパラメータ
+						bindParams.stream().filter(param -> param.startsWith(constPrefix))
+								.sorted().forEach(param -> {
+									// 定数についてはバインド値が取得できるので、実際の値を追加で表示
+									var parameter = ctx.getParam(param);
+									if (parameter != null) {
+										var value = parameter.getValue();
+										String suffix = null;
+										if (value instanceof String) {
+											suffix = String.format(" ('%s')", value);
+										} else {
+											suffix = String.format(" (%s)", value);
+										}
+										write(writer, 1, null, param, suffix);
+									} else {
+										write(writer, 1, null, param, " (not found)");
+									}
+								});
+					}, () -> {
+						writer.println("sqlName : " + parts[1] + " not found.");
+					});
 		} else {
 			writer.println("sqlName must be specified.");
 		}

--- a/src/main/java/jp/co/future/uroborosql/parameter/mapper/OptionalParameterMapper.java
+++ b/src/main/java/jp/co/future/uroborosql/parameter/mapper/OptionalParameterMapper.java
@@ -34,6 +34,7 @@ public class OptionalParameterMapper implements BindParameterMapper<Optional<?>>
 	@Override
 	public Object toJdbc(final Optional<?> original, final Connection connection,
 			final BindParameterMapperManager parameterMapperManager) {
-		return original.isPresent() ? parameterMapperManager.toJdbc(original.get(), connection) : null;
+		return original.map(obj -> parameterMapperManager.toJdbc(obj, connection))
+				.orElse(null);
 	}
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityInsertTest.java
@@ -24,7 +24,7 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 			var product = new Product(1, "商品1", "ショウヒン1", "1111-1", "商品-1", new Date(), new Date(), 1);
 			agent.insert(product);
 
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品1"));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品1"));
 		});
 	}
 
@@ -35,8 +35,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 			var product = new Product(1, "商品1", "ショウヒン1", "1111-1", "商品-1", new Date(), new Date(), 1);
 			var insertedProduct = agent.insertAndReturn(product);
 
-			assertThat(agent.find(Product.class, 1).get().getProductId(), is(insertedProduct.getProductId()));
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品1"));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductId(), is(insertedProduct.getProductId()));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品1"));
 		});
 	}
 
@@ -68,8 +68,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			})), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -84,8 +84,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			})), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -130,8 +130,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BATCH), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -146,8 +146,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BATCH), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -168,8 +168,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BULK), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -184,8 +184,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BULK), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -206,8 +206,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			})), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -222,8 +222,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			})), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -244,8 +244,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BATCH), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -260,8 +260,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BULK), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -276,8 +276,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BATCH), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 
 		// 事前条件
@@ -292,8 +292,8 @@ public class SqlEntityInsertTest extends AbstractDbTest {
 				e.setProductDescription(e.getProductDescription() + "_new");
 				return e;
 			}), InsertsType.BULK), is(2));
-			assertThat(agent.find(Product.class, 11).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 12).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 11).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 12).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
@@ -159,13 +159,17 @@ public class SqlEntityQueryTest extends AbstractDbTest {
 		// camel case
 		var productName = agent.query(Product.class)
 				.equal("product_id", 1)
-				.select("productName", String.class).findFirst().get();
+				.select("productName", String.class)
+				.findFirst()
+				.orElseThrow();
 		assertEquals(productName, "商品名1");
 
 		// snake case
 		var janCode = agent.query(Product.class)
 				.equal("product_id", 1)
-				.select("jan_code", String.class).findFirst().get();
+				.select("jan_code", String.class)
+				.findFirst()
+				.orElseThrow();
 		assertEquals(janCode, "1234567890124");
 
 		// multiple case

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -37,7 +37,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 		agent.required(() -> {
 			assertThat(agent.update(Product.class).set("productName", "商品名_new").equal("productId", 1).count(), is(1));
 			assertThat(agent.query(Product.class).equal("productId", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -50,7 +50,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 			assertThat(agent.update(Product.class).set("product_name", "商品名_new").equal("product_id", 1).count(),
 					is(1));
 			assertThat(agent.query(Product.class).equal("product_id", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -68,11 +68,11 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			var product0 = agent.query(Product.class).equal("productId", 0)
-					.one().get();
+					.one().orElseThrow();
 			assertThat(product0.getProductName(), is("商品名_new"));
 			assertThat(product0.getProductKanaName(), is("ショウヒンメイ_new"));
 			var product1 = agent.query(Product.class).equal("productId", 1)
-					.one().get();
+					.one().orElseThrow();
 			assertThat(product1.getProductName(), is("商品名_new"));
 			assertThat(product1.getProductKanaName(), is("ショウヒンメイ_new"));
 		});
@@ -89,9 +89,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("productId", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("productId", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -106,9 +106,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("product_id", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("product_id", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -124,9 +124,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("productId", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("productId", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -142,9 +142,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("product_id", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("product_id", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -160,9 +160,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("productId", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("productId", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -178,9 +178,9 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 							.count(),
 					is(2));
 			assertThat(agent.query(Product.class).equal("product_id", 0)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 			assertThat(agent.query(Product.class).equal("product_id", 1)
-					.one().get().getProductName(), is("商品名_new"));
+					.one().orElseThrow().getProductName(), is("商品名_new"));
 		});
 	}
 
@@ -200,8 +200,8 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 
 			assertThat(agent.update(product), is(1));
 			assertThat(product.getVersionNo(), is(1));
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品名_new"));
-			assertThat(agent.find(Product.class, 2).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品名_new"));
+			assertThat(agent.find(Product.class, 2).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -221,8 +221,8 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 
 			assertThat(agent.updateAndReturn(product), is(product));
 			assertThat(product.getVersionNo(), is(1));
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品名_new"));
-			assertThat(agent.find(Product.class, 2).get().getVersionNo(), is(0));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品名_new"));
+			assertThat(agent.find(Product.class, 2).orElseThrow().getVersionNo(), is(0));
 		});
 	}
 
@@ -319,10 +319,10 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 			}).collect(Collectors.toList());
 			assertThat(agent.updates(products.stream()), is(2));
 
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 1).get().getProductKanaName(), nullValue());
-			assertThat(agent.find(Product.class, 2).get().getProductName(), is("商品名2_new"));
-			assertThat(agent.find(Product.class, 2).get().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductName(), is("商品名2_new"));
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductKanaName(), nullValue());
 		});
 	}
 
@@ -370,10 +370,10 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 			}).collect(Collectors.toList());
 			assertThat(agent.updates(Product.class, products.stream()), is(2));
 
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 1).get().getProductKanaName(), nullValue());
-			assertThat(agent.find(Product.class, 2).get().getProductName(), is("商品名2_new"));
-			assertThat(agent.find(Product.class, 2).get().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductName(), is("商品名2_new"));
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductKanaName(), nullValue());
 		});
 	}
 
@@ -458,10 +458,10 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 			}).collect(Collectors.toList());
 			assertThat(agent.updates(products.stream(), (ctx, count, e) -> count == 1), is(2));
 
-			assertThat(agent.find(Product.class, 1).get().getProductName(), is("商品名1_new"));
-			assertThat(agent.find(Product.class, 1).get().getProductKanaName(), nullValue());
-			assertThat(agent.find(Product.class, 2).get().getProductName(), is("商品名2_new"));
-			assertThat(agent.find(Product.class, 2).get().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductName(), is("商品名1_new"));
+			assertThat(agent.find(Product.class, 1).orElseThrow().getProductKanaName(), nullValue());
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductName(), is("商品名2_new"));
+			assertThat(agent.find(Product.class, 2).orElseThrow().getProductKanaName(), nullValue());
 		});
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlQueryTest.java
@@ -538,7 +538,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.param("product_id", List.of(0, 1, 2, 3)).findFirst();
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
 		assertEquals("ショウヒンメイゼロ", map.get("PRODUCT_KANA_NAME"));
@@ -570,7 +570,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.param("product_id", List.of(0)).findOne();
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("PRODUCT_ID"));
 		assertEquals("商品名0", map.get("PRODUCT_NAME"));
 		assertEquals("ショウヒンメイゼロ", map.get("PRODUCT_KANA_NAME"));
@@ -601,7 +601,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.param("product_id", List.of(0, 1, 2, 3)).findFirst();
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
 		assertEquals("ショウヒンメイゼロ", map.get("product_kana_name"));
@@ -640,7 +640,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.findOne();
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("product_id"));
 		assertEquals("商品名0", map.get("product_name"));
 		assertEquals("ショウヒンメイゼロ", map.get("product_kana_name"));
@@ -724,7 +724,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.param("product_id", List.of(0, 1, 2, 3)).findFirst(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("ProductId"));
 		assertEquals("商品名0", map.get("ProductName"));
 		assertEquals("ショウヒンメイゼロ", map.get("ProductKanaName"));
@@ -757,7 +757,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.findOne(CaseFormat.PASCAL_CASE);
 		assertTrue(optional.isPresent());
 
-		var map = optional.get();
+		var map = optional.orElseThrow();
 		assertEquals(new BigDecimal("0"), map.get("ProductId"));
 		assertEquals("商品名0", map.get("ProductName"));
 		assertEquals("ショウヒンメイゼロ", map.get("ProductKanaName"));
@@ -823,7 +823,7 @@ public class SqlQueryTest extends AbstractDbTest {
 
 		assertTrue(optional.isPresent());
 
-		var product = optional.get();
+		var product = optional.orElseThrow();
 
 		assertEquals(0, product.getProductId());
 		assertEquals("商品名0", product.getProductName());
@@ -920,7 +920,7 @@ public class SqlQueryTest extends AbstractDbTest {
 				.findOne(Product.class);
 		assertTrue(optional.isPresent());
 
-		var product = optional.get();
+		var product = optional.orElseThrow();
 
 		assertEquals(0, product.getProductId());
 		assertEquals("商品名0", product.getProductName());

--- a/src/test/java/jp/co/future/uroborosql/converter/EntityResultSetConverterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/converter/EntityResultSetConverterTest.java
@@ -140,7 +140,7 @@ public class EntityResultSetConverterTest {
 		Optional<ColumnTypeTest2> optional = agent.queryWith("select * from COLUMN_TYPE_TEST2").findFirst(
 				ColumnTypeTest2.class);
 		assertThat(optional.isPresent(), is(true));
-		var row = optional.get();
+		var row = optional.orElseThrow();
 
 		assertThat(row.getColClob(), is(clob));
 		assertThat(row.getColNclob(), is(nclob));

--- a/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
+++ b/src/test/java/jp/co/future/uroborosql/converter/MapResultSetConverterTest.java
@@ -129,7 +129,7 @@ public class MapResultSetConverterTest {
 
 			var optional = agent.queryWith("select * from COLUMN_TYPE_TEST2").findFirst();
 			assertThat(optional.isPresent(), is(true));
-			var row = optional.get();
+			var row = optional.orElseThrow();
 
 			assertThat(row.get("COL_INT"), is(1));
 			assertThat(row.get("COL_BOOLEAN"), is(true));

--- a/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/DefaultEntityHandlerWithDefaultValueTest.java
@@ -80,9 +80,9 @@ public class DefaultEntityHandlerWithDefaultValueTest {
 				assertThat(data, is(test1));
 				data = agent.find(TestEntityWithDefaultValue.class, 2).orElse(null);
 				assertThat(data.getId(), is(2L));
-				assertThat(data.getName().get(), is("default name"));
-				assertThat(data.getAge().get(), is(10));
-				assertThat(data.getBirthday().get(), is(LocalDate.of(2000, Month.JANUARY, 1)));
+				assertThat(data.getName().orElseThrow(), is("default name"));
+				assertThat(data.getAge().orElseThrow(), is(10));
+				assertThat(data.getBirthday().orElseThrow(), is(LocalDate.of(2000, Month.JANUARY, 1)));
 				assertThat(data.getMemo(), is(Optional.empty()));
 			});
 		}
@@ -107,15 +107,15 @@ public class DefaultEntityHandlerWithDefaultValueTest {
 				var data = agent.find(TestEntityWithDefaultValue.class, result1.getId())
 						.orElse(null);
 				assertThat(data.getId(), is(result1.getId()));
-				assertThat(data.getName().get(), is("name1"));
-				assertThat(data.getAge().get(), is(20));
-				assertThat(data.getBirthday().get(), is(LocalDate.of(1990, Month.APRIL, 1)));
+				assertThat(data.getName().orElseThrow(), is("name1"));
+				assertThat(data.getAge().orElseThrow(), is(20));
+				assertThat(data.getBirthday().orElseThrow(), is(LocalDate.of(1990, Month.APRIL, 1)));
 				assertThat(data.getMemo(), is(Optional.of("memo1")));
 				data = agent.find(TestEntityWithDefaultValue.class, result2.getId()).orElse(null);
 				assertThat(data.getId(), is(result2.getId()));
-				assertThat(data.getName().get(), is("default name"));
-				assertThat(data.getAge().get(), is(10));
-				assertThat(data.getBirthday().get(), is(LocalDate.of(2000, Month.JANUARY, 1)));
+				assertThat(data.getName().orElseThrow(), is("default name"));
+				assertThat(data.getAge().orElseThrow(), is(10));
+				assertThat(data.getBirthday().orElseThrow(), is(LocalDate.of(2000, Month.JANUARY, 1)));
 				assertThat(data.getMemo(), is(Optional.empty()));
 			});
 		}

--- a/src/test/java/jp/co/future/uroborosql/mapping/IdentityGeneratedKeysTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/IdentityGeneratedKeysTest.java
@@ -87,7 +87,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithId("name1");
@@ -180,7 +182,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithId("name1");
@@ -197,7 +201,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertWithObjectKeyValueNotSetId() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithIdObj("name1");
@@ -213,7 +219,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertWithObjectKeyValueSetId() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var id = currVal + 100;
 
@@ -231,7 +239,9 @@ public class IdentityGeneratedKeysTest {
 	void testInserts() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				List<TestEntityWithId> entities = new ArrayList<>();
@@ -364,7 +374,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -397,7 +409,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsWithObjectKeyValueNotSetId() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				List<TestEntityWithIdObj> entities = new ArrayList<>();
@@ -426,7 +440,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsWithObjectKeyValueSetValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -459,7 +475,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsBatch() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				List<TestEntityWithId> entities = new ArrayList<>();
@@ -592,7 +610,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsBatchWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -625,7 +645,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsBatchWithObjectKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -658,7 +680,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsAndReturn() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				List<TestEntityWithId> entities = new ArrayList<>();
@@ -688,7 +712,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertsAndReturnBatch() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				List<TestEntityWithId> entities = new ArrayList<>();
@@ -718,7 +744,9 @@ public class IdentityGeneratedKeysTest {
 	void testInsertAndUpdate() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithId("name1");
@@ -766,10 +794,14 @@ public class IdentityGeneratedKeysTest {
 	void testInsertMultiKey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithMultiId("name1");
 				agent.insert(test1);
@@ -801,10 +833,14 @@ public class IdentityGeneratedKeysTest {
 	void testInsertMultiKeyWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				// 複数のIDすべてに値を設定した場合
 				var test1 = new TestEntityWithMultiId("name1");
@@ -1033,10 +1069,14 @@ public class IdentityGeneratedKeysTest {
 	void testInsertMultiKeyWithObjectKeyValueNotSetId() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithMultiIdObj("name1");
 				agent.insert(test1);
@@ -1069,10 +1109,14 @@ public class IdentityGeneratedKeysTest {
 	void testInsertMultiKeyWithObjectKeyValueSetId() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var idVal = idCurrVal + 100;
 				var id2Val = id2CurrVal + 100;
@@ -1117,7 +1161,9 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithId("name1");
@@ -1149,7 +1195,9 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInsertWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -1186,7 +1234,9 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInsertWithObjectKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -1223,10 +1273,14 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInserMultikey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithMultiId("name1");
 				var test2 = new TestEntityWithMultiId("name2");
@@ -1262,10 +1316,14 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInserMultikeyWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var idVal = idCurrVal + 100;
 				var id2Val = id2CurrVal + 100;
 
@@ -1311,10 +1369,14 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInserMultikeyWithObjectKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var idVal = idCurrVal + 100;
 				var id2Val = id2CurrVal + 100;
 
@@ -1361,10 +1423,14 @@ public class IdentityGeneratedKeysTest {
 	void testBulkInserMultikeyWithObjectKeyValue2() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var id2Val = id2CurrVal + 100;
 
 				var test1 = new TestEntityWithMultiIdObj("name1");
@@ -1406,7 +1472,9 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithId("name1");
@@ -1438,7 +1506,9 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -1475,7 +1545,9 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertWithObjectKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 				var idVal = currVal + 100;
 
@@ -1512,10 +1584,14 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertMultikey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithMultiId("name1");
 				var test2 = new TestEntityWithMultiId("name2");
@@ -1551,10 +1627,14 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertMultikeyWithPrimitiveKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var idVal = idCurrVal + 100;
 				var id2Val = id2CurrVal + 100;
 
@@ -1600,10 +1680,14 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertMultikeyWithObjectKeyValue() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var idVal = idCurrVal + 100;
 				var id2Val = id2CurrVal + 100;
 
@@ -1650,10 +1734,14 @@ public class IdentityGeneratedKeysTest {
 	void testBatchInsertMultikeyWithObjectKeyValue2() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 				var id2Val = id2CurrVal + 100;
 
 				var test1 = new TestEntityWithMultiIdObj("name1");

--- a/src/test/java/jp/co/future/uroborosql/mapping/SequenceGeneratedKeysTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/SequenceGeneratedKeysTest.java
@@ -71,7 +71,9 @@ public class SequenceGeneratedKeysTest {
 	void testInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithSeq("name1");
@@ -100,7 +102,9 @@ public class SequenceGeneratedKeysTest {
 	void testInsertAndUpdate() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithSeq("name1");
@@ -124,10 +128,14 @@ public class SequenceGeneratedKeysTest {
 	void testInsertMultikey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithSeqMultikey("name1");
 				agent.insert(test1);
@@ -172,7 +180,9 @@ public class SequenceGeneratedKeysTest {
 	void testBulkInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithSeq("name1");
@@ -204,10 +214,14 @@ public class SequenceGeneratedKeysTest {
 	void testBulkInserMultikey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithSeqMultikey("name1");
 				var test2 = new TestEntityWithSeqMultikey("name2");
@@ -244,7 +258,9 @@ public class SequenceGeneratedKeysTest {
 	void testBatchInsert() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id").findFirst().get()
+				long currVal = (Long) agent.queryWith("select currval('test_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
 						.get("ID");
 
 				var test1 = new TestEntityWithSeq("name1");
@@ -276,10 +292,14 @@ public class SequenceGeneratedKeysTest {
 	void testBatchInsertMultikey() throws Exception {
 		try (var agent = config.agent()) {
 			agent.required(() -> {
-				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id").findFirst()
-						.get().get("ID");
-				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id").findFirst()
-						.get().get("ID");
+				long idCurrVal = (Long) agent.queryWith("select currval('test_multikey_id_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
+				long id2CurrVal = (Long) agent.queryWith("select currval('test_multikey_id2_seq') as id")
+						.findFirst()
+						.orElseThrow()
+						.get("ID");
 
 				var test1 = new TestEntityWithSeqMultikey("name1");
 				var test2 = new TestEntityWithSeqMultikey("name2");


### PR DESCRIPTION
Fixed to use Optional#orElseThrow() instead of Optional#get() because it is a deprecated API.