### PR TITLE
Add contextAttrs api for SqlEntity

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/AbstractExtractionCondition.java
+++ b/src/main/java/jp/co/future/uroborosql/AbstractExtractionCondition.java
@@ -556,6 +556,16 @@ abstract class AbstractExtractionCondition<T extends ExtractionCondition<T>> imp
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.fluent.ExtractionCondition#contextAttrs()
+	 */
+	@Override
+	public Map<String, Object> contextAttrs() {
+		return context().contextAttrs();
+	}
+
+	/**
 	 * 条件指定用のラップクラス
 	 */
 	public static abstract class Operator {

--- a/src/main/java/jp/co/future/uroborosql/fluent/ExtractionCondition.java
+++ b/src/main/java/jp/co/future/uroborosql/fluent/ExtractionCondition.java
@@ -307,4 +307,10 @@ public interface ExtractionCondition<T> {
 	 */
 	T where(CharSequence rawString, Map<String, Object> paramMap);
 
+	/**
+	 * ExecutionContextが保持する属性を取得する
+	 * @return ExecutionContext属性情報
+	 */
+	Map<String, Object> contextAttrs();
+
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityDeleteTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityDeleteTest.java
@@ -61,4 +61,11 @@ public class SqlEntityDeleteTest extends AbstractDbTest {
 		});
 	}
 
+	@Test
+	void testContextAttrs() {
+		var delete = agent.delete(Product.class);
+		delete.contextAttrs().put("dummyValue", Integer.MAX_VALUE);
+		assertThat(delete.contextAttrs().get("dummyValue"), is(Integer.MAX_VALUE));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityQueryTest.java
@@ -481,4 +481,11 @@ public class SqlEntityQueryTest extends AbstractDbTest {
 		assertThat(products.size(), is(2));
 	}
 
+	@Test
+	void testContextAttrs() {
+		var query = agent.query(Product.class);
+		query.contextAttrs().put("dummyValue", Integer.MAX_VALUE);
+		assertThat(query.contextAttrs().get("dummyValue"), is(Integer.MAX_VALUE));
+	}
+
 }

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -532,6 +532,13 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 		});
 	}
 
+	@Test
+	void testContextAttrs() {
+		var update = agent.update(TestEntity.class);
+		update.contextAttrs().put("dummyValue", Integer.MAX_VALUE);
+		assertThat(update.contextAttrs().get("dummyValue"), is(Integer.MAX_VALUE));
+	}
+
 	@Table(name = "test_entity")
 	public static class TestEntity {
 		@Id


### PR DESCRIPTION
Added APIs to access ExecutionContext#contextAttrs to SqlEntityQuery, SqlEntityUpdate, and SqlEntityDelete