### PR TITLE
cache DatabaseMetaData fixed value and Connection getSchema value.

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/connection/CachedDatabaseMetaData.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/CachedDatabaseMetaData.java
@@ -1,0 +1,979 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.connection;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+
+/**
+ * 接続後に変更されない項目をキャッシュするDatabaseMetadataを提供するためのWrapper
+ *
+ * @author H.Sugimoto
+ * @since v0.26.10
+ */
+public class CachedDatabaseMetaData implements DatabaseMetaData {
+	private final DatabaseMetaData originalMetaData;
+	private final Connection originalConn;
+
+	/** Cached databaseMajorVersion */
+	private Integer databaseMajorVersion = null;
+
+	/** Cached databaseMinorVersion */
+	private Integer databaseMinorVersion = null;
+
+	/** Cached databaseProductName */
+	private String databaseProductName = null;
+
+	/** Cached databaseProductVersion */
+	private String databaseProductVersion = null;
+
+	/** Cached url */
+	private String url = null;
+
+	CachedDatabaseMetaData(final DatabaseMetaData originalMetaData, final Connection originalConn) {
+		this.originalMetaData = originalMetaData;
+		this.originalConn = originalConn;
+	}
+
+	@Override
+	public <T> T unwrap(final Class<T> iface) throws SQLException {
+		return originalMetaData.unwrap(iface);
+	}
+
+	@Override
+	public boolean isWrapperFor(final Class<?> iface) throws SQLException {
+		return originalMetaData.isWrapperFor(iface);
+	}
+
+	@Override
+	public boolean allProceduresAreCallable() throws SQLException {
+		return originalMetaData.allProceduresAreCallable();
+	}
+
+	@Override
+	public boolean allTablesAreSelectable() throws SQLException {
+		return originalMetaData.allTablesAreSelectable();
+	}
+
+	@Override
+	public String getURL() throws SQLException {
+		if (url == null) {
+			url = originalMetaData.getURL();
+		}
+		return url;
+	}
+
+	@Override
+	public String getUserName() throws SQLException {
+		return originalMetaData.getUserName();
+	}
+
+	@Override
+	public boolean isReadOnly() throws SQLException {
+		return originalMetaData.isReadOnly();
+	}
+
+	@Override
+	public boolean nullsAreSortedHigh() throws SQLException {
+		return originalMetaData.nullsAreSortedHigh();
+	}
+
+	@Override
+	public boolean nullsAreSortedLow() throws SQLException {
+		return originalMetaData.nullsAreSortedLow();
+	}
+
+	@Override
+	public boolean nullsAreSortedAtStart() throws SQLException {
+		return originalMetaData.nullsAreSortedAtStart();
+	}
+
+	@Override
+	public boolean nullsAreSortedAtEnd() throws SQLException {
+		return originalMetaData.nullsAreSortedAtEnd();
+	}
+
+	@Override
+	public String getDatabaseProductName() throws SQLException {
+		if (databaseProductName == null) {
+			databaseProductName = originalMetaData.getDatabaseProductName();
+		}
+		return databaseProductName;
+	}
+
+	@Override
+	public String getDatabaseProductVersion() throws SQLException {
+		if (databaseProductVersion == null) {
+			databaseProductVersion = originalMetaData.getDatabaseProductVersion();
+		}
+		return databaseProductVersion;
+	}
+
+	@Override
+	public String getDriverName() throws SQLException {
+		return originalMetaData.getDriverName();
+	}
+
+	@Override
+	public String getDriverVersion() throws SQLException {
+		return originalMetaData.getDriverVersion();
+	}
+
+	@Override
+	public int getDriverMajorVersion() {
+		return originalMetaData.getDriverMajorVersion();
+	}
+
+	@Override
+	public int getDriverMinorVersion() {
+		return originalMetaData.getDriverMinorVersion();
+	}
+
+	@Override
+	public boolean usesLocalFiles() throws SQLException {
+		return originalMetaData.usesLocalFiles();
+	}
+
+	@Override
+	public boolean usesLocalFilePerTable() throws SQLException {
+		return originalMetaData.usesLocalFilePerTable();
+	}
+
+	@Override
+	public boolean supportsMixedCaseIdentifiers() throws SQLException {
+		return originalMetaData.supportsMixedCaseIdentifiers();
+	}
+
+	@Override
+	public boolean storesUpperCaseIdentifiers() throws SQLException {
+		return originalMetaData.storesUpperCaseIdentifiers();
+	}
+
+	@Override
+	public boolean storesLowerCaseIdentifiers() throws SQLException {
+		return originalMetaData.storesLowerCaseIdentifiers();
+	}
+
+	@Override
+	public boolean storesMixedCaseIdentifiers() throws SQLException {
+		return originalMetaData.storesMixedCaseIdentifiers();
+	}
+
+	@Override
+	public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
+		return originalMetaData.supportsMixedCaseQuotedIdentifiers();
+	}
+
+	@Override
+	public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
+		return originalMetaData.storesUpperCaseQuotedIdentifiers();
+	}
+
+	@Override
+	public boolean storesLowerCaseQuotedIdentifiers() throws SQLException {
+		return originalMetaData.storesLowerCaseQuotedIdentifiers();
+	}
+
+	@Override
+	public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
+		return originalMetaData.storesMixedCaseQuotedIdentifiers();
+	}
+
+	@Override
+	public String getIdentifierQuoteString() throws SQLException {
+		return originalMetaData.getIdentifierQuoteString();
+	}
+
+	@Override
+	public String getSQLKeywords() throws SQLException {
+		return originalMetaData.getSQLKeywords();
+	}
+
+	@Override
+	public String getNumericFunctions() throws SQLException {
+		return originalMetaData.getNumericFunctions();
+	}
+
+	@Override
+	public String getStringFunctions() throws SQLException {
+		return originalMetaData.getStringFunctions();
+	}
+
+	@Override
+	public String getSystemFunctions() throws SQLException {
+		return originalMetaData.getSystemFunctions();
+	}
+
+	@Override
+	public String getTimeDateFunctions() throws SQLException {
+		return originalMetaData.getTimeDateFunctions();
+	}
+
+	@Override
+	public String getSearchStringEscape() throws SQLException {
+		return originalMetaData.getSearchStringEscape();
+	}
+
+	@Override
+	public String getExtraNameCharacters() throws SQLException {
+		return originalMetaData.getExtraNameCharacters();
+	}
+
+	@Override
+	public boolean supportsAlterTableWithAddColumn() throws SQLException {
+		return originalMetaData.supportsAlterTableWithAddColumn();
+	}
+
+	@Override
+	public boolean supportsAlterTableWithDropColumn() throws SQLException {
+		return originalMetaData.supportsAlterTableWithDropColumn();
+	}
+
+	@Override
+	public boolean supportsColumnAliasing() throws SQLException {
+		return originalMetaData.supportsColumnAliasing();
+	}
+
+	@Override
+	public boolean nullPlusNonNullIsNull() throws SQLException {
+		return originalMetaData.nullPlusNonNullIsNull();
+	}
+
+	@Override
+	public boolean supportsConvert() throws SQLException {
+		return originalMetaData.supportsConvert();
+	}
+
+	@Override
+	public boolean supportsConvert(final int fromType, final int toType) throws SQLException {
+		return originalMetaData.supportsConvert(fromType, toType);
+	}
+
+	@Override
+	public boolean supportsTableCorrelationNames() throws SQLException {
+		return originalMetaData.supportsTableCorrelationNames();
+	}
+
+	@Override
+	public boolean supportsDifferentTableCorrelationNames() throws SQLException {
+		return originalMetaData.supportsDifferentTableCorrelationNames();
+	}
+
+	@Override
+	public boolean supportsExpressionsInOrderBy() throws SQLException {
+		return originalMetaData.supportsExpressionsInOrderBy();
+	}
+
+	@Override
+	public boolean supportsOrderByUnrelated() throws SQLException {
+		return originalMetaData.supportsOrderByUnrelated();
+	}
+
+	@Override
+	public boolean supportsGroupBy() throws SQLException {
+		return originalMetaData.supportsGroupBy();
+	}
+
+	@Override
+	public boolean supportsGroupByUnrelated() throws SQLException {
+		return originalMetaData.supportsGroupByUnrelated();
+	}
+
+	@Override
+	public boolean supportsGroupByBeyondSelect() throws SQLException {
+		return originalMetaData.supportsGroupByBeyondSelect();
+	}
+
+	@Override
+	public boolean supportsLikeEscapeClause() throws SQLException {
+		return originalMetaData.supportsLikeEscapeClause();
+	}
+
+	@Override
+	public boolean supportsMultipleResultSets() throws SQLException {
+		return originalMetaData.supportsMultipleResultSets();
+	}
+
+	@Override
+	public boolean supportsMultipleTransactions() throws SQLException {
+		return originalMetaData.supportsMultipleTransactions();
+	}
+
+	@Override
+	public boolean supportsNonNullableColumns() throws SQLException {
+		return originalMetaData.supportsNonNullableColumns();
+	}
+
+	@Override
+	public boolean supportsMinimumSQLGrammar() throws SQLException {
+		return originalMetaData.supportsMinimumSQLGrammar();
+	}
+
+	@Override
+	public boolean supportsCoreSQLGrammar() throws SQLException {
+		return originalMetaData.supportsCoreSQLGrammar();
+	}
+
+	@Override
+	public boolean supportsExtendedSQLGrammar() throws SQLException {
+		return originalMetaData.supportsExtendedSQLGrammar();
+	}
+
+	@Override
+	public boolean supportsANSI92EntryLevelSQL() throws SQLException {
+		return originalMetaData.supportsANSI92EntryLevelSQL();
+	}
+
+	@Override
+	public boolean supportsANSI92IntermediateSQL() throws SQLException {
+		return originalMetaData.supportsANSI92IntermediateSQL();
+	}
+
+	@Override
+	public boolean supportsANSI92FullSQL() throws SQLException {
+		return originalMetaData.supportsANSI92FullSQL();
+	}
+
+	@Override
+	public boolean supportsIntegrityEnhancementFacility() throws SQLException {
+		return originalMetaData.supportsIntegrityEnhancementFacility();
+	}
+
+	@Override
+	public boolean supportsOuterJoins() throws SQLException {
+		return originalMetaData.supportsOuterJoins();
+	}
+
+	@Override
+	public boolean supportsFullOuterJoins() throws SQLException {
+		return originalMetaData.supportsFullOuterJoins();
+	}
+
+	@Override
+	public boolean supportsLimitedOuterJoins() throws SQLException {
+		return originalMetaData.supportsLimitedOuterJoins();
+	}
+
+	@Override
+	public String getSchemaTerm() throws SQLException {
+		return originalMetaData.getSchemaTerm();
+	}
+
+	@Override
+	public String getProcedureTerm() throws SQLException {
+		return originalMetaData.getProcedureTerm();
+	}
+
+	@Override
+	public String getCatalogTerm() throws SQLException {
+		return originalMetaData.getCatalogTerm();
+	}
+
+	@Override
+	public boolean isCatalogAtStart() throws SQLException {
+		return originalMetaData.isCatalogAtStart();
+	}
+
+	@Override
+	public String getCatalogSeparator() throws SQLException {
+		return originalMetaData.getCatalogSeparator();
+	}
+
+	@Override
+	public boolean supportsSchemasInDataManipulation() throws SQLException {
+		return originalMetaData.supportsSchemasInDataManipulation();
+	}
+
+	@Override
+	public boolean supportsSchemasInProcedureCalls() throws SQLException {
+		return originalMetaData.supportsSchemasInProcedureCalls();
+	}
+
+	@Override
+	public boolean supportsSchemasInTableDefinitions() throws SQLException {
+		return originalMetaData.supportsSchemasInTableDefinitions();
+	}
+
+	@Override
+	public boolean supportsSchemasInIndexDefinitions() throws SQLException {
+		return originalMetaData.supportsSchemasInIndexDefinitions();
+	}
+
+	@Override
+	public boolean supportsSchemasInPrivilegeDefinitions() throws SQLException {
+		return originalMetaData.supportsSchemasInPrivilegeDefinitions();
+	}
+
+	@Override
+	public boolean supportsCatalogsInDataManipulation() throws SQLException {
+		return originalMetaData.supportsCatalogsInDataManipulation();
+	}
+
+	@Override
+	public boolean supportsCatalogsInProcedureCalls() throws SQLException {
+		return originalMetaData.supportsCatalogsInProcedureCalls();
+	}
+
+	@Override
+	public boolean supportsCatalogsInTableDefinitions() throws SQLException {
+		return originalMetaData.supportsCatalogsInTableDefinitions();
+	}
+
+	@Override
+	public boolean supportsCatalogsInIndexDefinitions() throws SQLException {
+		return originalMetaData.supportsCatalogsInIndexDefinitions();
+	}
+
+	@Override
+	public boolean supportsCatalogsInPrivilegeDefinitions() throws SQLException {
+		return originalMetaData.supportsCatalogsInPrivilegeDefinitions();
+	}
+
+	@Override
+	public boolean supportsPositionedDelete() throws SQLException {
+		return originalMetaData.supportsPositionedDelete();
+	}
+
+	@Override
+	public boolean supportsPositionedUpdate() throws SQLException {
+		return originalMetaData.supportsPositionedUpdate();
+	}
+
+	@Override
+	public boolean supportsSelectForUpdate() throws SQLException {
+		return originalMetaData.supportsSelectForUpdate();
+	}
+
+	@Override
+	public boolean supportsStoredProcedures() throws SQLException {
+		return originalMetaData.supportsStoredProcedures();
+	}
+
+	@Override
+	public boolean supportsSubqueriesInComparisons() throws SQLException {
+		return originalMetaData.supportsSubqueriesInComparisons();
+	}
+
+	@Override
+	public boolean supportsSubqueriesInExists() throws SQLException {
+		return originalMetaData.supportsSubqueriesInExists();
+	}
+
+	@Override
+	public boolean supportsSubqueriesInIns() throws SQLException {
+		return originalMetaData.supportsSubqueriesInIns();
+	}
+
+	@Override
+	public boolean supportsSubqueriesInQuantifieds() throws SQLException {
+		return originalMetaData.supportsSubqueriesInQuantifieds();
+	}
+
+	@Override
+	public boolean supportsCorrelatedSubqueries() throws SQLException {
+		return originalMetaData.supportsCorrelatedSubqueries();
+	}
+
+	@Override
+	public boolean supportsUnion() throws SQLException {
+		return originalMetaData.supportsUnion();
+	}
+
+	@Override
+	public boolean supportsUnionAll() throws SQLException {
+		return originalMetaData.supportsUnionAll();
+	}
+
+	@Override
+	public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
+		return originalMetaData.supportsOpenCursorsAcrossCommit();
+	}
+
+	@Override
+	public boolean supportsOpenCursorsAcrossRollback() throws SQLException {
+		return originalMetaData.supportsOpenCursorsAcrossRollback();
+	}
+
+	@Override
+	public boolean supportsOpenStatementsAcrossCommit() throws SQLException {
+		return originalMetaData.supportsOpenStatementsAcrossCommit();
+	}
+
+	@Override
+	public boolean supportsOpenStatementsAcrossRollback() throws SQLException {
+		return originalMetaData.supportsOpenStatementsAcrossRollback();
+	}
+
+	@Override
+	public int getMaxBinaryLiteralLength() throws SQLException {
+		return originalMetaData.getMaxBinaryLiteralLength();
+	}
+
+	@Override
+	public int getMaxCharLiteralLength() throws SQLException {
+		return originalMetaData.getMaxCharLiteralLength();
+	}
+
+	@Override
+	public int getMaxColumnNameLength() throws SQLException {
+		return originalMetaData.getMaxColumnNameLength();
+	}
+
+	@Override
+	public int getMaxColumnsInGroupBy() throws SQLException {
+		return originalMetaData.getMaxColumnsInGroupBy();
+	}
+
+	@Override
+	public int getMaxColumnsInIndex() throws SQLException {
+		return originalMetaData.getMaxColumnsInIndex();
+	}
+
+	@Override
+	public int getMaxColumnsInOrderBy() throws SQLException {
+		return originalMetaData.getMaxColumnsInOrderBy();
+	}
+
+	@Override
+	public int getMaxColumnsInSelect() throws SQLException {
+		return originalMetaData.getMaxColumnsInSelect();
+	}
+
+	@Override
+	public int getMaxColumnsInTable() throws SQLException {
+		return originalMetaData.getMaxColumnsInTable();
+	}
+
+	@Override
+	public int getMaxConnections() throws SQLException {
+		return originalMetaData.getMaxConnections();
+	}
+
+	@Override
+	public int getMaxCursorNameLength() throws SQLException {
+		return originalMetaData.getMaxCursorNameLength();
+	}
+
+	@Override
+	public int getMaxIndexLength() throws SQLException {
+		return originalMetaData.getMaxIndexLength();
+	}
+
+	@Override
+	public int getMaxSchemaNameLength() throws SQLException {
+		return originalMetaData.getMaxSchemaNameLength();
+	}
+
+	@Override
+	public int getMaxProcedureNameLength() throws SQLException {
+		return originalMetaData.getMaxProcedureNameLength();
+	}
+
+	@Override
+	public int getMaxCatalogNameLength() throws SQLException {
+		return originalMetaData.getMaxCatalogNameLength();
+	}
+
+	@Override
+	public int getMaxRowSize() throws SQLException {
+		return originalMetaData.getMaxRowSize();
+	}
+
+	@Override
+	public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
+		return originalMetaData.doesMaxRowSizeIncludeBlobs();
+	}
+
+	@Override
+	public int getMaxStatementLength() throws SQLException {
+		return originalMetaData.getMaxStatementLength();
+	}
+
+	@Override
+	public int getMaxStatements() throws SQLException {
+		return originalMetaData.getMaxStatements();
+	}
+
+	@Override
+	public int getMaxTableNameLength() throws SQLException {
+		return originalMetaData.getMaxTableNameLength();
+	}
+
+	@Override
+	public int getMaxTablesInSelect() throws SQLException {
+		return originalMetaData.getMaxTablesInSelect();
+	}
+
+	@Override
+	public int getMaxUserNameLength() throws SQLException {
+		return originalMetaData.getMaxUserNameLength();
+	}
+
+	@Override
+	public int getDefaultTransactionIsolation() throws SQLException {
+		return originalMetaData.getDefaultTransactionIsolation();
+	}
+
+	@Override
+	public boolean supportsTransactions() throws SQLException {
+		return originalMetaData.supportsTransactions();
+	}
+
+	@Override
+	public boolean supportsTransactionIsolationLevel(final int level) throws SQLException {
+		return originalMetaData.supportsTransactionIsolationLevel(level);
+	}
+
+	@Override
+	public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
+		return originalMetaData.supportsDataDefinitionAndDataManipulationTransactions();
+	}
+
+	@Override
+	public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
+		return originalMetaData.supportsDataManipulationTransactionsOnly();
+	}
+
+	@Override
+	public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
+		return originalMetaData.dataDefinitionCausesTransactionCommit();
+	}
+
+	@Override
+	public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
+		return originalMetaData.dataDefinitionIgnoredInTransactions();
+	}
+
+	@Override
+	public ResultSet getProcedures(final String catalog, final String schemaPattern, final String procedureNamePattern)
+			throws SQLException {
+		return originalMetaData.getProcedures(catalog, schemaPattern, procedureNamePattern);
+	}
+
+	@Override
+	public ResultSet getProcedureColumns(final String catalog, final String schemaPattern,
+			final String procedureNamePattern,
+			final String columnNamePattern) throws SQLException {
+		return originalMetaData.getProcedureColumns(catalog, schemaPattern, procedureNamePattern, columnNamePattern);
+	}
+
+	@Override
+	public ResultSet getTables(final String catalog, final String schemaPattern, final String tableNamePattern,
+			final String[] types)
+			throws SQLException {
+		return originalMetaData.getTables(catalog, schemaPattern, tableNamePattern, types);
+	}
+
+	@Override
+	public ResultSet getSchemas() throws SQLException {
+		return originalMetaData.getSchemas();
+	}
+
+	@Override
+	public ResultSet getCatalogs() throws SQLException {
+		return originalMetaData.getCatalogs();
+	}
+
+	@Override
+	public ResultSet getTableTypes() throws SQLException {
+		return originalMetaData.getTableTypes();
+	}
+
+	@Override
+	public ResultSet getColumns(final String catalog, final String schemaPattern, final String tableNamePattern,
+			final String columnNamePattern)
+			throws SQLException {
+		return originalMetaData.getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern);
+	}
+
+	@Override
+	public ResultSet getColumnPrivileges(final String catalog, final String schema, final String table,
+			final String columnNamePattern)
+			throws SQLException {
+		return originalMetaData.getColumnPrivileges(catalog, schema, table, columnNamePattern);
+	}
+
+	@Override
+	public ResultSet getTablePrivileges(final String catalog, final String schemaPattern, final String tableNamePattern)
+			throws SQLException {
+		return originalMetaData.getTablePrivileges(catalog, schemaPattern, tableNamePattern);
+	}
+
+	@Override
+	public ResultSet getBestRowIdentifier(final String catalog, final String schema, final String table,
+			final int scope, final boolean nullable)
+			throws SQLException {
+		return originalMetaData.getBestRowIdentifier(catalog, schema, table, scope, nullable);
+	}
+
+	@Override
+	public ResultSet getVersionColumns(final String catalog, final String schema, final String table)
+			throws SQLException {
+		return originalMetaData.getVersionColumns(catalog, schema, table);
+	}
+
+	@Override
+	public ResultSet getPrimaryKeys(final String catalog, final String schema, final String table) throws SQLException {
+		return originalMetaData.getPrimaryKeys(catalog, schema, table);
+	}
+
+	@Override
+	public ResultSet getImportedKeys(final String catalog, final String schema, final String table)
+			throws SQLException {
+		return originalMetaData.getImportedKeys(catalog, schema, table);
+	}
+
+	@Override
+	public ResultSet getExportedKeys(final String catalog, final String schema, final String table)
+			throws SQLException {
+		return originalMetaData.getExportedKeys(catalog, schema, table);
+	}
+
+	@Override
+	public ResultSet getCrossReference(final String parentCatalog, final String parentSchema, final String parentTable,
+			final String foreignCatalog, final String foreignSchema, final String foreignTable) throws SQLException {
+		return originalMetaData.getCrossReference(parentCatalog, parentSchema, parentTable, foreignCatalog,
+				foreignSchema,
+				foreignTable);
+	}
+
+	@Override
+	public ResultSet getTypeInfo() throws SQLException {
+		return originalMetaData.getTypeInfo();
+	}
+
+	@Override
+	public ResultSet getIndexInfo(final String catalog, final String schema, final String table, final boolean unique,
+			final boolean approximate)
+			throws SQLException {
+		return originalMetaData.getIndexInfo(catalog, schema, table, unique, approximate);
+	}
+
+	@Override
+	public boolean supportsResultSetType(final int type) throws SQLException {
+		return originalMetaData.supportsResultSetType(type);
+	}
+
+	@Override
+	public boolean supportsResultSetConcurrency(final int type, final int concurrency) throws SQLException {
+		return originalMetaData.supportsResultSetConcurrency(type, concurrency);
+	}
+
+	@Override
+	public boolean ownUpdatesAreVisible(final int type) throws SQLException {
+		return originalMetaData.ownUpdatesAreVisible(type);
+	}
+
+	@Override
+	public boolean ownDeletesAreVisible(final int type) throws SQLException {
+		return originalMetaData.ownDeletesAreVisible(type);
+	}
+
+	@Override
+	public boolean ownInsertsAreVisible(final int type) throws SQLException {
+		return originalMetaData.ownInsertsAreVisible(type);
+	}
+
+	@Override
+	public boolean othersUpdatesAreVisible(final int type) throws SQLException {
+		return originalMetaData.othersUpdatesAreVisible(type);
+	}
+
+	@Override
+	public boolean othersDeletesAreVisible(final int type) throws SQLException {
+		return originalMetaData.othersDeletesAreVisible(type);
+	}
+
+	@Override
+	public boolean othersInsertsAreVisible(final int type) throws SQLException {
+		return originalMetaData.othersInsertsAreVisible(type);
+	}
+
+	@Override
+	public boolean updatesAreDetected(final int type) throws SQLException {
+		return originalMetaData.updatesAreDetected(type);
+	}
+
+	@Override
+	public boolean deletesAreDetected(final int type) throws SQLException {
+		return originalMetaData.deletesAreDetected(type);
+	}
+
+	@Override
+	public boolean insertsAreDetected(final int type) throws SQLException {
+		return originalMetaData.insertsAreDetected(type);
+	}
+
+	@Override
+	public boolean supportsBatchUpdates() throws SQLException {
+		return originalMetaData.supportsBatchUpdates();
+	}
+
+	@Override
+	public ResultSet getUDTs(final String catalog, final String schemaPattern, final String typeNamePattern,
+			final int[] types)
+			throws SQLException {
+		return originalMetaData.getUDTs(catalog, schemaPattern, typeNamePattern, types);
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return originalConn;
+	}
+
+	@Override
+	public boolean supportsSavepoints() throws SQLException {
+		return originalMetaData.supportsSavepoints();
+	}
+
+	@Override
+	public boolean supportsNamedParameters() throws SQLException {
+		return originalMetaData.supportsNamedParameters();
+	}
+
+	@Override
+	public boolean supportsMultipleOpenResults() throws SQLException {
+		return originalMetaData.supportsMultipleOpenResults();
+	}
+
+	@Override
+	public boolean supportsGetGeneratedKeys() throws SQLException {
+		return originalMetaData.supportsGetGeneratedKeys();
+	}
+
+	@Override
+	public ResultSet getSuperTypes(final String catalog, final String schemaPattern, final String typeNamePattern)
+			throws SQLException {
+		return originalMetaData.getSuperTypes(catalog, schemaPattern, typeNamePattern);
+	}
+
+	@Override
+	public ResultSet getSuperTables(final String catalog, final String schemaPattern, final String tableNamePattern)
+			throws SQLException {
+		return originalMetaData.getSuperTables(catalog, schemaPattern, tableNamePattern);
+	}
+
+	@Override
+	public ResultSet getAttributes(final String catalog, final String schemaPattern, final String typeNamePattern,
+			final String attributeNamePattern) throws SQLException {
+		return originalMetaData.getAttributes(catalog, schemaPattern, typeNamePattern, attributeNamePattern);
+	}
+
+	@Override
+	public boolean supportsResultSetHoldability(final int holdability) throws SQLException {
+		return originalMetaData.supportsResultSetHoldability(holdability);
+	}
+
+	@Override
+	public int getResultSetHoldability() throws SQLException {
+		return originalMetaData.getResultSetHoldability();
+	}
+
+	@Override
+	public int getDatabaseMajorVersion() throws SQLException {
+		if (databaseMajorVersion == null) {
+			databaseMajorVersion = originalMetaData.getDatabaseMajorVersion();
+		}
+		return databaseMajorVersion;
+	}
+
+	@Override
+	public int getDatabaseMinorVersion() throws SQLException {
+		if (databaseMinorVersion == null) {
+			databaseMinorVersion = originalMetaData.getDatabaseMinorVersion();
+		}
+		return databaseMinorVersion;
+	}
+
+	@Override
+	public int getJDBCMajorVersion() throws SQLException {
+		return originalMetaData.getJDBCMajorVersion();
+	}
+
+	@Override
+	public int getJDBCMinorVersion() throws SQLException {
+		return originalMetaData.getJDBCMinorVersion();
+	}
+
+	@Override
+	public int getSQLStateType() throws SQLException {
+		return originalMetaData.getSQLStateType();
+	}
+
+	@Override
+	public boolean locatorsUpdateCopy() throws SQLException {
+		return originalMetaData.locatorsUpdateCopy();
+	}
+
+	@Override
+	public boolean supportsStatementPooling() throws SQLException {
+		return originalMetaData.supportsStatementPooling();
+	}
+
+	@Override
+	public RowIdLifetime getRowIdLifetime() throws SQLException {
+		return originalMetaData.getRowIdLifetime();
+	}
+
+	@Override
+	public ResultSet getSchemas(final String catalog, final String schemaPattern) throws SQLException {
+		return originalMetaData.getSchemas(catalog, schemaPattern);
+	}
+
+	@Override
+	public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
+		return originalMetaData.supportsStoredFunctionsUsingCallSyntax();
+	}
+
+	@Override
+	public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
+		return originalMetaData.autoCommitFailureClosesAllResultSets();
+	}
+
+	@Override
+	public ResultSet getClientInfoProperties() throws SQLException {
+		return originalMetaData.getClientInfoProperties();
+	}
+
+	@Override
+	public ResultSet getFunctions(final String catalog, final String schemaPattern, final String functionNamePattern)
+			throws SQLException {
+		return originalMetaData.getFunctions(catalog, schemaPattern, functionNamePattern);
+	}
+
+	@Override
+	public ResultSet getFunctionColumns(final String catalog, final String schemaPattern,
+			final String functionNamePattern,
+			final String columnNamePattern) throws SQLException {
+		return originalMetaData.getFunctionColumns(catalog, schemaPattern, functionNamePattern, columnNamePattern);
+	}
+
+	@Override
+	public ResultSet getPseudoColumns(final String catalog, final String schemaPattern, final String tableNamePattern,
+			final String columnNamePattern) throws SQLException {
+		return originalMetaData.getPseudoColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern);
+	}
+
+	@Override
+	public boolean generatedKeyAlwaysReturned() throws SQLException {
+		return originalMetaData.generatedKeyAlwaysReturned();
+	}
+
+	@Override
+	public long getMaxLogicalLobSize() throws SQLException {
+		return originalMetaData.getMaxLogicalLobSize();
+	}
+
+	@Override
+	public boolean supportsRefCursors() throws SQLException {
+		return originalMetaData.supportsRefCursors();
+	}
+
+}

