### PR TITLE
Add ExecutionContext#getClock() method.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/context/ExecutionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/context/ExecutionContext.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLType;
+import java.time.Clock;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -308,4 +309,10 @@ public interface ExecutionContext
 	 */
 	ExecutionContext setUpdateDelegate(Function<ExecutionContext, Integer> updateDelegate);
 
+	/**
+	 * SqlConfigが保持するClockを取得する.
+	 *
+	 * @return SqlConfigが保持するClock
+	 */
+	Clock getClock();
 }

--- a/src/main/java/jp/co/future/uroborosql/context/ExecutionContextImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/ExecutionContextImpl.java
@@ -14,6 +14,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLType;
+import java.time.Clock;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1242,6 +1243,16 @@ public class ExecutionContextImpl implements ExecutionContext, SqlConfigAware, S
 	public ExecutionContext setUpdateDelegate(final Function<ExecutionContext, Integer> updateDelegate) {
 		this.updateDelegate = updateDelegate;
 		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see jp.co.future.uroborosql.context.ExecutionContext#getClock()
+	 */
+	@Override
+	public Clock getClock() {
+		return getSqlConfig().getClock();
 	}
 
 }

--- a/src/test/java/jp/co/future/uroborosql/context/ExecutionContextImplTest.java
+++ b/src/test/java/jp/co/future/uroborosql/context/ExecutionContextImplTest.java
@@ -722,6 +722,12 @@ public class ExecutionContextImplTest {
 		assertThat(ctx.getSqlId(), is(testSqlId));
 	}
 
+	@Test
+	void testGetClock() {
+		var ctx = config.context().setSql("select * from test");
+		assertThat(ctx.getClock(), is(config.getClock()));
+	}
+
 	private void transform(final ExecutionContext ctx) {
 		SqlParser sqlParser = new SqlParserImpl(ctx.getSql(), config.getExpressionParser(),
 				config.getDialect().isRemoveTerminator(), true);


### PR DESCRIPTION
ExecutionContext is provided as an argument in the EventSubscriber, but there are cases where you want to perform processing using a Clock instance set in SqlConfig in that EventSubscriber.
Since direct access to SqlConfig from ExecutionContext is not possible, we added an API to get the Clock instance in ExecutionContext.

----

ExecutionContextはEventSubscriberで引数として提供されるが、そのEventSubscriberの中でSqlConfigに設定したClockインスタンスを使った処理を行いたいケースがある。
ExecutionContextからSqlConfigへの直接アクセスはできないため、ExecutionContextにClockインスタンスを取得するAPIを追加した。