### PR TITLE
Add multi sqlfile bulk update method.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/SqlAgent.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgent.java
@@ -279,6 +279,14 @@ public interface SqlAgent extends TransactionManager {
 	SqlUpdate updateWith(String sql);
 
 	/**
+	 * 複数SQL更新処理の実行（Fluent API）
+	 *
+	 * @param sqlNames 実行するSQLファイル名リスト
+	 * @return SqlUpdate
+	 */
+	SqlUpdate updates(List<String> sqlNames);
+
+	/**
 	 * バッチ処理の実行（Fluent API）
 	 *
 	 * @param sqlName 実行するSQLファイル名

--- a/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/SqlAgentImpl.java
@@ -527,6 +527,35 @@ public class SqlAgentImpl implements SqlAgent, ServiceLoggingSupport, Performanc
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.SqlAgent#updates(java.util.List)
+	 */
+	@Override
+	public SqlUpdate updates(final List<String> sqlNames) {
+		if (sqlNames == null || sqlNames.isEmpty()) {
+			throw new IllegalArgumentException("sqlNames is required.");
+		}
+		if (sqlNames.size() == 1) {
+			return update(sqlNames.get(0));
+		}
+		var sqls = sqlNames.stream()
+				.map(sqlName -> {
+					var sql = getSqlResourceManager().getSql(sqlName);
+					if (ObjectUtils.isEmpty(sql)) {
+						throw new UroborosqlRuntimeException("sql file:[" + sqlName + "] is not found.");
+					}
+					return sql;
+				})
+				.collect(Collectors.joining(";" + System.lineSeparator()));
+
+		var sqlName = sqlNames.stream()
+				.collect(Collectors.joining(","));
+
+		return new SqlUpdateImpl(this, context().setSqlName(sqlName).setSql(sqls));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.SqlAgent#batch(java.lang.String)
 	 */
 	@Override

--- a/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlUpdateTest.java
@@ -9,15 +9,18 @@ import java.math.BigDecimal;
 import java.nio.file.Paths;
 import java.sql.JDBCType;
 import java.sql.Types;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import jp.co.future.uroborosql.converter.MapResultSetConverter;
 import jp.co.future.uroborosql.exception.UroborosqlRuntimeException;
+import jp.co.future.uroborosql.model.Product;
 import jp.co.future.uroborosql.utils.CaseFormat;
 
 public class SqlUpdateTest extends AbstractDbTest {
@@ -100,6 +103,59 @@ public class SqlUpdateTest extends AbstractDbTest {
 	}
 
 	/**
+	 * DB複数更新処理(SQLファイル1件)のテストケース。(Fluent API)
+	 */
+	@Test
+	void testUpdatesSingleFileFluent() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteUpdate.ltsv"));
+
+		var updateCount = agent.updates(List.of("example/selectinsert_product"))
+				.param("product_id", new BigDecimal("0"))
+				.param("jan_code", "1234567890123").count();
+		assertEquals(1, updateCount, "データの登録に失敗しました。");
+
+		// 検証処理
+		var expectedDataList = getDataFromFile(Paths.get(
+				"src/test/resources/data/expected/SqlAgent", "testExecuteUpdate.ltsv"));
+		List<Map<String, Object>> actualDataList = agent.query("example/select_product")
+				.param("product_id", List.of(0, 1))
+				.stream(new MapResultSetConverter(agent.getSqlConfig(), CaseFormat.LOWER_SNAKE_CASE))
+				.collect(Collectors.toList());
+
+		assertEquals(expectedDataList.toString(), actualDataList.toString());
+	}
+
+	/**
+	 * DB複数更新処理(SQLファイルn件)のテストケース。(Fluent API)
+	 */
+	@Test
+	void testUpdatesMultiFileFluent() throws Exception {
+		// 事前条件
+		cleanInsert(Paths.get("src/test/resources/data/setup", "testExecuteUpdate.ltsv"));
+
+		var updateCount = agent.updates(List.of("example/selectinsert_product",
+				"example/insert_product_regist_work"))
+				.param("product_id", new BigDecimal("2"))
+				.param("product_name", "商品名2")
+				.param("product_kana_name", "ショウヒンメイニ")
+				.param("jan_code", "1234567890123")
+				.param("product_description", "2番目の商品")
+				.param("ins_datetime", ZonedDateTime.now())
+				.count();
+		assertEquals(1, updateCount, "データの登録に失敗しました。");
+
+		// 検証処理
+		if (agent.find(Product.class, 2).isEmpty()) {
+			Assert.fail();
+		}
+		var productRegistWorks = agent.queryWith("select * from product_regist_work")
+				.collect();
+
+		assertEquals(productRegistWorks.size(), 2);
+	}
+
+	/**
 	 * DB更新処理のテストケース(NULLに設定)。
 	 */
 	@Test
@@ -158,6 +214,26 @@ public class SqlUpdateTest extends AbstractDbTest {
 	void testUpdateWithSqlEmpty() throws Exception {
 		Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
 			agent.updateWith("");
+		});
+	}
+
+	/**
+	 * 複数SQL更新実行処理のテストケース（引数がEmptyの場合）。
+	 */
+	@Test
+	void testUpdatesSqlNameEmpty() throws Exception {
+		Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
+			agent.updates(List.of());
+		});
+	}
+
+	/**
+	 * 複数SQL更新実行処理のテストケース（引数で指定したSQLファイルのいずれかが存在しない場合）。
+	 */
+	@Test
+	void testUpdatesNotFoundFile() throws Exception {
+		Assertions.assertThrowsExactly(UroborosqlRuntimeException.class, () -> {
+			agent.updates(List.of("example/selectinsert_product", "not_exists_file"));
 		});
 	}
 


### PR DESCRIPTION
There are cases where multiple SQL files for updating need to be issued at once, mainly to speed up processing.
To handle such cases, we have added an API that accepts multiple SQL files and issues them at once.

- Add SqlAgent#update(List<String> sqlNames)

----

主に処理高速化のために複数の更新用SQLファイルを一括で発行したいケースがある。
このようなケースに対応するため、複数のSQLファイルを受け付け、一度に発行するAPIを追加した。