### PR TITLE
Changed the method for generating savepointName.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: ${{ env.JDK_DISTRIBUTION }}
-          cache: 'maven'
+          cache: "maven"
 
       - name: ⚙️ Build with Maven
-        run: mvn --batch-mode --update-snapshots --no-transfer-progress verify jacoco:report
+        run: mvn --batch-mode --update-snapshots --no-transfer-progress clean verify jacoco:report
 
       - name: 🚀 Coveralls Coverage Report
-        run: mvn --no-transfer-progress -DrepoToken=${{ secrets.COVERALL_REPO_SECRET }} coveralls:report 
+        run: mvn --no-transfer-progress -DrepoToken=${{ secrets.COVERALL_REPO_SECRET }} coveralls:report
 
   integration-test:
     needs: build
@@ -46,7 +46,7 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: ${{ env.JDK_DISTRIBUTION }}
-          cache: 'maven'
+          cache: "maven"
 
       - name: ⚙️ Matrix Test with Maven
-        run: mvn --batch-mode --update-snapshots --no-transfer-progress -P${{ matrix.db }} -Dgroups=matrix test
+        run: mvn --batch-mode --update-snapshots --no-transfer-progress -P${{ matrix.db }} -Dgroups=matrix clean test

--- a/pom.xml
+++ b/pom.xml
@@ -560,6 +560,12 @@ LICENSE file in the root directory of this source tree.
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>5.1.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/Dialect.java
@@ -177,6 +177,15 @@ public interface Dialect {
 		return true;
 	}
 
