### PR TITLE
Add mssql wildcard char '[' and ']'

### DIFF
--- a/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
@@ -19,6 +19,8 @@ import jp.co.future.uroborosql.enums.ForUpdateType;
  * @author H.Sugimoto
  */
 public class MsSqlDialect extends AbstractDialect {
+	private static final char[] WILDCARDS = { '%', '_', '[', ']' };
+
 	/**
 	 * 悲観ロックのErrorCode もしくは SqlState. MSSQLの場合はErrorCodeで判定する.
 	 * <pre>SQL Error [1222] [S00045]: ロック要求がタイムアウトしました。 </pre>
@@ -29,6 +31,7 @@ public class MsSqlDialect extends AbstractDialect {
 	 * コンストラクタ
 	 */
 	public MsSqlDialect() {
+		super('$', WILDCARDS);
 	}
 
 	/**

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -69,9 +69,11 @@ public class MsSqlDialectTest {
 		assertThat(dialect.escapeLikePattern("pat_tern"), is("pat$_tern"));
 		assertThat(dialect.escapeLikePattern("pattern%"), is("pattern$%"));
 		assertThat(dialect.escapeLikePattern("pattern_"), is("pattern$_"));
-		assertThat(dialect.escapeLikePattern("pat[]tern"), is("pat[]tern"));
 		assertThat(dialect.escapeLikePattern("pat％tern"), is("pat％tern"));
 		assertThat(dialect.escapeLikePattern("pat＿tern"), is("pat＿tern"));
+		assertThat(dialect.escapeLikePattern("p[at]tern"), is("p$[at$]tern"));
+		assertThat(dialect.escapeLikePattern("[]pattern"), is("$[$]pattern"));
+		assertThat(dialect.escapeLikePattern("pattern[]"), is("pattern$[$]"));
 	}
 
 	@Test


### PR DESCRIPTION
Since ‘[’ and ‘]’ can be used as wildcards in mssql, add these characters as wildcards to MssqlDialect.

Reference: 
https://learn.microsoft.com/ja-jp/sql/t-sql/language-elements/wildcard-character-s-to-match-transact-sql?view=sql-server-ver17