--- a/src/main/java/jp/co/future/uroborosql/connection/ConnectionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/ConnectionContext.java
@@ -23,12 +23,13 @@ public abstract class ConnectionContext extends ConcurrentHashMap<String, Object
 	public static String PROPS_READ_ONLY = "readonly";
 	/** プロパティ：トランザクション分離レベル */
 	public static String PROPS_TRANSACTION_ISOLATION = "transactionisolation";
+	/** プロパティ：スキーマ名のキャッシュ */
+	private static String PROPS_CACHE_SCHEMA_NAME = "__cache_schema_name__";
 
 	/**
 	 * コンストラクタ
 	 */
 	protected ConnectionContext() {
-		super();
 	}
 
 	/**
@@ -111,6 +112,28 @@ public abstract class ConnectionContext extends ConcurrentHashMap<String, Object
 		} else {
 			throw new IllegalArgumentException("Unsupported level [" + transactionIsolation + "]");
 		}
+		return (T) this;
+	}
+
+	/**
+	 * スキーマ名のキャッシュオプションを取得
+	 *
+	 * @return スキーマ名をキャッシュする場合は<code>true</code>. 初期値は<code>true</code>
+	 */
+	public boolean cacheSchemaName() {
+		return (boolean) getOrDefault(PROPS_CACHE_SCHEMA_NAME, true);
+	}
+
+	/**
+	 * スキーマ名のキャッシュオプションを指定
+	 *
+	 * @param <T> {@link ConnectionContext}の具象型
+	 * @param cached スキーマ名をキャッシュする場合は<code>true</code>
+	 * @return {@link ConnectionContext}
+	 */
+	@SuppressWarnings("unchecked")
+	public <T extends ConnectionContext> T cacheSchemaName(final boolean cached) {
+		put(PROPS_CACHE_SCHEMA_NAME, cached);
 		return (T) this;
 	}
 

