### PR TITLE
We stopped caching JarFile instances obtained from JarURLConnection in multithreaded environments to prevent them from being unexpectedly closed.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/context/ExecutionContextProviderImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/context/ExecutionContextProviderImpl.java
@@ -389,8 +389,17 @@ public class ExecutionContextProviderImpl
 				}
 			}
 			if ("jar".equalsIgnoreCase(root.getProtocol())) {
-				try (var jarFile = ((JarURLConnection) root.openConnection()).getJarFile()) {
-					classes.addAll(findEnumClassesWithJar(packageName, jarFile));
+				try {
+					var conn = (JarURLConnection) root.openConnection();
+					conn.setUseCaches(false);
+					try (var jarFile = conn.getJarFile()) {
+						classes.addAll(findEnumClassesWithJar(packageName, jarFile));
+					} catch (IOException ex) {
+						errorWith(LOG)
+								.setMessage(ex.getMessage())
+								.setCause(ex)
+								.log();
+					}
 				} catch (IOException ex) {
 					errorWith(LOG)
 							.setMessage(ex.getMessage())


### PR DESCRIPTION
We've been encountering intermittent "zip file closed" errors when loading SQL from a Jar file in a multithreaded environment.

The root cause is the default behavior of JarURLConnection. When JarURLConnection.getJarFile() is called, it caches the JarFile instance. If this JarFile is inadvertently closed by one thread, other threads attempting to access it will then throw the "zip file closed" error.

The solution is to prevent JarFile caching by calling JarURLConnection#setUseCaches(false). This ensures that a new JarFile instance is generated each time it's needed.

----

マルチスレッド環境でJarファイルからSQLをロードしていると不定期に `zip file closed` が発生。

原因はJarファイルからSQLを読み込む際、JarUrlConnectionのデフォルトの動作ではJarUrlConnection.getJarFile() した時のJarFileをキャッシュするため、マルチスレッドで意図せずJarFileがクローズされると別のスレッドで上記エラーが発生する



解決策としては、JarUrlConnection#setUseCaches(false)を設定することでJarFileのキャッシュを行わず都度生成するようにする。