### PR TITLE
fix logger name.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
+++ b/src/main/java/jp/co/future/uroborosql/client/SqlREPL.java
@@ -96,12 +96,12 @@ public class SqlREPL implements ReplLoggingSupport {
 	public static void main(final String... args) {
 		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.log")).setLevel(Level.INFO);
 		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.setting")).setLevel(Level.ERROR);
-		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.performance")).setLevel(Level.INFO);
+		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.performance")).setLevel(Level.DEBUG);
 		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.event")).setLevel(Level.DEBUG);
 		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.repl")).setLevel(Level.WARN);
 		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.sql")).setLevel(Level.DEBUG);
-		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.sql.parser")).setLevel(Level.ERROR);
-		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.sql.coverage")).setLevel(Level.ERROR);
+		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.parser")).setLevel(Level.ERROR);
+		((Logger) LoggerFactory.getLogger("jp.co.future.uroborosql.coverage")).setLevel(Level.ERROR);
 
 		var propFile = "repl.properties";
 		if (args.length != 0) {

--- a/src/main/java/jp/co/future/uroborosql/log/support/CoverageLoggingSupport.java
+++ b/src/main/java/jp/co/future/uroborosql/log/support/CoverageLoggingSupport.java
@@ -11,5 +11,5 @@ import org.slf4j.LoggerFactory;
 
 public interface CoverageLoggingSupport extends LoggerBase {
 	/** SQLカバレッジ用ロガー */
-	Logger COVERAGE_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.sql.coverage");
+	Logger COVERAGE_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.coverage");
 }

--- a/src/main/java/jp/co/future/uroborosql/log/support/ParserLoggingSupport.java
+++ b/src/main/java/jp/co/future/uroborosql/log/support/ParserLoggingSupport.java
@@ -11,5 +11,5 @@ import org.slf4j.LoggerFactory;
 
 public interface ParserLoggingSupport extends LoggerBase {
 	/** パーサーロガー */
-	Logger PARSER_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.sql.parser");
+	Logger PARSER_LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.parser");
 }

--- a/src/main/java/jp/co/future/uroborosql/log/support/ServiceLoggingSupport.java
+++ b/src/main/java/jp/co/future/uroborosql/log/support/ServiceLoggingSupport.java
@@ -11,5 +11,5 @@ import org.slf4j.LoggerFactory;
 
 public interface ServiceLoggingSupport extends LoggerBase {
 	/** ロガー */
-	Logger LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.log.support");
+	Logger LOG = LoggerFactory.getLogger("jp.co.future.uroborosql.log");
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -33,11 +33,11 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="jp.co.future.uroborosql.sql.parser" level="INFO" additivity="false">
+	<logger name="jp.co.future.uroborosql.parser" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="jp.co.future.uroborosql.sql.coverage" level="INFO" additivity="false">
+	<logger name="jp.co.future.uroborosql.coverage" level="INFO" additivity="false">
 		<appender-ref ref="CoverageLog" />
 	</logger>
 


### PR DESCRIPTION
fix logger name

- jp.co.future.uroborosql.log.support ->  ->  jp.co.future.uroborosql.log（ fix name ）
- jp.co.future.uroborosql.setting
- jp.co.future.uroborosql.sql
- jp.co.future.uroborosql.sql.parser ->  jp.co.future.uroborosql.parser（ remove `sql` ）
- jp.co.future.uroborosql.performance
- jp.co.future.uroborosql.sql.coverage -> jp.co.future.uroborosql.coverage（ remove `sql` ）
- jp.co.future.uroborosql.event.  + event name