--- a/src/main/java/jp/co/future/uroborosql/connection/DataSourceConnectionSupplierImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/DataSourceConnectionSupplierImpl.java
@@ -96,7 +96,7 @@ public class DataSourceConnectionSupplierImpl implements ConnectionSupplier {
 					DataSourceConnectionSupplierImpl::getNewDataSource);
 			final Connection connection;
 			synchronized (ds) {
-				connection = ds.getConnection();
+				connection = new MetadataCachedConnectionWrapper(ds.getConnection(), ctx.cacheSchemaName());
 			}
 			if (ctx.autoCommit() != connection.getAutoCommit()) {
 				connection.setAutoCommit(ctx.autoCommit());

--- a/src/main/java/jp/co/future/uroborosql/connection/JdbcConnectionSupplierImpl.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/JdbcConnectionSupplierImpl.java
@@ -97,7 +97,8 @@ public class JdbcConnectionSupplierImpl implements ConnectionSupplier {
 		}
 		JdbcConnectionContext jdbcCtx = (JdbcConnectionContext) ctx;
 		try {
-			Connection connection = DriverManager.getConnection(jdbcCtx.url(), jdbcCtx.toProperties());
+			Connection connection = new MetadataCachedConnectionWrapper(
+					DriverManager.getConnection(jdbcCtx.url(), jdbcCtx.toProperties()), ctx.cacheSchemaName());
 
 			String schema = jdbcCtx.schema();
 			if (schema != null && !Objects.equals(connection.getSchema(), schema)) {

--- a/src/main/java/jp/co/future/uroborosql/connection/MetadataCachedConnectionWrapper.java
+++ b/src/main/java/jp/co/future/uroborosql/connection/MetadataCachedConnectionWrapper.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright (c) 2017-present, Future Corporation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package jp.co.future.uroborosql.connection;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * DatabaseMetadataの一部をキャッシュするConnectionを提供するためのWrapper
+ *
+ * @author H.Sugimoto
+ * @since v0.26.10
+ */
+public class MetadataCachedConnectionWrapper implements Connection {
+
+	/** Original connection. */
+	private final Connection original;
+
+	/** Whether to cache the schema name. */
+	private final boolean cacheSchema;
+
+	/** Cached DatabaseMetaData. */
+	private DatabaseMetaData cachedMetadata = null;
+
+	/** Cached Schema Name. */
+	private String cachedSchemaName = null;
+
+	/**
+	 * コンストラクタ
+	 *
+	 * @param original 元となるコネクション
+	 * @param cacheSchema スキーマ名をキャッシュするかどうか. キャッシュする場合は <code>true</code>
+	 */
+	MetadataCachedConnectionWrapper(final Connection original, final boolean cacheSchema) {
+		this.original = original;
+		this.cacheSchema = cacheSchema;
+	}
+
+	@Override
+	public <T> T unwrap(final Class<T> iface) throws SQLException {
+		return original.unwrap(iface);
+	}
+
+	@Override
+	public boolean isWrapperFor(final Class<?> iface) throws SQLException {
+		return original.isWrapperFor(iface);
+	}
+
+	@Override
+	public Statement createStatement() throws SQLException {
+		return original.createStatement();
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql) throws SQLException {
+		return original.prepareStatement(sql);
+	}
+
+	@Override
+	public CallableStatement prepareCall(final String sql) throws SQLException {
+		return original.prepareCall(sql);
+	}
+
+	@Override
+	public String nativeSQL(final String sql) throws SQLException {
+		return original.nativeSQL(sql);
+	}
+
+	@Override
+	public void setAutoCommit(final boolean autoCommit) throws SQLException {
+		original.setAutoCommit(autoCommit);
+	}
+
+	@Override
+	public boolean getAutoCommit() throws SQLException {
+		return original.getAutoCommit();
+	}
+
+	@Override
+	public void commit() throws SQLException {
+		original.commit();
+	}
+
+	@Override
+	public void rollback() throws SQLException {
+		original.rollback();
+	}
+
+	@Override
+	public void close() throws SQLException {
+		original.close();
+	}
+
+	@Override
+	public boolean isClosed() throws SQLException {
+		return original.isClosed();
+	}
+
+	@Override
+	public DatabaseMetaData getMetaData() throws SQLException {
+		if (cachedMetadata == null) {
+			cachedMetadata = new CachedDatabaseMetaData(original.getMetaData(), this);
+		}
+		return cachedMetadata;
+	}
+
+	@Override
+	public void setReadOnly(final boolean readOnly) throws SQLException {
+		original.setReadOnly(readOnly);
+	}
+
+	@Override
+	public boolean isReadOnly() throws SQLException {
+		return original.isReadOnly();
+	}
+
+	@Override
+	public void setCatalog(final String catalog) throws SQLException {
+		original.setCatalog(catalog);
+	}
+
+	@Override
+	public String getCatalog() throws SQLException {
+		return original.getCatalog();
+	}
+
+	@Override
+	public void setTransactionIsolation(final int level) throws SQLException {
+		original.setTransactionIsolation(level);
+	}
+
+	@Override
+	public int getTransactionIsolation() throws SQLException {
+		return original.getTransactionIsolation();
+	}
+
+	@Override
+	public SQLWarning getWarnings() throws SQLException {
+		return original.getWarnings();
+	}
+
+	@Override
+	public void clearWarnings() throws SQLException {
+		original.clearWarnings();
+	}
+
+	@Override
+	public Statement createStatement(final int resultSetType, final int resultSetConcurrency) throws SQLException {
+		return original.createStatement(resultSetType, resultSetConcurrency);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql, final int resultSetType, final int resultSetConcurrency)
+			throws SQLException {
+		return original.prepareStatement(sql, resultSetType, resultSetConcurrency);
+	}
+
+	@Override
+	public CallableStatement prepareCall(final String sql, final int resultSetType, final int resultSetConcurrency)
+			throws SQLException {
+		return original.prepareCall(sql, resultSetType, resultSetConcurrency);
+	}
+
+	@Override
+	public Map<String, Class<?>> getTypeMap() throws SQLException {
+		return original.getTypeMap();
+	}
+
+	@Override
+	public void setTypeMap(final Map<String, Class<?>> map) throws SQLException {
+		original.setTypeMap(map);
+	}
+
+	@Override
+	public void setHoldability(final int holdability) throws SQLException {
+		original.setHoldability(holdability);
+	}
+
+	@Override
+	public int getHoldability() throws SQLException {
+		return original.getHoldability();
+	}
+
+	@Override
+	public Savepoint setSavepoint() throws SQLException {
+		return original.setSavepoint();
+	}
+
+	@Override
+	public Savepoint setSavepoint(final String name) throws SQLException {
+		return original.setSavepoint(name);
+	}
+
+	@Override
+	public void rollback(final Savepoint savepoint) throws SQLException {
+		original.rollback(savepoint);
+	}
+
+	@Override
+	public void releaseSavepoint(final Savepoint savepoint) throws SQLException {
+		original.releaseSavepoint(savepoint);
+	}
+
+	@Override
+	public Statement createStatement(final int resultSetType, final int resultSetConcurrency,
+			final int resultSetHoldability)
+			throws SQLException {
+		return original.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql, final int resultSetType, final int resultSetConcurrency,
+			final int resultSetHoldability) throws SQLException {
+		return original.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+	}
+
+	@Override
+	public CallableStatement prepareCall(final String sql, final int resultSetType, final int resultSetConcurrency,
+			final int resultSetHoldability) throws SQLException {
+		return original.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql, final int autoGeneratedKeys) throws SQLException {
+		return original.prepareStatement(sql, autoGeneratedKeys);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql, final int[] columnIndexes) throws SQLException {
+		return original.prepareStatement(sql, columnIndexes);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(final String sql, final String[] columnNames) throws SQLException {
+		return original.prepareStatement(sql, columnNames);
+	}
+
+	@Override
+	public Clob createClob() throws SQLException {
+		return original.createClob();
+	}
+
+	@Override
+	public Blob createBlob() throws SQLException {
+		return original.createBlob();
+	}
+
+	@Override
+	public NClob createNClob() throws SQLException {
+		return original.createNClob();
+	}
+
+	@Override
+	public SQLXML createSQLXML() throws SQLException {
+		return original.createSQLXML();
+	}
+
+	@Override
+	public boolean isValid(final int timeout) throws SQLException {
+		return original.isValid(timeout);
+	}
+
+	@Override
+	public void setClientInfo(final String name, final String value) throws SQLClientInfoException {
+		original.setClientInfo(name, value);
+	}
+
+	@Override
+	public void setClientInfo(final Properties properties) throws SQLClientInfoException {
+		original.setClientInfo(properties);
+	}
+
+	@Override
+	public String getClientInfo(final String name) throws SQLException {
+		return original.getClientInfo(name);
+	}
+
+	@Override
+	public Properties getClientInfo() throws SQLException {
+		return original.getClientInfo();
+	}
+
+	@Override
+	public Array createArrayOf(final String typeName, final Object[] elements) throws SQLException {
+		return original.createArrayOf(typeName, elements);
+	}
+
+	@Override
+	public Struct createStruct(final String typeName, final Object[] attributes) throws SQLException {
+		return original.createStruct(typeName, attributes);
+	}
+
+	@Override
+	public void setSchema(final String schema) throws SQLException {
+		original.setSchema(schema);
+		cachedSchemaName = schema;
+	}
+
+	@Override
+	public String getSchema() throws SQLException {
+		if (!cacheSchema) {
+			return original.getSchema();
+		} else {
+			if (cachedSchemaName == null) {
+				cachedSchemaName = original.getSchema();
+			}
+			return cachedSchemaName;
+		}
+	}
+
+	@Override
+	public void abort(final Executor executor) throws SQLException {
+		original.abort(executor);
+	}
+
+	@Override
+	public void setNetworkTimeout(final Executor executor, final int milliseconds) throws SQLException {
+		original.setNetworkTimeout(executor, milliseconds);
+	}
+
+	@Override
+	public int getNetworkTimeout() throws SQLException {
+		return original.getNetworkTimeout();
+	}
+
+}

--- a/src/test/java/jp/co/future/uroborosql/mapping/MappingUtilsTest.java
+++ b/src/test/java/jp/co/future/uroborosql/mapping/MappingUtilsTest.java
@@ -5,10 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,7 +73,11 @@ public class MappingUtilsTest {
 	public void testMultiSchema() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 
 				assertThat(agent.queryWith("select schema() as current_schema").one().get("CURRENT_SCHEMA"),
 						is("SCHEMA1"));
@@ -82,7 +88,11 @@ public class MappingUtilsTest {
 				assertThat(test1Result.getId1(), is(test1.getId1()));
 				assertThat(test1Result.getName1(), is(test1.getName1()));
 
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 
 				assertThat(agent.queryWith("select schema() as current_schema").one().get("CURRENT_SCHEMA"),
 						is("SCHEMA2"));
@@ -100,11 +110,20 @@ public class MappingUtilsTest {
 	public void testGetMappingColumn() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
+
 				assertThat(MappingUtils.getMappingColumn(Test1.class, "id1").getName(), is("ID1"));
 				assertThat(MappingUtils.getMappingColumn(Test1.class, SqlKind.NONE, "id1").getName(), is("ID1"));
 				assertThat(MappingUtils.getMappingColumn("SCHEMA1", Test1.class, "id1").getName(), is("ID1"));
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				assertThat(MappingUtils.getMappingColumn(Test1.class, "id1").getName(), is("ID1"));
 				assertThat(MappingUtils.getMappingColumn(Test1.class, SqlKind.NONE, "id1").getName(), is("ID1"));
 				assertThat(MappingUtils.getMappingColumn("SCHEMA2", Test1.class, "id1").getName(), is("ID1"));
@@ -116,13 +135,21 @@ public class MappingUtilsTest {
 	public void testGetMappingColumns() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				MappingColumn[] test1Columns = MappingUtils.getMappingColumns(Test1.class);
 				assertThat(test1Columns.length, is(3));
 				test1Columns = MappingUtils.getMappingColumns(Test1.class, SqlKind.NONE);
 				assertThat(test1Columns.length, is(3));
 
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				MappingColumn[] test2Columns = MappingUtils.getMappingColumns(Test1.class);
 				assertThat(test2Columns.length, is(3));
 				test2Columns = MappingUtils.getMappingColumns(Test1.class, SqlKind.NONE);
@@ -135,13 +162,21 @@ public class MappingUtilsTest {
 	public void testGetMappingColumnMap() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				Map<String, MappingColumn> test1Columns = MappingUtils.getMappingColumnMap(Test1.class, SqlKind.NONE);
 				assertThat(test1Columns.size(), is(3));
 				test1Columns = MappingUtils.getMappingColumnMap("SCHEMA1", Test1.class, SqlKind.NONE);
 				assertThat(test1Columns.size(), is(3));
 
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				Map<String, MappingColumn> test2Columns = MappingUtils.getMappingColumnMap(Test1.class, SqlKind.NONE);
 				assertThat(test2Columns.size(), is(3));
 				test2Columns = MappingUtils.getMappingColumnMap("SCHEMA2", Test1.class, SqlKind.NONE);
@@ -154,7 +189,11 @@ public class MappingUtilsTest {
 	public void testGetIdMappingColumns() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				MappingColumn[] test1IdColumns = MappingUtils.getIdMappingColumns(Test1.class);
 				assertThat(test1IdColumns.length, is(1));
 				assertThat(test1IdColumns[0].getName(), is("ID1"));
@@ -162,7 +201,11 @@ public class MappingUtilsTest {
 				assertThat(test1IdColumnsWithSchema.length, is(1));
 				assertThat(test1IdColumnsWithSchema[0].getName(), is("ID1"));
 
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				MappingColumn[] test2IdColumns = MappingUtils.getIdMappingColumns(Test1.class);
 				assertThat(test2IdColumns.length, is(1));
 				assertThat(test2IdColumns[0].getName(), is("ID1"));
@@ -178,13 +221,21 @@ public class MappingUtilsTest {
 	public void testGetVersionMappingColumn() throws Exception {
 		try (SqlAgent agent = config.agent()) {
 			agent.required(() -> {
-				agent.updateWith("set schema schema1").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA1");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				Optional<MappingColumn> test1VersionColumn = MappingUtils.getVersionMappingColumn(Test1.class);
 				assertThat(test1VersionColumn.isPresent(), is(true));
 				test1VersionColumn = MappingUtils.getVersionMappingColumn("SCHEMA1", Test1.class);
 				assertThat(test1VersionColumn.isPresent(), is(true));
 
-				agent.updateWith("set schema schema2").count();
+				try {
+					agent.getConnection().setSchema("SCHEMA2");
+				} catch (SQLException ex) {
+					Assert.fail(ex.getMessage());
+				}
 				Optional<MappingColumn> test2VersionColumn = MappingUtils.getVersionMappingColumn(Test1.class);
 				assertThat(test2VersionColumn.isPresent(), is(true));
 				test2VersionColumn = MappingUtils.getVersionMappingColumn("SCHEMA2", Test1.class);
@@ -215,8 +266,7 @@ public class MappingUtilsTest {
 		public Test1() {
 		}
 
-		public Test1(Integer id1, String name1) {
-			super();
+		public Test1(final Integer id1, final String name1) {
 			this.id1 = id1;
 			this.name1 = name1;
 		}
@@ -225,7 +275,7 @@ public class MappingUtilsTest {
 			return id1;
 		}
 
-		public void setId1(Integer id1) {
+		public void setId1(final Integer id1) {
 			this.id1 = id1;
 		}
 
@@ -233,7 +283,7 @@ public class MappingUtilsTest {
 			return name1;
 		}
 
-		public void setName1(String name1) {
+		public void setName1(final String name1) {
 			this.name1 = name1;
 		}
 	}
@@ -248,8 +298,7 @@ public class MappingUtilsTest {
 		public Test2() {
 		}
 
-		public Test2(Integer id2, String name2) {
-			super();
+		public Test2(final Integer id2, final String name2) {
 			this.id2 = id2;
 			this.name2 = name2;
 		}
@@ -258,7 +307,7 @@ public class MappingUtilsTest {
 			return id2;
 		}
 
-		public void setId2(Integer id2) {
+		public void setId2(final Integer id2) {
 			this.id2 = id2;
 		}
 
@@ -266,7 +315,7 @@ public class MappingUtilsTest {
 			return name2;
 		}
 
-		public void setName2(String name2) {
+		public void setName2(final String name2) {
 			this.name2 = name2;
 		}
 	}


### PR DESCRIPTION
Modified to reduce unnecessary DB access by caching fixed value information (such as databaseProductName and url) for schema and DatabaseMetaData accessible from the Connection object.
Since there are cases where you may not want to cache schema, an API has been added to the ConnectionContext option to disable caching.

----

ConnectionオブジェクトからアクセスできるschemaやDatabaseMetaDataの固定値情報（databaseProductNameやurlなど）をキャッシュすることで不要なDBアクセスを減らすように修正。
schemaについてはキャッシュしたくないケースもあるため、ConnectionContextのオプションでキャッシュしないように切り替えるAPIを追加している。