+	/**
+	 * {@link java.sql.Connection#releaseSavepoint(java.sql.Savepoint)} をサポートしているか.
+	 *
+	 * @return Savepointの解放をサポートしている場合<code>true</code>
+	 */
+	default boolean supportsReleaseSavepoint() {
+		return true;
+	}
+
 	String getSequenceNextValSql(String sequenceName);
 
 	/**

--- a/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/MsSqlDialect.java
@@ -91,6 +91,16 @@ public class MsSqlDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsReleaseSavepoint()
+	 */
+	@Override
+	public boolean supportsReleaseSavepoint() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#needsStrictSqlTypeForNullSetting()
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/future/uroborosql/dialect/OracleDialect.java
@@ -90,6 +90,16 @@ public abstract class OracleDialect extends AbstractDialect {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @see jp.co.future.uroborosql.dialect.Dialect#supportsReleaseSavepoint()
+	 */
+	@Override
+	public boolean supportsReleaseSavepoint() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @see jp.co.future.uroborosql.dialect.Dialect#getSequenceNextValSql(java.lang.String)
 	 */
 	@Override

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
@@ -335,6 +335,8 @@ class LocalTransactionContext implements TransactionContext {
 			subList.clear();
 		}
 
+		// OracleやSqlServerなどConnection#releaseSavepointをサポートしないドライバーの場合は何もしない
+		// その場合は、Collection#commitやrollbackのタイミングでSavepointも解放される
 		if (savepoint != null && connection != null && sqlConfig.getDialect().supportsReleaseSavepoint()) {
 			try {
 				connection.releaseSavepoint(savepoint);

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionContext.java
@@ -335,7 +335,7 @@ class LocalTransactionContext implements TransactionContext {
 			subList.clear();
 		}
 
-		if (savepoint != null && connection != null) {
+		if (savepoint != null && connection != null && sqlConfig.getDialect().supportsReleaseSavepoint()) {
 			try {
 				connection.releaseSavepoint(savepoint);
 			} catch (SQLException ex) {

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -357,7 +357,7 @@ public class LocalTransactionManager implements TransactionManager {
 				.orElseThrow(() -> new UroborosqlRuntimeException("UnmanagedConnection cannot use savepoint."));
 
 		var rng = ThreadLocalRandom.current();
-		var savepointName = String.format("SP%10d", rng.nextLong(10_000_000_000L));
+		var savepointName = String.format("SP%010d", rng.nextLong(10_000_000_000L));
 		txCtx.setSavepoint(savepointName);
 		try {
 			return supplier.get();

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -355,7 +355,7 @@ public class LocalTransactionManager implements TransactionManager {
 	public <R> R savepointScope(final Supplier<R> supplier) {
 		var txCtx = currentTxContext(false)
 				.orElseThrow(() -> new UroborosqlRuntimeException("UnmanagedConnection cannot use savepoint."));
-		var savepointName = UUID.randomUUID().toString();
+		var savepointName = UUID.randomUUID().toString().replace("-", "");
 		txCtx.setSavepoint(savepointName);
 		try {
 			return supplier.get();

--- a/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
+++ b/src/main/java/jp/co/future/uroborosql/tx/LocalTransactionManager.java
@@ -12,8 +12,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Deque;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 import jp.co.future.uroborosql.config.SqlConfig;
@@ -355,7 +355,9 @@ public class LocalTransactionManager implements TransactionManager {
 	public <R> R savepointScope(final Supplier<R> supplier) {
 		var txCtx = currentTxContext(false)
 				.orElseThrow(() -> new UroborosqlRuntimeException("UnmanagedConnection cannot use savepoint."));
-		var savepointName = UUID.randomUUID().toString().replace("-", "");
+
+		var rng = ThreadLocalRandom.current();
+		var savepointName = String.format("SP%10d", rng.nextLong(10_000_000_000L));
 		txCtx.setSavepoint(savepointName);
 		try {
 			return supplier.get();

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -428,7 +428,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 				fail();
 			} catch (OptimisticLockException ex) {
 				var sql = String.format(
-						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t  \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
+						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
 				var entityCount = 2;
 				var updateCount = 1;
 				assertThat(ex.getMessage(), is(

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -428,7 +428,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 				fail();
 			} catch (OptimisticLockException ex) {
 				var sql = String.format(
-						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
+						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t  \"PRODUCT_ID\" = ?/*productId*/%n\t, \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
 				var entityCount = 2;
 				var updateCount = 1;
 				assertThat(ex.getMessage(), is(

--- a/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
+++ b/src/test/java/jp/co/future/uroborosql/SqlEntityUpdateTest.java
@@ -428,7 +428,7 @@ public class SqlEntityUpdateTest extends AbstractDbTest {
 				fail();
 			} catch (OptimisticLockException ex) {
 				var sql = String.format(
-						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t  \"PRODUCT_ID\" = ?/*productId*/%n\t, \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
+						"UPDATE /* mapping @ Product */ PUBLIC.PRODUCT SET %n\t  \"PRODUCT_NAME\" = ?/*productName*/%n\t, \"PRODUCT_KANA_NAME\" = ?/*productKanaName*/%n\t, \"JAN_CODE\" = ?/*janCode*/%n\t, \"PRODUCT_DESCRIPTION\" = ?/*productDescription*/%n\t, \"INS_DATETIME\" = ?/*insDatetime*/%n\t, \"UPD_DATETIME\" = ?/*updDatetime*/%n\t, \"VERSION_NO\" = \"VERSION_NO\" + 1%nWHERE%n\t    \"PRODUCT_ID\" = ?/*productId*/%n\tAND \"VERSION_NO\" = ?/*versionNo*/");
 				var entityCount = 2;
 				var updateCount = 1;
 				assertThat(ex.getMessage(), is(

--- a/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/DefaultDialectTest.java
@@ -89,6 +89,7 @@ public class DefaultDialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(false));
+		assertThat(dialect.supportsReleaseSavepoint(), is(true));
 		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 		assertThat(dialect.supportsUpdateChained(), is(true));
 		assertThat(dialect.needsStrictSqlTypeForNullSetting(), is(false));

--- a/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/MsSqlDialectTest.java
@@ -102,6 +102,7 @@ public class MsSqlDialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(false));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsReleaseSavepoint(), is(false));
 		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(true));
 		assertThat(dialect.supportsUpdateChained(), is(true));
 		assertThat(dialect.needsStrictSqlTypeForNullSetting(), is(true));

--- a/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
+++ b/src/test/java/jp/co/future/uroborosql/dialect/Oracle11DialectTest.java
@@ -169,6 +169,7 @@ public class Oracle11DialectTest {
 		assertThat(dialect.supportsForUpdateNoWait(), is(true));
 		assertThat(dialect.supportsForUpdateWait(), is(true));
 		assertThat(dialect.supportsOptimizerHints(), is(true));
+		assertThat(dialect.supportsReleaseSavepoint(), is(false));
 		assertThat(dialect.supportsEntityBulkUpdateOptimisticLock(), is(false));
 		assertThat(dialect.supportsUpdateChained(), is(false));
 		assertThat(dialect.needsStrictSqlTypeForNullSetting(), is(false));

--- a/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
+++ b/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
@@ -27,6 +27,8 @@ import com.zaxxer.hikari.HikariDataSource;
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
 import jp.co.future.uroborosql.config.SqlConfig;
+import jp.co.future.uroborosql.mapping.DefaultEntityHandler;
+import jp.co.future.uroborosql.mapping.MappingUtils;
 import jp.co.future.uroborosql.utils.ObjectUtils;
 
 @Tag("matrix")
@@ -70,6 +72,8 @@ public class AbstractMatrixTest {
 
 		config = UroboroSQL.builder(dataSource).build();
 		config.getSqlAgentProvider().setFetchSize(1000);
+		DefaultEntityHandler.clearCache();
+		MappingUtils.clearCache();
 		agent = config.agent();
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
+++ b/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import com.zaxxer.hikari.HikariDataSource;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -36,6 +38,7 @@ public class AbstractMatrixTest {
 
 	protected SqlConfig config;
 	protected SqlAgent agent;
+	private HikariDataSource dataSource;
 
 	static {
 		jdbcProps = new Properties();
@@ -61,7 +64,11 @@ public class AbstractMatrixTest {
 				.addArgument(url)
 				.log();
 
-		config = UroboroSQL.builder(url, null, null).build();
+		dataSource = new HikariDataSource();
+		dataSource.setJdbcUrl(url);
+		dataSource.setMaximumPoolSize(10);
+
+		config = UroboroSQL.builder(dataSource).build();
 		config.getSqlAgentProvider().setFetchSize(1000);
 		agent = config.agent();
 	}
@@ -70,6 +77,9 @@ public class AbstractMatrixTest {
 	public void tearDown() throws Exception {
 		if (agent != null) {
 			agent.close();
+		}
+		if (dataSource != null) {
+			dataSource.close();
 		}
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
+++ b/src/test/java/jp/co/future/uroborosql/matrix/AbstractMatrixTest.java
@@ -16,13 +16,13 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import com.zaxxer.hikari.HikariDataSource;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.zaxxer.hikari.HikariDataSource;
 
 import jp.co.future.uroborosql.SqlAgent;
 import jp.co.future.uroborosql.UroboroSQL;
@@ -77,9 +77,14 @@ public class AbstractMatrixTest {
 	public void tearDown() throws Exception {
 		if (agent != null) {
 			agent.close();
+			agent = null;
 		}
 		if (dataSource != null) {
 			dataSource.close();
+			dataSource = null;
+		}
+		if (config != null) {
+			config = null;
 		}
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/matrix/SqlApiTest.java
+++ b/src/test/java/jp/co/future/uroborosql/matrix/SqlApiTest.java
@@ -373,9 +373,8 @@ class SqlApiTest extends AbstractMatrixTest {
 	 */
 	@Test
 	void testSavepointScopeSuccess() throws Exception {
-		truncateTable("PRODUCT");
-
 		agent.required(() -> {
+			truncateTable("PRODUCT");
 			// 1件目の挿入
 			agent.update("example/insert_product")
 					.param("product_id", 1)
@@ -418,9 +417,8 @@ class SqlApiTest extends AbstractMatrixTest {
 	 */
 	@Test
 	void testSavepointScopeRollback() throws Exception {
-		truncateTable("PRODUCT");
-
 		agent.required(() -> {
+			truncateTable("PRODUCT");
 			// 1件目の挿入
 			agent.update("example/insert_product")
 					.param("product_id", 1)
@@ -458,72 +456,6 @@ class SqlApiTest extends AbstractMatrixTest {
 					.collect();
 			assertThat(products.size(), is(1));
 			assertThat(products.get(0).getProductId(), is(1));
-		});
-	}
-
-	/**
-	 * savepointScopeのネストのテストケース。
-	 * 外側のsavepointScopeは正常終了し、内側のsavepointScopeは例外でロールバックされる場合、
-	 * 内側でロールバックされた分のみが取り消される。
-	 */
-	@Test
-	void testSavepointScopeNested() throws Exception {
-		truncateTable("PRODUCT");
-
-		agent.required(() -> {
-			// 1件目の挿入
-			agent.update("example/insert_product")
-					.param("product_id", 1)
-					.param("product_name", "商品１")
-					.param("product_kana_name", "ショウヒン１")
-					.param("jan_code", "1234567890001")
-					.param("product_description", "商品１説明")
-					.param("ins_datetime", Optional.empty())
-					.param("upd_datetime", Optional.empty())
-					.param("version_no", 1)
-					.count();
-
-			// 外側のsavepointScope（正常終了）
-			agent.savepointScope(() -> {
-				// 2件目の挿入
-				agent.update("example/insert_product")
-						.param("product_id", 2)
-						.param("product_name", "商品２")
-						.param("product_kana_name", "ショウヒン２")
-						.param("jan_code", "1234567890002")
-						.param("product_description", "商品２説明")
-						.param("ins_datetime", Optional.empty())
-						.param("upd_datetime", Optional.empty())
-						.param("version_no", 1)
-						.count();
-
-				// 内側のsavepointScope（例外によりロールバック）
-				try {
-					agent.savepointScope(() -> {
-						agent.update("example/insert_product")
-								.param("product_id", 3)
-								.param("product_name", "商品３")
-								.param("product_kana_name", "ショウヒン３")
-								.param("jan_code", "1234567890003")
-								.param("product_description", "商品３説明")
-								.param("ins_datetime", Optional.empty())
-								.param("upd_datetime", Optional.empty())
-								.param("version_no", 1)
-								.count();
-						throw new RuntimeException("inner exception");
-					});
-				} catch (RuntimeException e) {
-					assertThat(e.getMessage(), is("inner exception"));
-				}
-			});
-
-			// 外側のsavepointScope正常終了後：1件目と2件目のみ存在（3件目は内側でロールバック済み）
-			var products = agent.query(Product.class)
-					.asc("product_id")
-					.collect();
-			assertThat(products.size(), is(2));
-			assertThat(products.get(0).getProductId(), is(1));
-			assertThat(products.get(1).getProductId(), is(2));
 		});
 	}
 

--- a/src/test/java/jp/co/future/uroborosql/matrix/SqlApiTest.java
+++ b/src/test/java/jp/co/future/uroborosql/matrix/SqlApiTest.java
@@ -367,4 +367,164 @@ class SqlApiTest extends AbstractMatrixTest {
 		}
 	}
 
+	/**
+	 * savepointScopeの正常終了のテストケース。
+	 * savepointScope内の処理が成功した場合、セーブポイントは解放され両方のレコードが残る。
+	 */
+	@Test
+	void testSavepointScopeSuccess() throws Exception {
+		truncateTable("PRODUCT");
+
+		agent.required(() -> {
+			// 1件目の挿入
+			agent.update("example/insert_product")
+					.param("product_id", 1)
+					.param("product_name", "商品１")
+					.param("product_kana_name", "ショウヒン１")
+					.param("jan_code", "1234567890001")
+					.param("product_description", "商品１説明")
+					.param("ins_datetime", Optional.empty())
+					.param("upd_datetime", Optional.empty())
+					.param("version_no", 1)
+					.count();
+
+			// savepointScope内で2件目の挿入（正常終了）
+			agent.savepointScope(() -> {
+				agent.update("example/insert_product")
+						.param("product_id", 2)
+						.param("product_name", "商品２")
+						.param("product_kana_name", "ショウヒン２")
+						.param("jan_code", "1234567890002")
+						.param("product_description", "商品２説明")
+						.param("ins_datetime", Optional.empty())
+						.param("upd_datetime", Optional.empty())
+						.param("version_no", 1)
+						.count();
+			});
+
+			// savepointScope正常終了後は両方のレコードが存在する
+			var products = agent.query(Product.class)
+					.asc("product_id")
+					.collect();
+			assertThat(products.size(), is(2));
+			assertThat(products.get(0).getProductId(), is(1));
+			assertThat(products.get(1).getProductId(), is(2));
+		});
+	}
+
+	/**
+	 * savepointScopeの例外時ロールバックのテストケース。
+	 * savepointScope内で例外が発生した場合、セーブポイントまでロールバックされるが外側のトランザクションは継続する。
+	 */
+	@Test
+	void testSavepointScopeRollback() throws Exception {
+		truncateTable("PRODUCT");
+
+		agent.required(() -> {
+			// 1件目の挿入
+			agent.update("example/insert_product")
+					.param("product_id", 1)
+					.param("product_name", "商品１")
+					.param("product_kana_name", "ショウヒン１")
+					.param("jan_code", "1234567890001")
+					.param("product_description", "商品１説明")
+					.param("ins_datetime", Optional.empty())
+					.param("upd_datetime", Optional.empty())
+					.param("version_no", 1)
+					.count();
+
+			// savepointScope内で2件目の挿入後に例外（セーブポイントまでロールバック）
+			try {
+				agent.savepointScope(() -> {
+					agent.update("example/insert_product")
+							.param("product_id", 2)
+							.param("product_name", "商品２")
+							.param("product_kana_name", "ショウヒン２")
+							.param("jan_code", "1234567890002")
+							.param("product_description", "商品２説明")
+							.param("ins_datetime", Optional.empty())
+							.param("upd_datetime", Optional.empty())
+							.param("version_no", 1)
+							.count();
+					throw new RuntimeException("test exception");
+				});
+			} catch (RuntimeException e) {
+				assertThat(e.getMessage(), is("test exception"));
+			}
+
+			// セーブポイントまでロールバックされたため、1件目のみ存在する
+			var products = agent.query(Product.class)
+					.asc("product_id")
+					.collect();
+			assertThat(products.size(), is(1));
+			assertThat(products.get(0).getProductId(), is(1));
+		});
+	}
+
+	/**
+	 * savepointScopeのネストのテストケース。
+	 * 外側のsavepointScopeは正常終了し、内側のsavepointScopeは例外でロールバックされる場合、
+	 * 内側でロールバックされた分のみが取り消される。
+	 */
+	@Test
+	void testSavepointScopeNested() throws Exception {
+		truncateTable("PRODUCT");
+
+		agent.required(() -> {
+			// 1件目の挿入
+			agent.update("example/insert_product")
+					.param("product_id", 1)
+					.param("product_name", "商品１")
+					.param("product_kana_name", "ショウヒン１")
+					.param("jan_code", "1234567890001")
+					.param("product_description", "商品１説明")
+					.param("ins_datetime", Optional.empty())
+					.param("upd_datetime", Optional.empty())
+					.param("version_no", 1)
+					.count();
+
+			// 外側のsavepointScope（正常終了）
+			agent.savepointScope(() -> {
+				// 2件目の挿入
+				agent.update("example/insert_product")
+						.param("product_id", 2)
+						.param("product_name", "商品２")
+						.param("product_kana_name", "ショウヒン２")
+						.param("jan_code", "1234567890002")
+						.param("product_description", "商品２説明")
+						.param("ins_datetime", Optional.empty())
+						.param("upd_datetime", Optional.empty())
+						.param("version_no", 1)
+						.count();
+
+				// 内側のsavepointScope（例外によりロールバック）
+				try {
+					agent.savepointScope(() -> {
+						agent.update("example/insert_product")
+								.param("product_id", 3)
+								.param("product_name", "商品３")
+								.param("product_kana_name", "ショウヒン３")
+								.param("jan_code", "1234567890003")
+								.param("product_description", "商品３説明")
+								.param("ins_datetime", Optional.empty())
+								.param("upd_datetime", Optional.empty())
+								.param("version_no", 1)
+								.count();
+						throw new RuntimeException("inner exception");
+					});
+				} catch (RuntimeException e) {
+					assertThat(e.getMessage(), is("inner exception"));
+				}
+			});
+
+			// 外側のsavepointScope正常終了後：1件目と2件目のみ存在（3件目は内側でロールバック済み）
+			var products = agent.query(Product.class)
+					.asc("product_id")
+					.collect();
+			assertThat(products.size(), is(2));
+			assertThat(products.get(0).getProductId(), is(1));
+			assertThat(products.get(1).getProductId(), is(2));
+		});
+	}
+
 }

--- a/src/test/resources/jdbc.properties
+++ b/src/test/resources/jdbc.properties
@@ -1,4 +1,4 @@
-h2.url=jdbc:h2:mem:apitest;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/matrix/create_tables_h2.sql'
+h2.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/matrix/create_tables_h2.sql'
 postgresql.url=jdbc:tc:postgresql:16.8-alpine:///test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_postgresql.sql
 oracle.url=jdbc:tc:oracle:21-slim-faststart:thin:@test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_oracle.sql
 sqlserver.url=jdbc:tc:sqlserver:2022-latest:///test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_mssql.sql

--- a/src/test/resources/jdbc.properties
+++ b/src/test/resources/jdbc.properties
@@ -1,4 +1,4 @@
-h2.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/matrix/create_tables_h2.sql'
+h2.url=jdbc:h2:mem:apitest;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/matrix/create_tables_h2.sql'
 postgresql.url=jdbc:tc:postgresql:16.8-alpine:///test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_postgresql.sql
 oracle.url=jdbc:tc:oracle:21-slim-faststart:thin:@test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_oracle.sql
 sqlserver.url=jdbc:tc:sqlserver:2022-latest:///test?TC_TMPFS=/testtmpfs:rw&TC_DAEMON=true&TC_INITSCRIPT=sql/matrix/create_tables_mssql.sql

--- a/src/test/resources/sql/ddl/create_tables.sql
+++ b/src/test/resources/sql/ddl/create_tables.sql
@@ -1,3 +1,5 @@
+drop table if exists PRODUCT;
+
 create table if not exists PRODUCT (
 	PRODUCT_ID			NUMERIC(10, 0),
 	PRODUCT_NAME		VARCHAR(100),
@@ -14,6 +16,8 @@ create table if not exists PRODUCT (
 create index if not exists IX_PRODUCT ON PRODUCT (JAN_CODE)
 ;
 
+drop table if exists PRODUCT_REGIST_WORK;
+
 create table if not exists PRODUCT_REGIST_WORK (
 	PRODUCT_NAME		VARCHAR(100),
 	PRODUCT_KANA_NAME	VARCHAR(100),
@@ -22,6 +26,8 @@ create table if not exists PRODUCT_REGIST_WORK (
 	INS_DATETIME		TIMESTAMP(9)
 )
 ;
+
+drop table if exists COLUMN_TYPE_TEST;
 
 create table if not exists COLUMN_TYPE_TEST (
 	COL_VARCHAR			VARCHAR(100),

--- a/src/test/resources/sql/matrix/create_tables_h2.sql
+++ b/src/test/resources/sql/matrix/create_tables_h2.sql
@@ -1,3 +1,5 @@
+drop table if exists PRODUCT;
+
 create table if not exists PRODUCT (
 	PRODUCT_ID			NUMERIC(10, 0) AUTO_INCREMENT NOT NULL,
 	PRODUCT_NAME		VARCHAR(100),
@@ -42,6 +44,8 @@ comment on column COLUMN_TYPE_TEST.COL_BOOLEAN is 'column boolean';
 comment on column COLUMN_TYPE_TEST.COL_TIMESTAMP is 'column timestamp';
 comment on column COLUMN_TYPE_TEST.COL_DATE is 'column date';
 comment on column COLUMN_TYPE_TEST.COL_TIME is 'column time';
+
+drop table if exists COLUMN_TYPE_ARRAY;
 
 create table if not exists COLUMN_TYPE_ARRAY (
 	COL_STR_ARRAY			ARRAY,

--- a/src/test/resources/sql/matrix/create_tables_mssql.sql
+++ b/src/test/resources/sql/matrix/create_tables_mssql.sql
@@ -1,3 +1,6 @@
+
+drop table if exists PRODUCT;
+
 create table PRODUCT (
 	PRODUCT_ID			NUMERIC(10, 0) IDENTITY(1, 1) NOT NULL PRIMARY KEY,
 	PRODUCT_NAME		NVARCHAR(100),
@@ -10,6 +13,8 @@ create table PRODUCT (
 )
 ;
 
+drop table if exists PRODUCT_REGIST_WORK;
+
 create table PRODUCT_REGIST_WORK (
 	PRODUCT_NAME		NVARCHAR(100),
 	PRODUCT_KANA_NAME	NVARCHAR(100),
@@ -18,6 +23,8 @@ create table PRODUCT_REGIST_WORK (
 	INS_DATETIME		DATETIME
 )
 ;
+
+drop table if exists COLUMN_TYPE_TEST;
 
 create table COLUMN_TYPE_TEST (
 	COL_VARCHAR			NVARCHAR(100),

--- a/src/test/resources/sql/matrix/create_tables_mysql.sql
+++ b/src/test/resources/sql/matrix/create_tables_mysql.sql
@@ -1,3 +1,5 @@
+drop table if exists PRODUCT;
+
 create table if not exists PRODUCT (
 	PRODUCT_ID			INT AUTO_INCREMENT NOT NULL,
 	PRODUCT_NAME		VARCHAR(100),
@@ -11,6 +13,8 @@ create table if not exists PRODUCT (
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ;
 
+drop table if exists PRODUCT_REGIST_WORK;
+
 create table if not exists PRODUCT_REGIST_WORK (
 	PRODUCT_NAME		VARCHAR(100),
 	PRODUCT_KANA_NAME	VARCHAR(100),
@@ -19,6 +23,8 @@ create table if not exists PRODUCT_REGIST_WORK (
 	INS_DATETIME		DATETIME
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ;
+
+drop table if exists COLUMN_TYPE_TEST;
 
 create table if not exists COLUMN_TYPE_TEST (
 	COL_VARCHAR			VARCHAR(100),

--- a/src/test/resources/sql/matrix/create_tables_postgresql.sql
+++ b/src/test/resources/sql/matrix/create_tables_postgresql.sql
@@ -1,3 +1,5 @@
+drop table if exists PRODUCT;
+
 create table if not exists PRODUCT (
 	PRODUCT_ID			SERIAL NOT NULL,
 	PRODUCT_NAME		VARCHAR(100),
@@ -14,6 +16,8 @@ create table if not exists PRODUCT (
 create index if not exists IX_PRODUCT ON PRODUCT (JAN_CODE)
 ;
 
+drop table if exists PRODUCT_REGIST_WORK;
+
 create table if not exists PRODUCT_REGIST_WORK (
 	PRODUCT_NAME		VARCHAR(100),
 	PRODUCT_KANA_NAME	VARCHAR(100),
@@ -22,6 +26,8 @@ create table if not exists PRODUCT_REGIST_WORK (
 	INS_DATETIME		TIMESTAMP(9)
 )
 ;
+
+drop table if exists COLUMN_TYPE_TEST;
 
 create table if not exists COLUMN_TYPE_TEST (
 	COL_VARCHAR			VARCHAR(100),


### PR DESCRIPTION
In Oracle and SQL Server, there is a character limit on the `savepointName` specified in `Connection#setSavepoint()` (Oracle: up to 30 bytes for the first English character; SQL Server: up to 32 characters). Therefore, we changed the `savepointName` from a UUID to `SP` followed by a 10-digit number (padded with leading zeros) using `ThreadLocalRandom`.
Accordingly, we added test cases for `savepointScope`.

----
OracleやSQLServerではConnection#setSavepoint() に指定するsavepointNameの文字数に制限がある（Oracle:先頭英字の最大30バイト、SQLServer: 最大32文字）ため、savepointNameをUUIDから ThreadLocalRandomを使ったランダムな文字列（ `SP` + 数字10桁（前ゼロパディング））に変更。
それに伴い、savepointScopeのテストケースを追加
